### PR TITLE
Update to correct component name

### DIFF
--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -70,7 +70,7 @@ Example:
 
 .. code-block:: console
 
-   ./fabulous_flow.sh sequential_16bit
+   ./fabulous_flow.sh sequential_16bit_en
 
 The output <benchmark_name>_output.bin can be used in further simulation.
 


### PR DESCRIPTION
Minor change to the documentation fixing the mistake pointed out [here](https://github.com/FPGA-Research-Manchester/FABulous/issues/13).