### PR TITLE
Update CI BRAM script args

### DIFF
--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -66,7 +66,7 @@ jobs:
         rm S_term_RAM_IO_ConfigMem.v
         rm S_term_single_ConfigMem.v
         rm S_term_single2_ConfigMem.v
-        python3 fabulous_top_wrapper_temp/top_wrapper_generator_with_BRAM.py -c 10 -r 16
+        python3 fabulous_top_wrapper_temp/top_wrapper_generator_with_BRAM.py -c 8 -r 14
         python3 fabric_gen.py -GenNextpnrModel
         python3 fabric_gen.py -GenVPRModel custom_info.xml
         python3 fabric_gen.py -GenBitstreamSpec npnroutput/meta_data.txt
@@ -115,7 +115,7 @@ jobs:
         rm S_term_RAM_IO_ConfigMem.v
         rm S_term_single_ConfigMem.v
         rm S_term_single2_ConfigMem.v
-        python3 fabulous_top_wrapper_temp/top_wrapper_generator_with_BRAM.py -c 10 -r 16
+        python3 fabulous_top_wrapper_temp/top_wrapper_generator_with_BRAM.py -c 8 -r 14
         python3 fabric_gen.py -GenNextpnrModel_pair
         mkdir -p verilog_output
         mv -f *.v ./verilog_output


### PR DESCRIPTION
Minor fix, just updating the integers passed as arguments to `fabulous_top_wrapper_temp/top_wrapper_generator_with_BRAM.py` so that they reflect the clarification in the docs that terminal blocks should not be counted in the row and column count.