### PR TITLE
Resurrect the emulation support and add a demo

### DIFF
--- a/fabric_files/fabric_emulation_example/.gitignore
+++ b/fabric_files/fabric_emulation_example/.gitignore
@@ -1,0 +1,13 @@
+fabric/*
+*.json
+*.fasm
+*.bit
+*.vvp
+*.vcd
+*.log
+test_design/*.vh
+test_design/*.vhd
+*.hex
+*.asc
+*.bin
+*.fst

--- a/fabric_files/fabric_emulation_example/README.md
+++ b/fabric_files/fabric_emulation_example/README.md
@@ -1,0 +1,12 @@
+This assumes the default instructions were followed to build a 8x14 fabric in `../fabric_generator`.
+
+Latest Yosys and `nextpnr-generic` from upstream (_not_ the old FABulous nextpnr fork) are used
+to build the test design.
+
+Run `build_test_design.sh` to create the bitstream and `run_simulation.sh` to compare a simulation
+of the fabric in bitstream emulation mode (where the configuration logic is bypassed and muxes are
+hardwired with Verilog parameters).
+
+
+Run `run_icebreaker.sh` to run the fabric in emulation mode on ice40-based icebreaker hardware (due
+to the size of intermediate fabric representations in Yosys about 12GB of free RAM is needed).

--- a/fabric_files/fabric_emulation_example/build_test_design.sh
+++ b/fabric_files/fabric_emulation_example/build_test_design.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+SYNTH_TCL=../../nextpnr/fabulous/synth/synth_fabulous.tcl
+BIT_GEN=../../nextpnr/fabulous/fab_arch/bit_gen.py
+
+if [[ -z "${DESIGN}" ]]; then
+	DESIGN=shiftreg
+fi
+
+set -ex
+yosys -qp "synth_fabulous -top top_wrapper -json test_design/${DESIGN}.json" test_design/${DESIGN}.v test_design/top_wrapper.v
+
+FAB_ROOT=../../fabric_generator nextpnr-generic --uarch fabulous --json test_design/${DESIGN}.json -o fasm=test_design/${DESIGN}_des.fasm
+python3 ${BIT_GEN} -genBitstream test_design/${DESIGN}_des.fasm ../../fabric_generator/npnroutput/meta_data.txt test_design/${DESIGN}.bin

--- a/fabric_files/fabric_emulation_example/fabulous_tb.v
+++ b/fabric_files/fabric_emulation_example/fabulous_tb.v
@@ -1,0 +1,60 @@
+`timescale 1ps/1ps
+`define CREATE_FST
+module fab_emulation_tb;
+
+    reg CLK;
+    reg [27:0] O_top;
+    wire [27:0] I_top, T_top;
+    // Instantiate both the fabric and the reference DUT
+    eFPGA_top top_i (
+        .I_top(I_top),
+        .T_top(T_top),
+        .O_top(O_top),
+        .A_config_C(), .B_config_C(),
+        .CLK(CLK), .SelfWriteStrobe(1'b0), .SelfWriteData(32'b0),
+        .Rx(1'b0),
+        .ComActive(),
+        .ReceiveLED(),
+        .s_clk(1'b0),
+        .s_data(1'b0)
+    );
+
+    wire [27:0] I_top_gold, T_top_gold;
+    top dut_i (
+        .clk(CLK),
+        .io_out(I_top_gold),
+        .io_oeb(T_top_gold),
+        .io_in(O_top)
+    );
+
+    always #5000 CLK = (CLK === 1'b0);
+
+    integer i;
+    reg have_errors = 1'b0;
+    initial begin
+`ifdef CREATE_FST
+        $dumpfile("fab_tb.fst");
+        $dumpvars(0, fab_emulation_tb);
+`endif
+        repeat (100) @(posedge CLK);
+        O_top = 28'b1; // reset
+        repeat (5) @(posedge CLK);
+        O_top = 28'b0;
+        for (i = 0; i < 100; i = i + 1) begin
+            @(negedge CLK);
+            $display("fabric = %b gold = %b", I_top, I_top_gold);
+            if (I_top != I_top_gold)
+                have_errors = 1'b1;
+        end
+
+        if (have_errors)
+            $fatal;
+        else
+            $finish;
+    end
+
+endmodule
+
+module clk_buf(input A, output X);
+assign X = A;
+endmodule

--- a/fabric_files/fabric_emulation_example/icebreaker_emu.pcf
+++ b/fabric_files/fabric_emulation_example/icebreaker_emu.pcf
@@ -1,0 +1,12 @@
+set_io -nowarn CLK        35
+set_frequency CLK 12
+
+set_io -nowarn BTN_N      10
+set_io -nowarn LEDR_N     11
+set_io -nowarn LEDG_N     37
+
+set_io -nowarn LED1       26
+set_io -nowarn LED2       27
+set_io -nowarn LED3       25
+set_io -nowarn LED4       23
+set_io -nowarn LED5       21

--- a/fabric_files/fabric_emulation_example/icebreaker_emu.v
+++ b/fabric_files/fabric_emulation_example/icebreaker_emu.v
@@ -1,0 +1,63 @@
+module top(input CLK, BTN_N, output LEDR_N, LEDG_N, LED1, LED2, LED3, LED4, LED5);
+    wire [27:0] O_top;
+    wire [27:0] I_top, T_top;
+    // Instantiate both the fabric and the reference DUT
+    eFPGA_top top_i (
+        .I_top(I_top),
+        .T_top(T_top),
+        .O_top(O_top),
+        .A_config_C(), .B_config_C(),
+        .CLK(CLK), .SelfWriteStrobe(1'b0), .SelfWriteData(32'b0),
+        .Rx(1'b0),
+        .ComActive(),
+        .ReceiveLED(),
+        .s_clk(1'b0),
+        .s_data(1'b0)
+    );
+
+    assign O_top = {26'b0, ~BTN_N};
+    assign {LEDR_N, LEDG_N, LED5, LED4, LED3, LED2, LED1} = I_top[27:21];
+
+endmodule
+
+module clk_buf(input A, output X);
+assign X = A;
+endmodule
+
+module sram_1rw1r_32_256_8_sky130(
+//`ifdef USE_POWER_PINS
+//  vdd,
+//  gnd,
+//`endif
+// Port 0: RW
+    clk0,csb0,web0,wmask0,addr0,din0,dout0,
+// Port 1: R
+    clk1,csb1,addr1,dout1
+  );
+
+  parameter NUM_WMASKS = 4 ;
+  parameter DATA_WIDTH = 32 ;
+  parameter ADDR_WIDTH = 8 ;
+  parameter RAM_DEPTH = 1 << ADDR_WIDTH;
+  // FIXME: This delay is arbitrary.
+  parameter DELAY = 3 ;
+//`ifdef USE_POWER_PINS
+ // inout vdd;
+ // inout gnd;
+//`endif
+  input  clk0; // clock
+  input   csb0; // active low chip select
+  input  web0; // active low write control
+  input [NUM_WMASKS-1:0]   wmask0; // write mask
+  input [ADDR_WIDTH-1:0]  addr0;
+  input [DATA_WIDTH-1:0]  din0;
+  output [DATA_WIDTH-1:0] dout0;
+  input  clk1; // clock
+  input   csb1; // active low chip select
+  input [ADDR_WIDTH-1:0]  addr1;
+  output [DATA_WIDTH-1:0] dout1;
+  // bram unsupported in emulation
+  assign dout0 = 0;
+  assign dout1 = 0;
+endmodule
+

--- a/fabric_files/fabric_emulation_example/run_icebreaker.sh
+++ b/fabric_files/fabric_emulation_example/run_icebreaker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -ex
+DESIGN=blinky
+BITSTREAM=test_design/${DESIGN}.bin
+VERILOG=../../fabric_generator/verilog_output
+
+DESIGN=${DESIGN} ./build_test_design.sh
+yosys -D EMULATION_MODE -p "read_verilog test_design/${DESIGN}.vh $VERILOG/* icebreaker_emu.v; script synth_emulation_ice40.ys; write_json icebreaker_emu.json"
+nextpnr-ice40 --up5k --package sg48 --pcf icebreaker_emu.pcf --json icebreaker_emu.json --asc icebreaker_emu.asc --ignore-loops
+icepack icebreaker_emu.asc icebreaker_emu.bin
+iceprog icebreaker_emu.bin

--- a/fabric_files/fabric_emulation_example/run_simulation.sh
+++ b/fabric_files/fabric_emulation_example/run_simulation.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ex
+DESIGN=shiftreg
+BITSTREAM=test_design/${DESIGN}.bin
+VERILOG=../../fabric_generator/verilog_output
+MAX_BITBYTES=16384
+
+iverilog -D EMULATION_MODE -s fab_emulation_tb -o fab_tb.vvp test_design/${DESIGN}.vh $VERILOG/* test_design/${DESIGN}.v fabulous_tb.v 
+vvp fab_tb.vvp -fst

--- a/fabric_files/fabric_emulation_example/synth_emulation_ice40.ys
+++ b/fabric_files/fabric_emulation_example/synth_emulation_ice40.ys
@@ -1,0 +1,11 @@
+# Up to ABC, run without flattening to hide (most) loops and speed things up
+synth_ice40 -noflatten -top top -run :map_cells
+# Make names a bit smaller and flatten
+rename -enumerate *
+opt_clean -purge
+flatten
+opt_clean -purge
+# Most LUTs now have constant inputs, optimise them
+opt_lut -dlogic SB_CARRY:I0=2:I1=1:CI=0
+# Final stages of iCE40 mapping
+synth_ice40 -run map_cells:

--- a/fabric_files/fabric_emulation_example/test_design/.gitignore
+++ b/fabric_files/fabric_emulation_example/test_design/.gitignore
@@ -1,0 +1,6 @@
+*.csv
+*.fasm
+*.json
+*.bit
+*.bin
+*.txt

--- a/fabric_files/fabric_emulation_example/test_design/blinky.v
+++ b/fabric_files/fabric_emulation_example/test_design/blinky.v
@@ -1,0 +1,20 @@
+module top(input wire clk, input wire [27:0] io_in, output wire [27:0] io_out, io_oeb);
+wire rst = io_in[0];
+reg [26:0] counter;
+
+always @ (posedge clk)
+begin
+    if (rst)
+        begin
+            counter <= 0;
+        end
+    else 
+        begin
+            counter <= counter + 1;
+        end
+end
+
+assign io_oeb = 28'b1;
+assign io_out = {counter, 1'b0};
+
+endmodule

--- a/fabric_files/fabric_emulation_example/test_design/shiftreg.v
+++ b/fabric_files/fabric_emulation_example/test_design/shiftreg.v
@@ -1,0 +1,23 @@
+module top(input wire clk, input wire [27:0] io_in, output wire [27:0] io_out, io_oeb);
+wire rst = io_in[0];
+reg [649:0] data_in;
+reg [13:0] counter;
+
+always @ (posedge clk)
+begin
+    if (rst)
+        begin
+            counter <= 0;
+            data_in <= 0;
+        end
+    else 
+        begin
+            data_in <= {counter,data_in[649:13]};
+            counter <= counter + 1;
+        end
+end
+
+assign io_oeb = 28'b1;
+assign io_out = {data_in[649-:14],data_in[13:0]};
+
+endmodule

--- a/fabric_files/fabric_emulation_example/test_design/top_wrapper.v
+++ b/fabric_files/fabric_emulation_example/test_design/top_wrapper.v
@@ -1,0 +1,41 @@
+// TODO: find a more fun test design
+
+module top_wrapper;
+
+wire [27:0] io_in, io_out, io_oeb;
+(* keep, BEL="X0Y1.A" *) IO_1_bidirectional_frame_config_pass io27_i (.O(io_in[27]), .I(io_out[27]), .T(io_oeb[27]));
+(* keep, BEL="X0Y1.B" *) IO_1_bidirectional_frame_config_pass io26_i (.O(io_in[26]), .I(io_out[26]), .T(io_oeb[26]));
+(* keep, BEL="X0Y2.A" *) IO_1_bidirectional_frame_config_pass io25_i (.O(io_in[25]), .I(io_out[25]), .T(io_oeb[25]));
+(* keep, BEL="X0Y2.B" *) IO_1_bidirectional_frame_config_pass io24_i (.O(io_in[24]), .I(io_out[24]), .T(io_oeb[24]));
+(* keep, BEL="X0Y3.A" *) IO_1_bidirectional_frame_config_pass io23_i (.O(io_in[23]), .I(io_out[23]), .T(io_oeb[23]));
+(* keep, BEL="X0Y3.B" *) IO_1_bidirectional_frame_config_pass io22_i (.O(io_in[22]), .I(io_out[22]), .T(io_oeb[22]));
+(* keep, BEL="X0Y4.A" *) IO_1_bidirectional_frame_config_pass io21_i (.O(io_in[21]), .I(io_out[21]), .T(io_oeb[21]));
+(* keep, BEL="X0Y4.B" *) IO_1_bidirectional_frame_config_pass io20_i (.O(io_in[20]), .I(io_out[20]), .T(io_oeb[20]));
+(* keep, BEL="X0Y5.A" *) IO_1_bidirectional_frame_config_pass io19_i (.O(io_in[19]), .I(io_out[19]), .T(io_oeb[19]));
+(* keep, BEL="X0Y5.B" *) IO_1_bidirectional_frame_config_pass io18_i (.O(io_in[18]), .I(io_out[18]), .T(io_oeb[18]));
+(* keep, BEL="X0Y6.A" *) IO_1_bidirectional_frame_config_pass io17_i (.O(io_in[17]), .I(io_out[17]), .T(io_oeb[17]));
+(* keep, BEL="X0Y6.B" *) IO_1_bidirectional_frame_config_pass io16_i (.O(io_in[16]), .I(io_out[16]), .T(io_oeb[16]));
+(* keep, BEL="X0Y7.A" *) IO_1_bidirectional_frame_config_pass io15_i (.O(io_in[15]), .I(io_out[15]), .T(io_oeb[15]));
+(* keep, BEL="X0Y7.B" *) IO_1_bidirectional_frame_config_pass io14_i (.O(io_in[14]), .I(io_out[14]), .T(io_oeb[14]));
+(* keep, BEL="X0Y8.A" *) IO_1_bidirectional_frame_config_pass io13_i (.O(io_in[13]), .I(io_out[13]), .T(io_oeb[13]));
+(* keep, BEL="X0Y8.B" *) IO_1_bidirectional_frame_config_pass io12_i (.O(io_in[12]), .I(io_out[12]), .T(io_oeb[12]));
+(* keep, BEL="X0Y9.A" *) IO_1_bidirectional_frame_config_pass io11_i (.O(io_in[11]), .I(io_out[11]), .T(io_oeb[11]));
+(* keep, BEL="X0Y9.B" *) IO_1_bidirectional_frame_config_pass io10_i (.O(io_in[10]), .I(io_out[10]), .T(io_oeb[10]));
+(* keep, BEL="X0Y10.A" *) IO_1_bidirectional_frame_config_pass io9_i (.O(io_in[9]), .I(io_out[9]), .T(io_oeb[9]));
+(* keep, BEL="X0Y10.B" *) IO_1_bidirectional_frame_config_pass io8_i (.O(io_in[8]), .I(io_out[8]), .T(io_oeb[8]));
+(* keep, BEL="X0Y11.A" *) IO_1_bidirectional_frame_config_pass io7_i (.O(io_in[7]), .I(io_out[7]), .T(io_oeb[7]));
+(* keep, BEL="X0Y11.B" *) IO_1_bidirectional_frame_config_pass io6_i (.O(io_in[6]), .I(io_out[6]), .T(io_oeb[6]));
+(* keep, BEL="X0Y12.A" *) IO_1_bidirectional_frame_config_pass io5_i (.O(io_in[5]), .I(io_out[5]), .T(io_oeb[5]));
+(* keep, BEL="X0Y12.B" *) IO_1_bidirectional_frame_config_pass io4_i (.O(io_in[4]), .I(io_out[4]), .T(io_oeb[4]));
+(* keep, BEL="X0Y13.A" *) IO_1_bidirectional_frame_config_pass io3_i (.O(io_in[3]), .I(io_out[3]), .T(io_oeb[3]));
+(* keep, BEL="X0Y13.B" *) IO_1_bidirectional_frame_config_pass io2_i (.O(io_in[2]), .I(io_out[2]), .T(io_oeb[2]));
+(* keep, BEL="X0Y14.A" *) IO_1_bidirectional_frame_config_pass io1_i (.O(io_in[1]), .I(io_out[1]), .T(io_oeb[1]));
+(* keep, BEL="X0Y14.B" *) IO_1_bidirectional_frame_config_pass io0_i (.O(io_in[0]), .I(io_out[0]), .T(io_oeb[0]));
+
+wire clk;
+(* keep *) Global_Clock clk_i (.CLK(clk));
+
+top top_i(.clk(clk), .io_in(io_in), .io_out(io_out), .io_oeb(io_oeb));
+
+endmodule
+

--- a/fabric_generator/fabulous_top_wrapper_temp/eFPGA_v3_top_sky130_with_BRAM_template.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/eFPGA_v3_top_sky130_with_BRAM_template.v
@@ -56,11 +56,11 @@ module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, SelfWriteStr
 	input wire s_data;
 
 	//BlockRAM ports
-	input wire [64-1:0] RAM2FAB_D;
-	output wire [64-1:0] FAB2RAM_D;
-	output wire [64-1:0] FAB2RAM_A;
-	output wire [64-1:0] FAB2RAM_C;
-	output wire [64-1:0] Config_accessC;
+	wire [64-1:0] RAM2FAB_D;
+	wire [64-1:0] FAB2RAM_D;
+	wire [64-1:0] FAB2RAM_A;
+	wire [64-1:0] FAB2RAM_C;
+	wire [64-1:0] Config_accessC;
 
 	// Signal declarations
 	wire [(NumberOfRows*FrameBitsPerRow)-1:0] FrameRegister;


### PR DESCRIPTION
This reinstates the broken remnants of the "emulation" support that hardcodes a bitstream using parameters and macros, allowing a FABulous bitstream to be tested with a model of the fabric on a commercial FPGA device.

It adds two tests currently:
 - a simulation that runs in "emulation" mode using the parameter overrides
 - a FPGA test on the icebreaker dev board with yosys for synthesis (this uses a slightly hacked up synth script to deal with some oddities of the fabric structure, and still currently requires ~12GB of free RAM)