### PR TITLE
VPR Refactor for Pin Constraints

### DIFF
--- a/fabric_files/generic/custom_info.xml
+++ b/fabric_files/generic/custom_info.xml
@@ -1,7 +1,7 @@
 <custom_xml_spec>
 	<bel_info name="LUT4c_frame_config">
 		<bel_pb>
-			<pb_type name="LUT4c_frame_config" num_pb="8">
+			<pb_type name="LUT4c_frame_config" num_pb="1">
 				<pb_type name="lut4" blif_model=".names" num_pb="1" class="lut">
 					<input name="in" num_pins="4" port_class="lut_in"/>
 					<output name="out" num_pins="1" port_class="lut_out"/>
@@ -30,7 +30,7 @@
 				<input name="I2" num_pins="1"/>
 				<input name="I3" num_pins="1"/>
 				<input name="Ci" num_pins="1"/>
-				<clock name="clk" num_pins="1"/>
+				<clock name="UserCLK" num_pins="1"/>
 				<output name="O" num_pins="1"/>
 				<output name="Co" num_pins="1"/>
 				<input name="SR" num_pins="1"/>
@@ -43,7 +43,7 @@
 					<direct name="LUT_out_to_ff" input="lut4.out" output="ff.D">
 						<pack_pattern name="lut_with_ff" in_port="lut4.out" out_port="ff.D"/>
 					</direct>
-					<direct name="clock_pb_to_lut" input="LUT4c_frame_config.clk" output="ff.clk"/>
+					<direct name="clock_pb_to_lut" input="LUT4c_frame_config.UserCLK" output="ff.clk"/>
 					<mux name="lut4c_out_mux" input="ff.Q lut4.out" output="LUT4c_frame_config.O">
 						<delay_constant max="25e-12" in_port="lut4.out" out_port="LUT4c_frame_config.O"/>
 						<delay_constant max="45e-12" in_port="ff.Q" out_port="LUT4c_frame_config.O"/>
@@ -73,7 +73,7 @@
 	</bel_info>
 	<bel_info name="IO_1_bidirectional_frame_config_pass">
 		<bel_pb>
-			<pb_type name="IO_1_bidirectional_frame_config_pass" num_pb="2">
+			<pb_type name="IO_1_bidirectional_frame_config_pass" num_pb="1">
 				<mode name="pad_is_input">
 					<pb_type name="W_input" blif_model=".input" num_pb="1">
 						<output name="inpad" num_pins="1"/>
@@ -90,6 +90,7 @@
 						<direct name="output_interconnect" input="IO_1_bidirectional_frame_config_pass.I" output="W_output.outpad"/>
 					</interconnect>
 				</mode>
+				<input name="UserCLK" num_pins="1"/>
 				<input name="I" num_pins="1"/>
 				<input name="T" num_pins="1"/>
 				<output name="O" num_pins="1"/>

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4893,7 +4893,7 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
     pb_typesString = '''<pb_type name="reserved_dummy">
     <interconnect>
     </interconnect>
-    <input name="dummy_pin" num_pins="1"/>
+    <input name="UserCLK" num_pins="1"/>
     </pb_type>
     '''
 
@@ -4926,7 +4926,7 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
             tilesString += f'  <equivalent_sites>\n'
             tilesString += f'    <site pb_type="reserved_dummy" pin_mapping="direct"/>\n'
             tilesString += f'  </equivalent_sites>\n'
-            tilesString += f'<input name="dummy_pin" num_pins="1"/>'
+            tilesString += f'<input name="UserCLK" num_pins="1"/>'
             tilesString += f'</sub_tile>\n'
 
 
@@ -4940,7 +4940,7 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
                 tilesString += f'  <equivalent_sites>\n'
                 tilesString += f'    <site pb_type="reserved_dummy" pin_mapping="direct"/>\n'
                 tilesString += f'  </equivalent_sites>\n'
-                tilesString += f'<input name="dummy_pin" num_pins="1"/>'
+                tilesString += f'<input name="UserCLK" num_pins="1"/>'
                 tilesString += f'</sub_tile>\n'
                 continue
 

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4893,6 +4893,7 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
     pb_typesString = '''<pb_type name="reserved_dummy">
     <interconnect>
     </interconnect>
+    <input name="dummy_pin" num_pins="1"/>
     </pb_type>
     '''
 
@@ -4925,6 +4926,7 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
             tilesString += f'  <equivalent_sites>\n'
             tilesString += f'    <site pb_type="reserved_dummy" pin_mapping="direct"/>\n'
             tilesString += f'  </equivalent_sites>\n'
+            tilesString += f'<input name="dummy_pin" num_pins="1"/>'
             tilesString += f'</sub_tile>\n'
 
 
@@ -4932,6 +4934,15 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
         for bel in cTile.belsWithIO: #Create second layer (leaf) blocks for each bel
             tileInputs.extend(bel[2]) #Add the inputs and outputs of this BEL to the top level tile inputs/outputs list
             tileOutputs.extend(bel[3])
+
+            if bel[2] == bel[3] == []:
+                tilesString += f'<sub_tile name="{bel[1]}{bel[0]}_dummy" capacity="1">\n'
+                tilesString += f'  <equivalent_sites>\n'
+                tilesString += f'    <site pb_type="reserved_dummy" pin_mapping="direct"/>\n'
+                tilesString += f'  </equivalent_sites>\n'
+                tilesString += f'<input name="dummy_pin" num_pins="1"/>'
+                tilesString += f'</sub_tile>\n'
+                continue
 
 
             #We generate a separate subtile for each BEL instance (so that we can wire them differently)

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -5024,12 +5024,6 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
                 pbPortsStr += f'    <output name="{cOutput}" num_pins="1"/>\n' #Add outputs to pb
                 passthroughInterconnectStr += f'<direct name="{bel[0]}_{cOutput}_child_to_top" input="{bel[0]}.{cOutput}" output="{bel[0]}_wrapper.{cOutput}"/>\n'
 
-            # for source in sourceSinkMap[cTile.genTileLoc()][0]:
-            #     pbPortsStr += f'   <output name="{source}" num_pins="1"/>\n' #Add top level inputs and outputs
-
-            # for sink in sourceSinkMap[cTile.genTileLoc()][1]:
-            #     pbPortsStr += f'   <input name="{sink}" num_pins="1"/>\n' #Add top level inputs and outputs
-
 
 
             if bel[0] in specialBelDict: #If the bel has custom pb_type XML
@@ -5114,7 +5108,6 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
                     for cOutput in unprefixedOutputs: #Add a constant delay between every pair of input and output ports (as currently we say they are all combinationally linked)
                         pb_typesString += f'    <delay_constant max="300e-12" in_port="{bel[0]}.{cInput}" out_port="{bel[0]}.{cOutput}"/>\n'
 
-
                 pb_typesString += pbPortsStr
                 pb_typesString += '   </pb_type>\n' #Close inner tag
                 pb_typesString += '   <interconnect>\n'
@@ -5159,89 +5152,6 @@ def genVPRModelXML(archObject: Fabric, customXmlFilename, generatePairs = True):
 
             pb_typesString += f'</pb_type>\n'
 
-
-        pinlocationsAndInputsStr = ''
-
-        pinlocationsAndInputsStr += '   <pinlocations pattern="custom">\n' #Custom pinlocations allow us to set all pins to the bottom of the tile - this just makes RR graph accuracy easier
-        
-        totalList = f'{cellType}_sub.UserCLK' #Add UserCLK to the list of pins
-        for cPin in (tileInputs + tileOutputs + list(sourceSinkMap[cTile.genTileLoc()][0]) + list(sourceSinkMap[cTile.genTileLoc()][1])): #List all pins 
-            totalList += f' {cellType}_sub.{cPin}' #And add them to the pinlocation list
-
-        pinlocationsAndInputsStr += f'    <loc side ="bottom"> {totalList} </loc>\n' #Set all to bottom of tile
-
-        # pinlocationsAndInputsStr += '   </pinlocations>\n'
-
-
-        # pb_typesString += '   <interconnect>\n' #We now need interconnect to link every bel to the top pb_type
-
-        # belCountDict = {} #Use dict to track how many of each bel we have seen
-        # belIndexList = [] #Shows what index the bel at the relevant index has
-
-        # for bel in cTile.belsWithIO:
-        #     if bel[0] in belCountDict: #If we've already seen one of the bel
-        #         i = belCountDict[bel[0]] #Then our index is the number we've already seen (indexing starts at 0)
-        #         belCountDict[bel[0]] = i + 1 #And we increment our seen count by 1
-        #     else:
-        #         i = 0
-        #         belCountDict[bel[0]] = 1 #Otherwise we set our seen count to 1 and set i to 0
-
-        #     belIndexList.append(i) #Update list to map current bel to its index
-
-        #     for cInput in bel[2]:  #Add direct connections from top level tile to the corresponding child port
-        #         pb_typesString += f'    <direct name="{cTile.tileType}_{cInput}_top_to_child" input="{cellType}.{cInput}" output="{bel[0]}[{i}].{removeStringPrefix(cInput, bel[1])}"/>\n'
-
-
-        #     for cOutput in bel[3]: #Add direct connections from child port to top level tile
-        #         pb_typesString += f'    <direct name="{cTile.tileType}_{cOutput}_child_to_top" input="{bel[0]}[{i}].{removeStringPrefix(cOutput, bel[1])}" output="{cellType}.{cOutput}"/>\n'
-
-        #     if bel[4] and bel[0] not in specialBelDict: #If the BEL has a clock input then route it in - we don't do this for custom XML so the user is not restricted in terms of clock port presence or naming
-        #         pb_typesString += f'    <direct name="{cTile.tileType}_{bel[0]}_{i}_clock_in" input="{cellType}.UserCLK" output="{bel[0]}[{i}].UserCLK"/>\n'
-
-        # TODO: REFACTOR THIS
-        # for pip in cTile.pips: 
-        #     if (pip[0] in tileOutputs) and (pip[1] in tileInputs): #If we have a pip connecting a bel output to a bel input we add it as a direct connection
-        #         for i, bel in enumerate(cTile.belsWithIO): 
-        #             if pip[0] in bel[3]: #If the pip's source is the same as the bel's output then we note it as the source of the pip
-        #                 sourceBel = bel #Note which bel it is
-        #                 sourceIndex = belIndexList[i] #And what index it has (in terms of its own type e.g. LUT4[2])
-        #             if pip[1] in bel[2]: #And if the pip's sink is the same as the bel's input then we note it as the sink
-        #                 sinkBel = bel #Note the same again
-        #                 sinkIndex = belIndexList[i]
-        #         sourceStr = f'{sourceBel[0]}[{sourceIndex}].{removeStringPrefix(pip[0], sourceBel[1])}' #Generate the source
-        #         sinkStr = f'{sinkBel[0]}[{sinkIndex}].{removeStringPrefix(pip[1], sinkBel[1])}' #And sink port names
-        #         pb_typesString += f'    <direct name="{pip[0]}_{pip[1]}_pip" input="{sourceStr}" output="{sinkStr}"/>\n' #And add the direct tag
- 
-
-        # pb_typesString += customInterconnectStr
-        # pb_typesString += '   </interconnect>\n'
-
-        # tilesString += f'   <input name="UserCLK" num_pins="1"/>\n'
-        # pb_typesString += f'   <input name="UserCLK" num_pins="1"/>\n'
-
-
-        # #Now we add tile and top-level pb_type inputs and outputs
-        # for cInput in tileInputs:
-        #     pb_typesString += f'   <input name="{cInput}" num_pins="1"/>\n' #Add top level inputs and outputs
-        #     pinlocationsAndInputsStr += f'   <input name="{cInput}" num_pins="1"/>\n'
-
-
-        # for cOutput in tileOutputs:
-        #     pb_typesString += f'   <output name="{cOutput}" num_pins="1"/>\n'
-        #     pinlocationsAndInputsStr += f'   <output name="{cOutput}" num_pins="1"/>\n'
-
-
-        # for source in sourceSinkMap[cTile.genTileLoc()][0]:
-        #     pb_typesString += f'   <output name="{source}" num_pins="1"/>\n' #Add top level inputs and outputs
-        #     pinlocationsAndInputsStr += f'   <output name="{source}" num_pins="1"/>\n'            
-
-        # for sink in sourceSinkMap[cTile.genTileLoc()][1]:
-        #     pb_typesString += f'   <input name="{sink}" num_pins="1"/>\n' #Add top level inputs and outputs
-        #     pinlocationsAndInputsStr += f'   <input name="{sink}" num_pins="1"/>\n'    
-
-        # #And close final tile & pb_type string
-        # pb_typesString += f'  </pb_type>\n'
-        # tilesString += pinlocationsAndInputsStr + '</sub_tile>\n' 
         tilesString += '  </tile>\n'
 
 
@@ -5396,16 +5306,12 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
         
         cTile = getTileByType(archObject, cellType) #Fetch tile of this type
         
+
+        # Following sections are deliberately ordered (based on comparison with VPR's generated RR graph)
+        # as the PTC numbers have to match those that VPR would generate for its own RR graph
+        # Pattern should be one subtile at a time, all subtile inputs then all subtile outputs (in order of declaration in architecture)
+
         ptc = 0
-
-        # blocksString += f'   <pin_class type="INPUT">\n' #Generate the tags 
-        # blocksString += f'    <pin ptc="{ptc}">{cellType}.UserCLK[0]</pin>\n'
-        # blocksString += f'   </pin_class>\n'
-
-        # ptc += 1        
-
-        # blockInputString = "" #String to hold all input declarations
-        # blockOutputString = "" #String to hold all output declarations
 
         if cTile.belsWithIO == []: #If no BELs then we need UserCLK as a dummy pin
             blocksString += f'   <pin_class type="INPUT">\n' #Generate the tags 
@@ -5419,7 +5325,6 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
                 blocksString += f'    <pin ptc="{ptc}">{cellType}.UserCLK[0]</pin>\n'
                 blocksString += f'   </pin_class>\n'    
                 ptc += 1 #And increment the ptc            
-
 
             for cInput in bel[2]: #Take each input and output
                 blocksString += f'   <pin_class type="INPUT">\n' #Generate the tags 
@@ -5450,11 +5355,6 @@ def genVPRModelRRGraph(archObject: Fabric, generatePairs = True):
             blocksString += f'   </pin_class>\n'
             tilePtcMap[source] = ptc
             ptc += 1     
-
-      
-
-        # blocksString += blockInputString
-        # blocksString += blockOutputString
 
         blocksString += '  </block_type>\n'
 


### PR DESCRIPTION
As discussed [here](https://groups.google.com/g/vtr-users/c/IkTgyfHLyQg), in order to have full control over placement of individual BELs through placement constraints, different BELs need to be on separate subtiles within each tile. This PR refactors the way that BELs are represented within VPR tiles to permit this - this also involves some changes to things such as pb_types (wrapper pb_types are now required, simply because each top level pb_type represents a BEL, but in VPR top-level pb_types cannot represent a primitive) and a minor change to the custom XML spec, documentation for which is incoming.