### PR TITLE
Clarify terminal blocks are not included in flow script message

### DIFF
--- a/fabric_generator/run_fab_flow.sh
+++ b/fabric_generator/run_fab_flow.sh
@@ -3,7 +3,7 @@
 # Check we have the correct argument count
 if [ $# -ne 2 ]
   then
-    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv"
+    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv (not including terminal blocks)"
     exit 1
 fi
 

--- a/fabric_generator/run_fab_flow_nextpnr.sh
+++ b/fabric_generator/run_fab_flow_nextpnr.sh
@@ -3,7 +3,7 @@
 # Check we have the correct argument count
 if [ $# -ne 2 ]
   then
-    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv"
+    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv (not including terminal blocks)"
     exit 1
 fi
 

--- a/fabric_generator/run_fab_flow_nextpnr_pair.sh
+++ b/fabric_generator/run_fab_flow_nextpnr_pair.sh
@@ -3,7 +3,7 @@
 # Check we have the correct argument count
 if [ $# -ne 2 ]
   then
-    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv"
+    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv (not including terminal blocks)"
     exit 1
 fi
 

--- a/fabric_generator/run_fab_flow_vpr.sh
+++ b/fabric_generator/run_fab_flow_vpr.sh
@@ -3,7 +3,7 @@
 # Check we have the correct argument count
 if [ $# -ne 2 ]
   then
-    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv"
+    echo "Expected 2 arguments: Number of columns in fabric.csv and number of rows in fabric.csv (not including terminal blocks)"
     exit 1
 fi
 


### PR DESCRIPTION
The part of the docs that clarifies that the flow scripts require arguments for the fabric size is the same bit that specifies these numbers exclude terminal blocks, so if you miss that and just go off the argument check message in the scripts themselves there's no indication to exclude terminal blocks. This just extends the message to clarify for all flow scripts.