### PR TITLE
Cadence genus syn fixes

### DIFF
--- a/fabric_files/fabric_simulation_example/ConfigFSM.v
+++ b/fabric_files/fabric_simulation_example/ConfigFSM.v
@@ -13,7 +13,7 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	input Reset;
 	
 	output reg [FrameBitsPerRow-1:0] FrameAddressRegister;
-	output reg LongFrameStrobe = 0;
+	output reg LongFrameStrobe;
 	output reg [RowSelectWidth-1:0] RowSelect;
 	
 	reg FrameStrobe = 0;

--- a/fabric_files/fabric_simulation_example/ConfigFSM.v
+++ b/fabric_files/fabric_simulation_example/ConfigFSM.v
@@ -13,7 +13,7 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	input Reset;
 	
 	output reg [FrameBitsPerRow-1:0] FrameAddressRegister;
-	output reg LongFrameStrobe;
+	output wire LongFrameStrobe;
 	output reg [RowSelectWidth-1:0] RowSelect;
 	
 	reg FrameStrobe = 0;
@@ -74,9 +74,11 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	end
 	
 	reg oldFrameStrobe = 0;
+	reg LongFrameStrobe_reg = 0;
 	always @ (posedge CLK) begin : P_StrobeREG
 		oldFrameStrobe <= FrameStrobe;
-		LongFrameStrobe <= (FrameStrobe || oldFrameStrobe);
+		LongFrameStrobe_reg <= (FrameStrobe || oldFrameStrobe);
 	end//CLK
+	assign LongFrameStrobe = LongFrameStrobe_reg;
 	
 endmodule

--- a/fabric_files/fabric_simulation_example/bitbang.v
+++ b/fabric_files/fabric_simulation_example/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active = 1'b0;
+	output reg active;
 	input clk; 
 
 	reg [3:0] s_data_sample;

--- a/fabric_files/fabric_simulation_example/bitbang.v
+++ b/fabric_files/fabric_simulation_example/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active;
+	output wire active;
 	input clk; 
 
 	reg [3:0] s_data_sample;
@@ -16,6 +16,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 
 	reg local_strobe;
 	reg old_local_strobe;
+	reg active_reg = 1'b0;
 
 	always @ (posedge clk)
 	begin : p_input_sync
@@ -54,12 +55,13 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	always @ (posedge clk)
 	begin : active_FSM
 		if (serial_control == on_pattern) begin// x"FAB1" then      
-			active <= 1'b1;
+			active_reg <= 1'b1;
 		end
 		if (serial_control == off_pattern) begin// x"FAB0" then      
-			active <= 1'b0;
+			active_reg <= 1'b0;
 		end
 	end
+	assign active = active_reg;
 
 // the following is just copy and past, in case we want use the bitbang interface to shift in other data (let's say to drive CPU port)
 // we can also read back the data by loading the parallel shift and shifting the content to an output pin

--- a/fabric_files/generic/bitbang.v
+++ b/fabric_files/generic/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active = 1'b0;
+	output reg active;
 	input clk; 
 
 	reg [3:0] s_data_sample;

--- a/fabric_files/generic/bitbang.v
+++ b/fabric_files/generic/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active;
+	output wire active;
 	input clk; 
 
 	reg [3:0] s_data_sample;
@@ -16,6 +16,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 
 	reg local_strobe;
 	reg old_local_strobe;
+	reg active_reg = 1'b0;
 
 	always @ (posedge clk)
 	begin : p_input_sync
@@ -54,12 +55,13 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	always @ (posedge clk)
 	begin : active_FSM
 		if (serial_control == on_pattern) begin// x"FAB1" then      
-			active <= 1'b1;
+			active_reg <= 1'b1;
 		end
 		if (serial_control == off_pattern) begin// x"FAB0" then      
-			active <= 1'b0;
+			active_reg <= 1'b0;
 		end
 	end
+	assign active = active_reg;
 
 // the following is just copy and past, in case we want use the bitbang interface to shift in other data (let's say to drive CPU port)
 // we can also read back the data by loading the parallel shift and shifting the content to an output pin

--- a/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
@@ -11,7 +11,7 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	input Reset;
 	
 	output reg [FrameBitsPerRow-1:0] FrameAddressRegister;
-	output reg LongFrameStrobe;
+	output wire LongFrameStrobe;
 	output reg [RowSelectWidth-1:0] RowSelect;
 	
 	reg FrameStrobe = 0;
@@ -72,9 +72,11 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	end
 	
 	reg oldFrameStrobe = 0;
+	reg LongFrameStrobe_reg = 0;
 	always @ (posedge CLK) begin : P_StrobeREG
 		oldFrameStrobe <= FrameStrobe;
-		LongFrameStrobe <= (FrameStrobe || oldFrameStrobe);
+		LongFrameStrobe_reg <= (FrameStrobe || oldFrameStrobe);
 	end//CLK
+	assign LongFrameStrobe = LongFrameStrobe_reg;
 	
 endmodule

--- a/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
@@ -11,7 +11,7 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 	input Reset;
 	
 	output reg [FrameBitsPerRow-1:0] FrameAddressRegister;
-	output reg LongFrameStrobe = 0;
+	output reg LongFrameStrobe;
 	output reg [RowSelectWidth-1:0] RowSelect;
 	
 	reg FrameStrobe = 0;

--- a/fabric_generator/fabulous_top_wrapper_temp/bitbang.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active = 1'b0;
+	output reg active;
 	input clk; 
 
 	reg [3:0] s_data_sample;

--- a/fabric_generator/fabulous_top_wrapper_temp/bitbang.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/bitbang.v
@@ -5,7 +5,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	input s_data;
 	output reg strobe;
 	output reg [31:0] data;
-	output reg active;
+	output wire active;
 	input clk; 
 
 	reg [3:0] s_data_sample;
@@ -16,6 +16,7 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 
 	reg local_strobe;
 	reg old_local_strobe;
+	reg active_reg = 1'b0;
 
 	always @ (posedge clk)
 	begin : p_input_sync
@@ -54,12 +55,13 @@ module bitbang (s_clk, s_data, strobe, data, active, clk);
 	always @ (posedge clk)
 	begin : active_FSM
 		if (serial_control == on_pattern) begin// x"FAB1" then      
-			active <= 1'b1;
+			active_reg <= 1'b1;
 		end
 		if (serial_control == off_pattern) begin// x"FAB0" then      
-			active <= 1'b0;
+			active_reg <= 1'b0;
 		end
 	end
+	assign active = active_reg;
 
 // the following is just copy and past, in case we want use the bitbang interface to shift in other data (let's say to drive CPU port)
 // we can also read back the data by loading the parallel shift and shifting the content to an output pin


### PR DESCRIPTION
### Description
- These updates fix the synthesis erros that I encountered when using Cadence Genus to synthesis the eFPGA_top.v

```
Error   : Illegal initial assignment for i/o declaration. [VLOGPT-79] [read_hdl]
        : Declaration 'active' in file '/u1/eFpgaFabric/hdl_output/bitbang.v' on line 8, column 20.
        : Illegal Verilog syntax is encountered.
        output reg active = 1'b0;

Error   : Illegal initial assignment for i/o declaration. [VLOGPT-79] [read_hdl]
        : Declaration 'LongFrameStrobe' in file '/u1/eFpgaFabric/hdl_output/ConfigFSM.v' on line 14, column 29.
        output reg LongFrameStrobe = 0;
```