### PR TITLE
Broken fabric_generator README image

### DIFF
--- a/fabric_generator/README.md
+++ b/fabric_generator/README.md
@@ -1,5 +1,4 @@
-<img src="https://www.dropbox.com/s/frnugxm1kjvv947/FABulous_flow2.png?raw=1" width="500"/>
-
+![FABulous Ecosystem Diagram](docs/source/figs/FABulous_flow2.png)
 
 The user can run the flow step by step as well (see below for instructions on building HDLs):
 

--- a/fabric_generator/README.md
+++ b/fabric_generator/README.md
@@ -1,4 +1,4 @@
-![FABulous Ecosystem Diagram](docs/source/figs/FABulous_flow2.png)
+![FABulous Ecosystem Diagram](../docs/source/figs/FABulous_flow2.png)
 
 The user can run the flow step by step as well (see below for instructions on building HDLs):
 


### PR DESCRIPTION
As was just fixed with the ecosystem diagram in the main README, the image in the fabric_generator README was a broken Dropbox link - this is updated here to link to the figure used in the docs source.