### PR TITLE
Fix README image

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This guide describes everything you need to set up your system to develop for FA
 
 Ways to run Symbiflow on these devices will be explained in the near future.
 
-<img src="https://www.dropbox.com/s/g6wrtom681nr7tb/fabulous_ecosystem.png?raw=1" width="600"/>
-
+![FABulous Ecosystem Diagram](docs/source/figs/fabulous_ecosystem.png)
 
 ## How to cite
 


### PR DESCRIPTION
The Dropbox link that the ecosystem diagram was originally fetched from has since been removed - this just displays it by using the copy in the docs directory.