### PR TITLE
Update docs CI test to run on push

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,6 +1,10 @@
 name: "Docs Build Check"
-on: 
-- pull_request
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   docs:


### PR DESCRIPTION
The CI docs build test currently only runs when a PR is made to master - this sets it to run on pushes too so we have the same reassurance with changes made to master.