### PR TITLE
Fix multiple tile bel recurrence bug

### DIFF
--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -3978,7 +3978,7 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
     tilesString = "" #String to store tiles
 
     sourceSinkMap = getFabricSourcesAndSinks(archObject)
-    
+    doneBels = [] # List to track bels that we've already created a pb_type for (by type)
     for cellType in archObject.cellTypes: 
         cTile = getTileByType(archObject, cellType)
 

--- a/fabric_generator/fabric_gen_v3.py
+++ b/fabric_generator/fabric_gen_v3.py
@@ -3979,7 +3979,7 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
     tilesString = "" #String to store tiles
 
     sourceSinkMap = getFabricSourcesAndSinks(archObject)
-    
+    doneBels = [] # List to track bels that we've already created a pb_type for (by type)
     for cellType in archObject.cellTypes: 
         cTile = getTileByType(archObject, cellType)
 
@@ -3990,7 +3990,6 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
         tilesString += '    </equivalent_sites>\n'
 
         pb_typesString += f'  <pb_type name="{cellType}">\n' #Top layer block
-        doneBels = [] # List to track bels that we've already created a pb_type for (by type)
 
         tileInputs = [] #Track the tile's top level inputs and outputs for the top pb_type definition
         tileOutputs = [] 


### PR DESCRIPTION
Currently, having multiple tile types in the fabric csv file that contain BELs with the same name will lead to multiple, conflicting definitions of these bels. This PR fixes this bug by keeping track of all BELs processed in any tile type, and avoiding repeats.