### PR TITLE
Change to assume source/sink names by default

### DIFF
--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -1991,6 +1991,7 @@ def GenTileSwitchMatrixVerilog( tile, CSV_FileName, file ):
     # CSVFile[0][1:]:   starts in the first row from the second element
     for port in CSVFile[0][1:]:
         # the following conditional is used to capture GND and VDD to not sow up in the switch matrix port list
+        #NOTE: if you change this to allow more hanging ports like this, you'll need to update the PnR flows (at time of writing, just search for occurences of 'GNDRE' to find these bits)
         if re.search('^GND', port, flags=re.IGNORECASE) or re.search('^VCC', port, flags=re.IGNORECASE) or re.search('^VDD', port, flags=re.IGNORECASE):
             pass # maybe needed one day
         else:

--- a/fabric_generator/fabric_gen.py
+++ b/fabric_generator/fabric_gen.py
@@ -4210,6 +4210,7 @@ def GetVerilogDeclarationForFile(VHDL_file_name):
 sDelay = "8"
 GNDRE = re.compile("GND(\d*)")
 VCCRE = re.compile("VCC(\d*)")
+VDDRE = re.compile("VDD(\d*)")
 BracketAddingRE = re.compile(r"^(\S+?)(\d+)$")
 letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W"] #For LUT labelling
 
@@ -4363,7 +4364,7 @@ def getFabricSourcesAndSinks(archObject: Fabric, assumeSourceSinkNames = True):
             sinkSet = set()
             for pip in tile.pips:
                 if assumeSourceSinkNames:
-                    if GNDRE.match(pip[0]) or VCCRE.match(pip[0]):
+                    if GNDRE.match(pip[0]) or VCCRE.match(pip[0]) or VDDRE.match(pip[0]):
                         sourceSet.add(pip[0])                 
                 else:
                     if (tileLoc + "." + pip[0]) not in allFabricOutputs:
@@ -4712,7 +4713,7 @@ def genNextpnrModel(archObject: Fabric, generatePairs = True):
                                         if destPort in cTile.belPorts:
                                             foundPhysicalPairs = True #This means it's connected to a BEL
                                             continue
-                                        if GNDRE.match(destPort) or VCCRE.match(destPort):
+                                        if GNDRE.match(destPort) or VCCRE.match(destPort) or VDDRE.match(destPort):
                                             foundPhysicalPairs = True
                                             continue
                                         stopOffs.append(destLoc + "." + destPort)


### PR DESCRIPTION
Currently VPR doesn't assume the name of hanging sources/sinks in the fabric, which is a bit more flexible if more of these are added. However, this would require moderate modification to the fabric generator itself, and so it's probably safe to assume that the possible names are fixed as (VCC, VDD, GND). Making this assumption has a very significant effect on runtime, and without it the VPR flow isn't very usable for large fabrics.