### PR TITLE
Fix MULADD sign extension

### DIFF
--- a/fabric_files/fabric_init_verilog_example/MULADD.v
+++ b/fabric_files/fabric_init_verilog_example/MULADD.v
@@ -86,9 +86,13 @@ module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C
 	assign OPB = ConfigBits[1] ? B_reg : B;
 	assign OPC = ConfigBits[2] ? C_reg : C;
 
+	// sign extend inputs when doing a signed multiply
+	wire [15:0] OPAE = ConfigBits[4] ? {{8{OPA[7]}},OPA} : {8'b00000000,OPA};
+	wire [15:0] OPBE = ConfigBits[4] ? {{8{OPB[7]}},OPB} : {8'b00000000,OPB};
+
 	assign sum_in = ConfigBits[3] ? ACC : OPC;// we can
 
-	assign product = OPA * OPB;
+	assign product = OPAE * OPBE;
 
 // The sign extension was not tested
 	assign product_extended = ConfigBits[4] ? {product[15],product[15],product[15],product[15],product} : {4'b0000,product};

--- a/fabric_files/fabric_init_vhdl_example/MULADD.vhdl
+++ b/fabric_files/fabric_init_vhdl_example/MULADD.vhdl
@@ -88,6 +88,9 @@ signal OPA : std_logic_vector(7 downto 0);		-- port A
 signal OPB : std_logic_vector(7 downto 0);		-- port B 
 signal OPC : std_logic_vector(19 downto 0);		-- port B  
 
+signal OPAE : std_logic_vector(15 downto 0);		-- port A 
+signal OPBE : std_logic_vector(15 downto 0);		-- port B 
+
 signal ACC  : std_logic_vector(19 downto 0);		-- accumulator register
 signal sum  : unsigned(19 downto 0);		-- port B read data register
 signal sum_in  : std_logic_vector(19 downto 0);		-- port B read data register
@@ -108,7 +111,10 @@ OPC <= C when (ConfigBits(2) = '0') else C_reg;
 
 sum_in <= OPC when (ConfigBits(3) = '0') else ACC;		-- we can
 
-product <= unsigned(OPA) * unsigned(OPB);
+OPAE <= std_logic_vector(resize(unsigned(OPA), 16)) when (ConfigBits(4) = '0') else std_logic_vector(resize(signed(OPA), 16));
+OPBE <= std_logic_vector(resize(unsigned(OPB), 16)) when (ConfigBits(4) = '0') else std_logic_vector(resize(signed(OPB), 16));
+
+product <= resize(unsigned(OPAE) * unsigned(OPBE), 16);
 
 -- The sign extension was not tested
 product_extended <= "0000" & product when (ConfigBits(4) = '0') else product(product'high) & product(product'high) & product(product'high) & product(product'high) & product;


### PR DESCRIPTION
To make a multiply signed, it's not sufficient just to sign extend the product - it's also necessary to sign extend both operands to the full width of the multiply.

Fixes #51 