### PR TITLE
Update VPR flow

### DIFF
--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -5411,6 +5411,10 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
     rowPtcArr = [0] * archObject.height
     colPtcArr = [2**14] * archObject.width
 
+    #These are just used as bound checks to make sure the fabric isn't still too big
+    rowMaxPtc = 2**14 - 1
+    colMaxPtc = 2**15 - 1
+
     for row in archObject.tiles:
         for tile in row:
             tileLoc = tile.genTileLoc()
@@ -5467,9 +5471,14 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
                     if nodeType == "CHANY":
                         wirePtc = colPtcArr[tile.x]
                         colPtcArr[tile.x] += 1
+                        if wirePtc > colMaxPtc:
+                            raise ValueError("Channel PTC value too high - FABulous' VPR flow may not currently be able to support this many overlapping wires.")
                     else: #i.e. if nodeType == "CHANX"
                         wirePtc = rowPtcArr[tile.y]
                         rowPtcArr[tile.y] += 1
+                        if wirePtc > rowMaxPtc:
+                            raise ValueError("Channel PTC value too high - FABulous' VPR flow may not currently be able to support this many overlapping wires.")
+
 
                     #Coordinates until now have been relative to the fabric - only account for padding when formatting actual string
                     nodesString += f'  <!-- Wire: {wireSource+str(i)} -> {wireDest+str(i)} -->\n' #Comment destination for clarity
@@ -5517,9 +5526,13 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
                 if nodeType == "CHANY":
                     wirePtc = colPtcArr[tile.x]
                     colPtcArr[tile.x] += 1
+                    if wirePtc > colMaxPtc:
+                        raise ValueError("Channel PTC value too high - FABulous' VPR flow may not currently be able to support this many overlapping wires.")
                 else: #i.e. if nodeType == "CHANX"
                     wirePtc = rowPtcArr[tile.y]
                     rowPtcArr[tile.y] += 1
+                    if wirePtc > rowMaxPtc:
+                        raise ValueError("Channel PTC value too high - FABulous' VPR flow may not currently be able to support this many overlapping wires.")
 
 
                 nodesString += f'  <!-- Atomic Wire: {wireSource} -> {wireDest} -->\n' #Comment destination for clarity

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4871,6 +4871,8 @@ lut4cStr = """
     <clock name="clk" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <output name="Co" num_pins="1"/>
+    <input name="SR" num_pins="1"/>
+    <input name="EN" num_pins="1"/>
     <interconnect>
      <direct name="I0_to_LUT_in" input="LUT4c_frame_config.I0" output="lut4.in[0]"/>
      <direct name="I1_to_LUT_in" input="LUT4c_frame_config.I1" output="lut4.in[1]"/>

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -5471,7 +5471,6 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
                         wirePtc = rowPtcArr[tile.y]
                         rowPtcArr[tile.y] += 1
 
-
                     #Coordinates until now have been relative to the fabric - only account for padding when formatting actual string
                     nodesString += f'  <!-- Wire: {wireSource+str(i)} -> {wireDest+str(i)} -->\n' #Comment destination for clarity
                     nodesString += f'  <node id="{curNodeId}" type="{nodeType}" capacity="1" direction="{direction}">\n' #Generate tag for each node
@@ -5521,6 +5520,7 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
                 else: #i.e. if nodeType == "CHANX"
                     wirePtc = rowPtcArr[tile.y]
                     rowPtcArr[tile.y] += 1
+
 
                 nodesString += f'  <!-- Atomic Wire: {wireSource} -> {wireDest} -->\n' #Comment destination for clarity
                 nodesString += f'  <node id="{curNodeId}" type="{nodeType}" capacity="1" direction="{direction}">\n' #Generate tag for each node
@@ -5646,7 +5646,7 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
 
     ### CHANNELS
 
-    max_width = wirePtc #Overwrite with an upper bound of the possible wire PTCs for now 
+    max_width = max(rowPtcArr + colPtcArr)
 
     #Use the max width generated before for this tag
     channelString = f'  <channel chan_width_max="{max_width}" x_min="0" y_min="0" x_max="{archObject.width + 1}" y_max="{archObject.height + 1}"/>\n'

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -5626,10 +5626,11 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
     channelString = f'  <channel chan_width_max="{max_width}" x_min="0" y_min="0" x_max="{archObject.width + 1}" y_max="{archObject.height + 1}"/>\n'
     
     #Generate x_list tag and y_list tag for every channel - use the upper bound max_width for simplicity
-    for i in range(archObject.width + 2):
+    #Not a bug that this uses height for the x_list and width for the y_list - see VtR's RR graph file format docs
+    for i in range(archObject.height + 2):
         channelString += f'  <x_list index ="{i}" info="{max_width}"/>\n'
 
-    for i in range(archObject.height + 2):
+    for i in range(archObject.width + 2):
         channelString += f'  <y_list index ="{i}" info="{max_width}"/>\n'
 
 

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4960,6 +4960,7 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
 
     sourceSinkMap = getFabricSourcesAndSinks(archObject)
     
+    doneBels = [] # List to track bels that we've already created a pb_type for (by type)
     for cellType in archObject.cellTypes: 
         cTile = getTileByType(archObject, cellType)
 
@@ -4970,7 +4971,6 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
         tilesString += '    </equivalent_sites>\n'
 
         pb_typesString += f'  <pb_type name="{cellType}">\n' #Top layer block
-        doneBels = [] # List to track bels that we've already created a pb_type for (by type)
 
         tileInputs = [] #Track the tile's top level inputs and outputs for the top pb_type definition
         tileOutputs = [] 
@@ -4978,7 +4978,6 @@ def genVPRModelXML(archObject: Fabric, generatePairs = True):
         customInterconnectStr = "" #Create empty string to store custom interconnect XML
 
         for bel in cTile.belsWithIO: #Create second layer (leaf) blocks for each bel
-
             tileInputs.extend(bel[2]) #Add the inputs and outputs of this BEL to the top level tile inputs/outputs list
             tileOutputs.extend(bel[3])
 


### PR DESCRIPTION
This contains a few fixes and updates for the VPR flow:
- Widen the scope of doneBels so that the same BEL can appear in different tiles. This was fixed in a previous PR, but seems like it was unintentionally undone at some point.
- Update default custom XML for LUTs so that it matches the latest LUT design
- Fix the x_ and y_ list sizes as they were previously the wrong way round
- Change the way that wire PTC numbers are assigned. It looks like when fabrics get larger, issues occur due to some kind of 16-bit integer overflow on the PTC (not sure when it gets handled as 16-bit but a PTC number of 2^15 somehow ends up being interpreted as -2^15) that eventually leads to VPR trying to give a vector a negative size and throwing an error. Previously these numbers were assigned inefficiently, so the assignment is now significantly more efficient and should be able to handle larger fabrics without issues. It's still not quite an optimal assignment, but I suspect optimal results would be quite expensive.