### PR TITLE
icarus: Invert T_top in testbench

### DIFF
--- a/fabric_files/fabric_icarus_example/fabulous_tb.v
+++ b/fabric_files/fabric_icarus_example/fabulous_tb.v
@@ -29,13 +29,15 @@ module fab_tb;
     );
 
 
-    wire [27:0] I_top_gold, T_top_gold;
+    wire [27:0] I_top_gold, oeb_gold, T_top_gold;
     top dut_i (
         .clk(CLK),
         .io_out(I_top_gold),
-        .io_oeb(T_top_gold),
+        .io_oeb(oeb_gold),
         .io_in(O_top)
     );
+
+    assign T_top_gold = ~oeb_gold;
 
     localparam MAX_BITBYTES = 16384;
     reg [7:0] bitstream[0:MAX_BITBYTES-1];


### PR DESCRIPTION
T_top is inverted by the fabric in https://github.com/FPGA-Research-Manchester/FABulous/blob/01b3c4484c686a0f7df40a7bc3fb4433904abba8/fabric_files/generic/IO_1_bidirectional_frame_config_pass.v#L36, do the same in the testbench when comparing against the gold