### PR TITLE
Fix argument checks

### DIFF
--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -40,5 +40,6 @@ jobs:
         ./run_fab_flow.sh
     - name: Check pair generation
       run: |
+        cd fabric_generator
         ./create_basic_files.sh
         python3 fabric_gen.py -genNextpnrModel_pair

--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -42,4 +42,4 @@ jobs:
       run: |
         cd fabric_generator
         ./create_basic_files.sh
-        python3 fabric_gen.py -genNextpnrModel_pair
+        ./run_fab_flow_nextpnr_pair.sh

--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -38,3 +38,7 @@ jobs:
         cd fabric_generator
         ./create_basic_files.sh
         ./run_fab_flow.sh
+    - name: Check pair generation
+      run: |
+        ./create_basic_files.sh
+        python3 fabric_gen.py -genNextpnrModel_pair

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4962,7 +4962,12 @@ TileTypes = GetCellTypes(fabric)
 
 print('### Script command arguments are:\n' , str(sys.argv))
 
-if ('-GenTileSwitchMatrixCSV'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+#Strip arguments
+processedArguments = map(lambda x: x.strip(), sys.argv)
+processedArguments = list(map(lambda x: x.lower(), processedArguments))
+
+
+if ('-GenTileSwitchMatrixCSV'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate initial switch matrix template (has to be bootstrapped first)')
     for tile in TileTypes:
         print('### generate csv for tile ', tile, ' # filename:', (str(tile)+'_switch_matrix.csv'))
@@ -4971,7 +4976,7 @@ if ('-GenTileSwitchMatrixCSV'.lower() in str(sys.argv).lower()) or ('-run_all'.l
         BootstrapSwitchMatrix(TileInformation,str(tile),(str(tile)+'_switch_matrix.csv'))
         TileFileHandler.close()
 
-if ('-GenTileSwitchMatrixVHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileSwitchMatrixVHDL'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate initial switch matrix VHDL code')
     for tile in TileTypes:
         print('### generate VHDL for tile ', tile, ' # filename:', (str(tile)+'_switch_matrix.vhdl'))
@@ -4979,7 +4984,7 @@ if ('-GenTileSwitchMatrixVHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.
         GenTileSwitchMatrixVHDL(tile,(str(tile)+'_switch_matrix.csv'),TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenTileSwitchMatrixVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileSwitchMatrixVerilog'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate initial switch matrix Verilog code')
     for tile in TileTypes:
         print('### generate Verilog for tile ', tile, ' # filename:', (str(tile)+'_switch_matrix.v'))
@@ -4987,7 +4992,7 @@ if ('-GenTileSwitchMatrixVerilog'.lower() in str(sys.argv).lower()) or ('-run_al
         GenTileSwitchMatrixVerilog(tile,(str(tile)+'_switch_matrix.csv'),TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenTileConfigMemVHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileConfigMemVHDL'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate all tile HDL descriptions')
     for tile in TileTypes:
         print('### generate configuration bitstream storage VHDL for tile ', tile, ' # filename:', (str(tile)+'_ConfigMem.vhdl'))
@@ -4999,7 +5004,7 @@ if ('-GenTileConfigMemVHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.low
         GenerateConfigMemVHDL(TileInformation,str(tile)+'_ConfigMem',TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenTileConfigMemVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileConfigMemVerilog'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     #print('### Generate all tile HDL descriptions')
     for tile in TileTypes:
         print('### generate configuration bitstream storage Verilog for tile ', tile, ' # filename:', (str(tile)+'_ConfigMem.v'))
@@ -5011,7 +5016,7 @@ if ('-GenTileConfigMemVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.
         GenerateConfigMemVerilog(TileInformation,str(tile)+'_ConfigMem',TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenTileHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileHDL'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate all tile HDL descriptions')
     for tile in TileTypes:
         print('### generate VHDL for tile ', tile, ' # filename:', (str(tile)+'_tile.vhdl'))
@@ -5023,7 +5028,7 @@ if ('-GenTileHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in st
         GenerateTileVHDL(TileInformation,str(tile),TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenTileVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenTileVerilog'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     #print('### Generate all tile Verilog descriptions')
     for tile in TileTypes:
         print('### generate Verilog for tile ', tile, ' # filename:', (str(tile)+'_tile.v'))
@@ -5035,13 +5040,13 @@ if ('-GenTileVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() i
         GenerateTileVerilog(TileInformation,str(tile),TileFileHandler)
         TileFileHandler.close()
 
-if ('-GenFabricHDL'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenFabricHDL'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate the Fabric VHDL descriptions')
     FileHandler = open('fabric.vhdl','w+')
     GenerateFabricVHDL(FabricFile,FileHandler)
     FileHandler.close()
 
-if ('-GenFabricVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower() in str(sys.argv).lower()):
+if ('-GenFabricVerilog'.lower() in processedArguments) or ('-run_all'.lower() in processedArguments):
     print('### Generate the Fabric Verilog descriptions')
     FileHandler = open('fabric.v','w+')
     fabric_top = GenerateFabricVerilog(FabricFile,FileHandler)
@@ -5050,7 +5055,7 @@ if ('-GenFabricVerilog'.lower() in str(sys.argv).lower()) or ('-run_all'.lower()
     #w.write(fabric_top)
     #w.close()
 
-if ('-CSV2list'.lower() in str(sys.argv).lower()) or ('-AddList2CSV'.lower() in str(sys.argv).lower()):
+if ('-CSV2list'.lower() in processedArguments) or ('-AddList2CSV'.lower() in processedArguments):
     arguments = re.split(' ',str(sys.argv))
     # index was not working...
     i = 0
@@ -5072,7 +5077,7 @@ if ('-CSV2list'.lower() in str(sys.argv).lower()) or ('-AddList2CSV'.lower() in 
     if ('-AddList2CSV'.lower() in str(sys.argv).lower()):
         list2CSV(InFileName, OutFileName)
 
-if ('-PrintCSV_FileInfo'.lower() in str(sys.argv).lower()) :
+if ('-PrintCSV_FileInfo'.lower() in processedArguments) :
     arguments = re.split(' ',str(sys.argv))
     # index was not working...
     i = 0
@@ -5088,10 +5093,10 @@ if ('-PrintCSV_FileInfo'.lower() in str(sys.argv).lower()) :
     # InFileName  = (replace(arguments[i+1], substitutions))
     # don't ask me why I have to delete the stupid '['...; but at least works now
     InFileName  = re.sub('\]','',re.sub('\'','',(replace(arguments[i+1], substitutions))))
-    if ('-PrintCSV_FileInfo'.lower() in str(sys.argv).lower()):
+    if ('-PrintCSV_FileInfo'.lower() in processedArguments):
         PrintCSV_FileInfo(InFileName)
 
-if ('-GenNextpnrModel'.lower() in str(sys.argv).lower()) :
+if ('-GenNextpnrModel'.lower() in processedArguments) :
     arguments = re.split(' ',str(sys.argv))
     fabricObject = genFabricObject(fabric)
     pipFile = open("npnroutput/pips.txt","w")
@@ -5114,7 +5119,7 @@ if ('-GenNextpnrModel'.lower() in str(sys.argv).lower()) :
     constraintFile.close()
     #pairFile.close()
 
-if ('-GenNextpnrModel_pair'.lower() in str(sys.argv).lower()) :
+if ('-GenNextpnrModel_pair'.lower() in processedArguments) :
     arguments = re.split(' ',str(sys.argv))
     fabricObject = genFabricObject(fabric)
     pipFile = open("npnroutput/pips.txt","w")
@@ -5137,7 +5142,7 @@ if ('-GenNextpnrModel_pair'.lower() in str(sys.argv).lower()) :
     constraintFile.close()
     pairFile.close()
 
-if ('-GenVPRModel'.lower() in str(sys.argv).lower()) :
+if ('-GenVPRModel'.lower() in processedArguments) :
     arguments = re.split(' ',str(sys.argv))
     fabricObject = genFabricObject(fabric)
 
@@ -5155,7 +5160,7 @@ if ('-GenVPRModel'.lower() in str(sys.argv).lower()) :
         print(rrGraphXML)
 
 
-if ('-GenBitstreamSpec'.lower() in str(sys.argv).lower()) :
+if ('-GenBitstreamSpec'.lower() in processedArguments) :
 	arguments = re.split(' ',str(sys.argv))
 	# index was not working...
 	i = 0
@@ -5181,7 +5186,7 @@ if ('-GenBitstreamSpec'.lower() in str(sys.argv).lower()) :
 		for key2, val in specObject["TileSpecs"][key1].items():
 		  w.writerow([key2,val])
 
-if ('-help'.lower() in str(sys.argv).lower()) or ('-h' in str(sys.argv).lower()):
+if ('-help'.lower() in processedArguments) or ('-h' in processedArguments):
     print('')
     print('Options/Switches')
     print('  -GenTileSwitchMatrixCSV    - generate initial switch matrix template (has to be bootstrapped first)')

--- a/fabric_generator/run_fab_flow_nextpnr_pair.sh
+++ b/fabric_generator/run_fab_flow_nextpnr_pair.sh
@@ -1,0 +1,45 @@
+#REM STEP 1 : Generate the switch matrix as an empty CSV file containing the adjacency matrix (gets populated in Step 2)
+python3 fabric_gen.py -GenTileSwitchMatrixCSV
+#REM STEP 2 : populate the switch matrix (adjacency matrix) entries
+#REM We do this for each tile individually in order to have some control what gets updated
+python3 fabric_gen.py -AddList2CSV LUT4AB_switch_matrix.list LUT4AB_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV N_term_single_switch_matrix.list N_term_single_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV S_term_single_switch_matrix.list S_term_single_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV N_term_single2_switch_matrix.list N_term_single2_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV S_term_single2_switch_matrix.list S_term_single2_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV CPU_IO_switch_matrix.list CPU_IO_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV W_IO_switch_matrix.list W_IO_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV RegFile_switch_matrix.list RegFile_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV DSP_top_switch_matrix.list DSP_top_switch_matrix.csv
+python3 fabric_gen.py -AddList2CSV DSP_bot_switch_matrix.list DSP_bot_switch_matrix.csv
+#REM STEP 3 : generate the tile switch matrices (RTL)
+python3 fabric_gen.py -GenTileSwitchMatrixVHDL
+python3 fabric_gen.py -GenTileSwitchMatrixVerilog
+#REM STEP 4 : generate the configuration storage (RTL)
+python3 fabric_gen.py -GenTileConfigMemVHDL
+python3 fabric_gen.py -GenTileConfigMemVerilog
+#REM STEP 5 : generate the actual tiles (RTL)
+python3 fabric_gen.py -GenTileHDL
+python3 fabric_gen.py -GenTileVerilog
+#REM STEP 6 : generate the entire fabric (RTL)
+python3 fabric_gen.py -GenFabricHDL
+python3 fabric_gen.py -GenFabricVerilog
+#REM STEP 7 : generate the nextpnr model
+python3 fabric_gen.py -GenNextpnrModel_pair
+python3 spec_gen.py -GenBitstreamSpec npnroutput/meta_data.txt
+#GOTO END
+
+mkdir -p verilog_output
+mv -f *.v ./verilog_output
+
+mkdir -p vhdl_output
+mv -f *.vhdl ./vhdl_output
+
+mkdir -p list_files
+mv -f *.list ./list_files
+
+mkdir -p csv_output
+mv -f *.csv ./csv_output
+
+cp ./npnroutput/{bel.txt,pips.txt,template.pcf,template.v,meta_data.txt} ../nextpnr-fabulous/fabulous/
+cp csv_output/fabric.csv ../nextpnr-fabulous/fabulous/


### PR DESCRIPTION
As mentioned in #5, FABulous' current method of checking arguments is not ideal as it converts arguments to a string and checks for presence of a substring, meaning that valid flags that are substrings of other valid flags can cause issues. This PR resolves this by creating a processed list of all arguments (by removing surrounding whitespace and making lower case), and checking the presence of valid flags within this list.

