### PR TITLE
tb: Use strict equality check

### DIFF
--- a/fabric_files/fabric_icarus_example/fabulous_tb.v
+++ b/fabric_files/fabric_icarus_example/fabulous_tb.v
@@ -70,9 +70,9 @@ module fab_tb;
         for (i = 0; i < 100; i = i + 1) begin
             @(negedge CLK);
             $display("fabric(I_top) = 0x%X gold = 0x%X, fabric(T_top) = 0x%X gold = 0x%X", I_top, I_top_gold, T_top, T_top_gold);
-            if (I_top != I_top_gold)
+            if (I_top !== I_top_gold)
                 have_errors = 1'b1;
-            if (T_top != T_top_gold)
+            if (T_top !== T_top_gold)
                 have_errors = 1'b1;
         end
 


### PR DESCRIPTION
Previously, if the fabric failed in such a way that it is outputting `z` or `x`, `!=` would also evaluate to `x` and per verilog rules the if-path would not be taken.

Changing to `!==` means that if the fabric outputs `z` or `x` then the inequality will be true and the if statement executed, so a failure is properly reported at the end.