### PR TITLE
config: Use resets everywhere instead of init values

### DIFF
--- a/fabric_files/fabric_icarus_example/fabulous_tb.v
+++ b/fabric_files/fabric_icarus_example/fabulous_tb.v
@@ -6,6 +6,7 @@ module fab_tb;
     wire [55:0] A_cfg, B_cfg;
 
     reg CLK = 1'b0;
+    reg resetn = 1'b1;
     reg SelfWriteStrobe = 1'b0;
     reg [31:0] SelfWriteData = 1'b0;
     reg Rx = 1'b1;
@@ -20,7 +21,8 @@ module fab_tb;
         .T_top(T_top),
         .O_top(O_top),
         .A_config_C(A_cfg), .B_config_C(B_cfg),
-        .CLK(CLK), .SelfWriteStrobe(SelfWriteStrobe), .SelfWriteData(SelfWriteData),
+        .CLK(CLK), .resetn(resetn),
+        .SelfWriteStrobe(SelfWriteStrobe), .SelfWriteData(SelfWriteData),
         .Rx(Rx),
         .ComActive(ComActive),
         .ReceiveLED(ReceiveLED),
@@ -52,8 +54,12 @@ module fab_tb;
         $dumpvars(0, fab_tb);
 `endif
         $readmemh("bitstream.hex", bitstream);
+        #100;
+        resetn = 1'b0;
         #10000;
-        repeat (10) @(posedge CLK);
+        resetn = 1'b1;
+        #10000;
+        repeat (20) @(posedge CLK);
         #2500;
         for (i = 0; i < MAX_BITBYTES; i = i + 4) begin
             SelfWriteData <= {bitstream[i], bitstream[i+1], bitstream[i+2], bitstream[i+3]};

--- a/fabric_files/generic/config_UART.v
+++ b/fabric_files/generic/config_UART.v
@@ -6,6 +6,7 @@ module config_UART #(
 	parameter ComRate = 217 // ComRate = f_CLK / Boud_rate (e.g., 25 MHz/115200 Boud = 217)
 ) (
 	input CLK,
+	input resetn,
 	input Rx,
 	output reg [31:0] WriteData,
 	output ComActive,
@@ -53,7 +54,7 @@ module config_UART #(
 	//typedef enum{HighNibble, LowNibble} ReceiveStateType; //systemverilog
 	localparam HighNibble = 1, LowNibble = 0;
 	//ReceiveStateType ReceiveState;
-	reg ReceiveState = HighNibble;
+	reg ReceiveState;
 	reg [3:0] HighReg;
 	wire [4:0] HexValue; // a 1'b0 MSB indicates a valid value on [3..0]
 	reg [7:0] HexData; // the received byte in hexmode mode
@@ -64,7 +65,7 @@ module config_UART #(
 	//typedef enum{WaitForStartBit, DelayAfterStartBit, GetBit0, GetBit1, GetBit2, GetBit3, GetBit4, GetBit5, GetBit6, GetBit7, GetStopBit} ComStateType;
 	//ComStateType ComState;
 	localparam WaitForStartBit=0, DelayAfterStartBit=1, GetBit0=2, GetBit1=3, GetBit2=4, GetBit3=5, GetBit4=6, GetBit5=7, GetBit6=8, GetBit7=9, GetStopBit=10;
-	reg [3:0] ComState = WaitForStartBit;
+	reg [3:0] ComState;
 	reg [7:0] ReceivedWord;
 	reg RxLocal;
 
@@ -85,12 +86,12 @@ module config_UART #(
 	//typedef enum{Idle, GetID_00, GetID_AA, GetID_FF, GetCommand, EvalCommand, GetData} PresentType;
 	//PresentType PresentState;
 	localparam Idle=0, GetID_00=1, GetID_AA=2, GetID_FF=3, GetCommand=4, EvalCommand=5, GetData=6;
-	reg [2:0] PresentState = Idle;
+	reg [2:0] PresentState;
 
 	//typedef enum{Word0, Word1, Word2, Word3} GetWordType;
 	//GetWordType GetWordState;
 	localparam Word0=0, Word1=1, Word2=2, Word3=3;
-	reg [1:0] GetWordState=Word0;
+	reg [1:0] GetWordState;
 
 	reg LocalWriteStrobe;
 
@@ -104,291 +105,328 @@ module config_UART #(
 	//wire [7:0] ReceivedWordDebug;
 	reg [22:0] blink;
 
-	initial begin
-	CRCReg = TestFileChecksum;
-	b_counter = TestFileChecksum;
-	blink = 23'b00000000000000000000000;
-	end
-
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_sync
-		RxLocal <= Rx;
+		if (!resetn)
+			RxLocal <= 1'b1;
+		else
+			RxLocal <= Rx;
 	end// CLK;
 
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_com_en
-		if (ComState == WaitForStartBit) begin
-			ComCount <= ComRate/2;// @ 25 MHz
-			ComTick <= 1'b0;
-		end else if (ComCount==0) begin
-			ComCount <= ComRate;
-			ComTick <= 1'b1;
+		if (!resetn) begin
+			ComCount <= 0;
+			ComTick <= 0;
 		end else begin
-			ComCount <= ComCount - 1;
-			ComTick <= 1'b0;
+			if (ComState == WaitForStartBit) begin
+				ComCount <= ComRate/2;// @ 25 MHz
+				ComTick <= 1'b0;
+			end else if (ComCount==0) begin
+				ComCount <= ComRate;
+				ComTick <= 1'b1;
+			end else begin
+				ComCount <= ComCount - 1;
+				ComTick <= 1'b0;
+			end
 		end
 	end
 
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_COM
-		case(ComState)
-		WaitForStartBit: begin
-			if (RxLocal==1'b0) begin
-				ComState <= DelayAfterStartBit;
-				ReceivedWord <= 0;
+		if (!resetn) begin
+			ComState <= WaitForStartBit;
+			ReceivedWord <= 8'b0;
+			ID_Reg <= 24'b0;
+			Start_Reg <= 32'b0;
+			Command_Reg <= 8'b0;
+		end else begin
+			case(ComState)
+			WaitForStartBit: begin
+				if (RxLocal==1'b0) begin
+					ComState <= DelayAfterStartBit;
+					ReceivedWord <= 0;
+				end
 			end
-		end
-		DelayAfterStartBit: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit0;
+			DelayAfterStartBit: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit0;
+				end
 			end
-		end
-		GetBit0: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit1;
-				ReceivedWord[0] <= RxLocal;
+			GetBit0: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit1;
+					ReceivedWord[0] <= RxLocal;
+				end
 			end
-		end
-		GetBit1: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit2;
-				ReceivedWord[1] <= RxLocal;
+			GetBit1: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit2;
+					ReceivedWord[1] <= RxLocal;
+				end
 			end
-		end
-		GetBit2: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit3;
-				ReceivedWord[2] <= RxLocal;
+			GetBit2: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit3;
+					ReceivedWord[2] <= RxLocal;
+				end
 			end
-		end
-		GetBit3: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit4;
-				ReceivedWord[3] <= RxLocal;
+			GetBit3: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit4;
+					ReceivedWord[3] <= RxLocal;
+				end
 			end
-		end
-		GetBit4: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit5;
-				ReceivedWord[4] <= RxLocal;
+			GetBit4: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit5;
+					ReceivedWord[4] <= RxLocal;
+				end
 			end
-		end
-		GetBit5: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit6;
-				ReceivedWord[5] <= RxLocal;
+			GetBit5: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit6;
+					ReceivedWord[5] <= RxLocal;
+				end
 			end
-		end
-		GetBit6: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit7;
-				ReceivedWord[6] <= RxLocal;
+			GetBit6: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit7;
+					ReceivedWord[6] <= RxLocal;
+				end
 			end
-		end
-		GetBit7: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetStopBit;
-				ReceivedWord[7] <= RxLocal;
+			GetBit7: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetStopBit;
+					ReceivedWord[7] <= RxLocal;
+				end
 			end
-		end
-		GetStopBit: begin
-			if (ComTick==1'b1) begin
-				ComState <= WaitForStartBit;
+			GetStopBit: begin
+				if (ComTick==1'b1) begin
+					ComState <= WaitForStartBit;
+				end
 			end
-		end
-		endcase
-// scan order:
-// <-to_modules_scan_in <- LSB_W0..MSB_W0 <- LSB_W1.... <- LSB_W7 <- from_modules_scan_out
-// W8(7..1)
-		if (ComState==GetStopBit && ComTick==1'b1) begin
-			case (PresentState)
-				GetID_00: ID_Reg[23:16] <= ReceivedWord;
-				GetID_AA: ID_Reg[15:8] <= ReceivedWord;
-				GetID_FF: ID_Reg[7:0] <= ReceivedWord;
-//         when GetSize0 => Size_Reg(15 downto 8) <= ReceivedWord;
-//         when GetSize1 => Size_Reg(7 downto 0) <= ReceivedWord;
-//         when GetCRC_H => CRC_Reg(15 downto 8) <= ReceivedWord;
-//         when GetCRC_L => CRC_Reg(7 downto 0) <= ReceivedWord;
-				GetCommand: Command_Reg <= ReceivedWord;
-				GetData: Data_Reg <= ReceivedWord;
 			endcase
+	// scan order:
+	// <-to_modules_scan_in <- LSB_W0..MSB_W0 <- LSB_W1.... <- LSB_W7 <- from_modules_scan_out
+	// W8(7..1)
+			if (ComState==GetStopBit && ComTick==1'b1) begin
+				case (PresentState)
+					GetID_00: ID_Reg[23:16] <= ReceivedWord;
+					GetID_AA: ID_Reg[15:8] <= ReceivedWord;
+					GetID_FF: ID_Reg[7:0] <= ReceivedWord;
+	//         when GetSize0 => Size_Reg(15 downto 8) <= ReceivedWord;
+	//         when GetSize1 => Size_Reg(7 downto 0) <= ReceivedWord;
+	//         when GetCRC_H => CRC_Reg(15 downto 8) <= ReceivedWord;
+	//         when GetCRC_L => CRC_Reg(7 downto 0) <= ReceivedWord;
+					GetCommand: Command_Reg <= ReceivedWord;
+					GetData: Data_Reg <= ReceivedWord;
+				endcase
+			end
 		end
 	end//CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_FSM
-		case(PresentState)
-		Idle: begin
-			if (ComState==WaitForStartBit && RxLocal==1'b0) begin 
-				PresentState <= GetID_00;
+		if (!resetn) begin
+			PresentState <= Idle;
+		end else begin
+			case(PresentState)
+			Idle: begin
+				if (ComState==WaitForStartBit && RxLocal==1'b0) begin 
+					PresentState <= GetID_00;
+				end
 			end
-		end
-		GetID_00: begin
-			if (TimeToSend==1'b1) begin 
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin
-				PresentState <= GetID_AA;
+			GetID_00: begin
+				if (TimeToSend==1'b1) begin 
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin
+					PresentState <= GetID_AA;
+				end
 			end
-		end
-		GetID_AA: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin
-				PresentState <= GetID_FF;
+			GetID_AA: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin
+					PresentState <= GetID_FF;
+				end
 			end
-		end
-		GetID_FF: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin 
-				PresentState <= GetCommand;
+			GetID_FF: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin 
+					PresentState <= GetCommand;
+				end
 			end
-		end
-//		GetSize1:
-//        if TimeToSend=1'b1 begin PresentState<=Idle;
-//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetSize0; end if;
-//		GetSize0:
-//        if TimeToSend=1'b1 begin PresentState<=Idle;
-//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetCommand; end if;
-		GetCommand: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin 
-				PresentState <= EvalCommand;
+	//		GetSize1:
+	//        if TimeToSend=1'b1 begin PresentState<=Idle;
+	//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetSize0; end if;
+	//		GetSize0:
+	//        if TimeToSend=1'b1 begin PresentState<=Idle;
+	//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetCommand; end if;
+			GetCommand: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin 
+					PresentState <= EvalCommand;
+				end
 			end
-		end
-		EvalCommand: begin
-			if (ID_Reg==24'h00AAFF && (Command_Reg[6:0]=={3'b000,4'h1} || Command_Reg[6:0]=={3'b000,4'h2})) begin
-				PresentState <= GetData;
-			end else begin
-				PresentState <= Idle;
+			EvalCommand: begin
+				if (ID_Reg==24'h00AAFF && (Command_Reg[6:0]=={3'b000,4'h1} || Command_Reg[6:0]=={3'b000,4'h2})) begin
+					PresentState <= GetData;
+				end else begin
+					PresentState <= Idle;
+				end
 			end
-		end
-		GetData: begin
-			if (TimeToSend==1'b1) begin 
-				PresentState<=Idle; 
+			GetData: begin
+				if (TimeToSend==1'b1) begin 
+					PresentState<=Idle; 
+				end
 			end
+			endcase
 		end
-		endcase
 	end//CLK
 	assign Command = Command_Reg;
 
 	if (Mode==0 || Mode==1) begin : L_hexmode// mode [0:auto|1:hex|2:bin]
 		assign HexValue = ASCII2HEX(ReceivedWord);
-		always @ (posedge CLK)
+		always @ (posedge CLK, negedge resetn)
 		begin
-			if (PresentState!=GetData) begin
+			if (!resetn) begin
 				ReceiveState <= HighNibble;
-			end else if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
-				if(ReceiveState==HighNibble) begin
-					ReceiveState <= LowNibble;
-				end
-			end else begin
-			  ReceiveState <= HighNibble;
-			end
-		//end// CLK
-			if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
-				if(ReceiveState==HighNibble) begin
-					HighReg <= HexValue[3:0];
-					HexWriteStrobe <= 1'b0;
-				end else begin// LowNibble
-					HexData <= {HighReg,HexValue[3:0]};
-					HexWriteStrobe <= 1'b1;
-				end
-			end else begin
+				HexData <= 8'b0;
+				HighReg <= 4'b0;
 				HexWriteStrobe <= 1'b0;
+			end else begin
+				if (PresentState!=GetData) begin
+					ReceiveState <= HighNibble;
+				end else if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
+					if(ReceiveState==HighNibble) begin
+						ReceiveState <= LowNibble;
+					end
+				end else begin
+				  ReceiveState <= HighNibble;
+				end
+			//end// CLK
+				if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
+					if(ReceiveState==HighNibble) begin
+						HighReg <= HexValue[3:0];
+						HexWriteStrobe <= 1'b0;
+					end else begin// LowNibble
+						HexData <= {HighReg,HexValue[3:0]};
+						HexWriteStrobe <= 1'b1;
+					end
+				end else begin
+					HexWriteStrobe <= 1'b0;
+				end
 			end
 		end// CLK
 	end
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_checksum
-		if (PresentState==GetCommand) begin // init before data arrives 
-			CRCReg <= 0;
-			b_counter <= 0;
-		end else if (Mode==1 || (Mode==0 && Command_Reg[7]==1'b1)) begin // mode [0:auto|1:hex|2:bin]
-			// if hex mode or if auto mode with detected hex mode in the command register
-			if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0 && PresentState==GetData && ReceiveState==LowNibble) begin
-				CRCReg <= CRCReg + {HighReg,HexValue[3:0]};
-				b_counter <= b_counter+1;
-			end
-		end else begin// binary mode
-			if (ComState==GetStopBit && ComTick==1'b1 && (PresentState==GetData)) begin
-				CRCReg <= CRCReg + ReceivedWord;
-				b_counter <= b_counter +1;
-			end
-		end// checksum computation
-
-		if (PresentState==GetData) begin
-			ReceiveLED <= 1'b1; // receive process in progress
-		end else if ((PresentState==Idle) && (CRCReg!=TestFileChecksum)) begin
-			//ReceiveLED <= blink(blink'high);
-			ReceiveLED <= blink[22];
+		if (!resetn) begin
+			CRCReg <= TestFileChecksum;
+			b_counter <= TestFileChecksum;
+			blink <= 23'b0;
 		end else begin
-			ReceiveLED <= 1'b0; // receive process was OK
+			if (PresentState==GetCommand) begin // init before data arrives 
+				CRCReg <= 0;
+				b_counter <= 0;
+			end else if (Mode==1 || (Mode==0 && Command_Reg[7]==1'b1)) begin // mode [0:auto|1:hex|2:bin]
+				// if hex mode or if auto mode with detected hex mode in the command register
+				if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0 && PresentState==GetData && ReceiveState==LowNibble) begin
+					CRCReg <= CRCReg + {HighReg,HexValue[3:0]};
+					b_counter <= b_counter+1;
+				end
+			end else begin// binary mode
+				if (ComState==GetStopBit && ComTick==1'b1 && (PresentState==GetData)) begin
+					CRCReg <= CRCReg + ReceivedWord;
+					b_counter <= b_counter +1;
+				end
+			end// checksum computation
+
+			if (PresentState==GetData) begin
+				ReceiveLED <= 1'b1; // receive process in progress
+			end else if ((PresentState==Idle) && (CRCReg!=TestFileChecksum)) begin
+				//ReceiveLED <= blink(blink'high);
+				ReceiveLED <= blink[22];
+			end else begin
+				ReceiveLED <= 1'b0; // receive process was OK
+			end
+
+			blink <= blink-1;
 		end
-
-		blink <= blink-1;
-
 	end //CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_bus
-		if (PresentState==EvalCommand) begin
+		if (!resetn) begin
 			LocalWriteStrobe <= 1'b0;
-		end else if (PresentState==GetData && ComState==GetStopBit && ComTick==1'b1) begin
-			LocalWriteStrobe <= 1'b1;
+			ByteWriteStrobe <= 1'b0;
 		end else begin
-			LocalWriteStrobe <= 1'b0;
-		end
+			if (PresentState==EvalCommand) begin
+				LocalWriteStrobe <= 1'b0;
+			end else if (PresentState==GetData && ComState==GetStopBit && ComTick==1'b1) begin
+				LocalWriteStrobe <= 1'b1;
+			end else begin
+				LocalWriteStrobe <= 1'b0;
+			end
 
-		if (Mode==2 || (Mode==0 && Command_Reg[7]==1'b0)) begin // mode [0:auto|1:hex|2:bin]
-		// if binary mode or if auto mode with detected binary mode in the command register
-			ByteWriteStrobe <= LocalWriteStrobe; // delay Strobe to ensure that data is valid when applying CLK
-													// should further prevent glitches in ICAP CLK
-		end else begin
-			ByteWriteStrobe <= HexWriteStrobe;
+			if (Mode==2 || (Mode==0 && Command_Reg[7]==1'b0)) begin // mode [0:auto|1:hex|2:bin]
+			// if binary mode or if auto mode with detected binary mode in the command register
+				ByteWriteStrobe <= LocalWriteStrobe; // delay Strobe to ensure that data is valid when applying CLK
+														// should further prevent glitches in ICAP CLK
+			end else begin
+				ByteWriteStrobe <= HexWriteStrobe;
+			end
 		end
 	end// CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_WordMode
-		if (PresentState==EvalCommand) begin
+		if (!resetn) begin
 			GetWordState <= Word0;
-			WriteData <= 0;
-		end else begin
-			case(GetWordState)
-			Word0: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[31:24] <= ReceivedByte;
-					GetWordState <= Word1;
-				end
-			end
-			Word1: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[23:16] <= ReceivedByte;
-					GetWordState <= Word2;
-				end
-			end
-			Word2: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[15:8] <= ReceivedByte;
-					GetWordState <= Word3;
-				end
-			end
-			Word3: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[7:0] <= ReceivedByte;
-					GetWordState <= Word0;
-				end
-			end
-			endcase
-		end
-
-		if (ByteWriteStrobe==1'b1 && GetWordState==Word3) begin
-			WriteStrobe <= 1'b1;
-		end else begin
+			WriteData <= 32'b0;
 			WriteStrobe <= 1'b0;
+		end else begin
+			if (PresentState==EvalCommand) begin
+				GetWordState <= Word0;
+				WriteData <= 0;
+			end else begin
+				case(GetWordState)
+				Word0: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[31:24] <= ReceivedByte;
+						GetWordState <= Word1;
+					end
+				end
+				Word1: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[23:16] <= ReceivedByte;
+						GetWordState <= Word2;
+					end
+				end
+				Word2: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[15:8] <= ReceivedByte;
+						GetWordState <= Word3;
+					end
+				end
+				Word3: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[7:0] <= ReceivedByte;
+						GetWordState <= Word0;
+					end
+				end
+				endcase
+			end
+
+			if (ByteWriteStrobe==1'b1 && GetWordState==Word3) begin
+				WriteStrobe <= 1'b1;
+			end else begin
+				WriteStrobe <= 1'b0;
+			end
 		end
 	end// CLK
 
@@ -398,18 +436,23 @@ module config_UART #(
 	// ReceivedWordDebug <= Data_Reg when (Mode="bin" OR (Mode="auto" && Command_Reg(7)=1'b0)) else HexData;
 	assign ComActive = (PresentState==GetData) ? 1'b1 : 1'b0;
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_TimeOut
-		if (PresentState==Idle || ComState==GetStopBit) begin
-		//Init TimeOut
+		if (!resetn) begin
 			TimeToSendCounter <= TimeToSendValue;
-			TimeToSend <= 1'b0;
-		end else if (TimeToSendCounter>0) begin
-			TimeToSendCounter <= TimeToSendCounter - 1;
-			TimeToSend <= 1'b0;
+			TimeToSendCounter <= 1'b0;
 		end else begin
-			TimeToSendCounter <= TimeToSendCounter;
-			TimeToSend <= 1'b1; // force FSM to go back to idle when inactive
+			if (PresentState==Idle || ComState==GetStopBit) begin
+			//Init TimeOut
+				TimeToSendCounter <= TimeToSendValue;
+				TimeToSend <= 1'b0;
+			end else if (TimeToSendCounter>0) begin
+				TimeToSendCounter <= TimeToSendCounter - 1;
+				TimeToSend <= 1'b0;
+			end else begin
+				TimeToSendCounter <= TimeToSendCounter;
+				TimeToSend <= 1'b1; // force FSM to go back to idle when inactive
+			end
 		end
 	end//CLK
 

--- a/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/ConfigFSM_template.v
@@ -1,65 +1,74 @@
-module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, LongFrameStrobe, RowSelect);
+module ConfigFSM (CLK, resetn, WriteData, WriteStrobe, FSM_Reset, FrameAddressRegister, LongFrameStrobe, RowSelect);
 	parameter NumberOfRows = 16;
 	parameter RowSelectWidth = 5;
 	parameter FrameBitsPerRow = 32;
 	parameter desync_flag = 20;
 
 	input CLK; 
-	
+	input resetn;	
+
 	input [31:0] WriteData;
 	input WriteStrobe;
-	input Reset;
+	input FSM_Reset;
 	
 	output reg [FrameBitsPerRow-1:0] FrameAddressRegister;
-	output reg LongFrameStrobe = 0;
+	output reg LongFrameStrobe;
 	output reg [RowSelectWidth-1:0] RowSelect;
 	
-	reg FrameStrobe = 0;
+	reg FrameStrobe;
 	//signal FrameShiftState : integer range 0 to (NumberOfRows + 2);
-	reg [4:0] FrameShiftState = 0;
+	reg [4:0] FrameShiftState;
 
 	//FSM
-	reg [1:0] state = 0;
+	reg [1:0] state;
 	reg old_reset;
-	always @ (posedge CLK) begin : P_FSM
-		old_reset <= Reset;
-		FrameStrobe <= 1'b0;
-		// we only activate the configuration after detecting a 32-bit aligned pattern "x"FAB0_FAB1"
-		// this allows placing the com-port header into the file and we can use the same file for parallel or UART configuration
-		// this also allows us to place whatever metadata, the only point to remeber is that the pattern/file needs to be 4-byte padded in the header
-		if ((old_reset == 1'b0) && (Reset == 1'b1)) begin // reset all on ComActive posedge
-			state <= 0;
-			FrameShiftState <= 0;
+	always @ (posedge CLK, negedge resetn) begin : P_FSM
+		if (!resetn) begin
+			old_reset <= 1'b0;
+			state <= 2'b00;
+			FrameShiftState <= 5'b00000;
+			FrameAddressRegister <= 0;
+			FrameStrobe <= 1'b0; 
 		end else begin
-			case(state)
-				0: begin // unsynched
-					if(WriteStrobe == 1'b1) begin // if writing enabled
-						if (WriteData == 32'hFAB0_FAB1) begin // fire only after seeing pattern 0xFAB0_FAB1
-							state <= 1; //go to synched state
+			old_reset <= FSM_Reset;
+			FrameStrobe <= 1'b0;
+			// we only activate the configuration after detecting a 32-bit aligned pattern "x"FAB0_FAB1"
+			// this allows placing the com-port header into the file and we can use the same file for parallel or UART configuration
+			// this also allows us to place whatever metadata, the only point to remeber is that the pattern/file needs to be 4-byte padded in the header
+			if ((old_reset == 1'b0) && (FSM_Reset == 1'b1)) begin // reset all on ComActive posedge
+				state <= 0;
+				FrameShiftState <= 0;
+			end else begin
+				case(state)
+					0: begin // unsynched
+						if(WriteStrobe == 1'b1) begin // if writing enabled
+							if (WriteData == 32'hFAB0_FAB1) begin // fire only after seeing pattern 0xFAB0_FAB1
+								state <= 1; //go to synched state
+							end
 						end
 					end
-				end
-				1: begin // SyncState read header
-					if(WriteStrobe == 1'b1) begin// if writing enabled
-						if(WriteData[desync_flag] == 1'b1) begin // desync
-							state <= 0; //desynced
-						end else begin
-							FrameAddressRegister <= WriteData;
-							FrameShiftState <= NumberOfRows  ;
-							state <= 2; //writing frame data
+					1: begin // SyncState read header
+						if(WriteStrobe == 1'b1) begin// if writing enabled
+							if(WriteData[desync_flag] == 1'b1) begin // desync
+								state <= 0; //desynced
+							end else begin
+								FrameAddressRegister <= WriteData;
+								FrameShiftState <= NumberOfRows  ;
+								state <= 2; //writing frame data
+							end
 						end
 					end
-				end
-				2: begin
-					if(WriteStrobe == 1'b1) begin// if writing enabled
-						FrameShiftState <= FrameShiftState -1 ;
-						if(FrameShiftState == 1) begin // on last frame
-							FrameStrobe <= 1'b1; //trigger FrameStrobe
-							state <= 1; // we go to synched state waiting for next frame or desync
+					2: begin
+						if(WriteStrobe == 1'b1) begin// if writing enabled
+							FrameShiftState <= FrameShiftState -1 ;
+							if(FrameShiftState == 1) begin // on last frame
+								FrameStrobe <= 1'b1; //trigger FrameStrobe
+								state <= 1; // we go to synched state waiting for next frame or desync
+							end
 						end
 					end
-				end
-			endcase
+				endcase
+			end
 		end
 	end
 	
@@ -71,10 +80,15 @@ module ConfigFSM (CLK, WriteData, WriteStrobe, Reset, FrameAddressRegister, Long
 		end
 	end
 	
-	reg oldFrameStrobe = 0;
-	always @ (posedge CLK) begin : P_StrobeREG
-		oldFrameStrobe <= FrameStrobe;
-		LongFrameStrobe <= (FrameStrobe || oldFrameStrobe);
+	reg oldFrameStrobe;
+	always @ (posedge CLK, negedge resetn) begin : P_StrobeREG
+		if (!resetn) begin
+			oldFrameStrobe <= 1'b0;
+			LongFrameStrobe <= 1'b0;
+		end else begin
+			oldFrameStrobe <= FrameStrobe;
+			LongFrameStrobe <= (FrameStrobe || oldFrameStrobe);
+		end
 	end//CLK
 	
 endmodule

--- a/fabric_generator/fabulous_top_wrapper_temp/config_UART.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/config_UART.v
@@ -6,6 +6,7 @@ module config_UART #(
 	parameter ComRate = 217 // ComRate = f_CLK / Boud_rate (e.g., 25 MHz/115200 Boud = 217)
 ) (
 	input CLK,
+	input resetn,
 	input Rx,
 	output reg [31:0] WriteData,
 	output ComActive,
@@ -53,7 +54,7 @@ module config_UART #(
 	//typedef enum{HighNibble, LowNibble} ReceiveStateType; //systemverilog
 	localparam HighNibble = 1, LowNibble = 0;
 	//ReceiveStateType ReceiveState;
-	reg ReceiveState = HighNibble;
+	reg ReceiveState;
 	reg [3:0] HighReg;
 	wire [4:0] HexValue; // a 1'b0 MSB indicates a valid value on [3..0]
 	reg [7:0] HexData; // the received byte in hexmode mode
@@ -64,7 +65,7 @@ module config_UART #(
 	//typedef enum{WaitForStartBit, DelayAfterStartBit, GetBit0, GetBit1, GetBit2, GetBit3, GetBit4, GetBit5, GetBit6, GetBit7, GetStopBit} ComStateType;
 	//ComStateType ComState;
 	localparam WaitForStartBit=0, DelayAfterStartBit=1, GetBit0=2, GetBit1=3, GetBit2=4, GetBit3=5, GetBit4=6, GetBit5=7, GetBit6=8, GetBit7=9, GetStopBit=10;
-	reg [3:0] ComState = WaitForStartBit;
+	reg [3:0] ComState;
 	reg [7:0] ReceivedWord;
 	reg RxLocal;
 
@@ -85,12 +86,12 @@ module config_UART #(
 	//typedef enum{Idle, GetID_00, GetID_AA, GetID_FF, GetCommand, EvalCommand, GetData} PresentType;
 	//PresentType PresentState;
 	localparam Idle=0, GetID_00=1, GetID_AA=2, GetID_FF=3, GetCommand=4, EvalCommand=5, GetData=6;
-	reg [2:0] PresentState = Idle;
+	reg [2:0] PresentState;
 
 	//typedef enum{Word0, Word1, Word2, Word3} GetWordType;
 	//GetWordType GetWordState;
 	localparam Word0=0, Word1=1, Word2=2, Word3=3;
-	reg [1:0] GetWordState=Word0;
+	reg [1:0] GetWordState;
 
 	reg LocalWriteStrobe;
 
@@ -104,291 +105,328 @@ module config_UART #(
 	//wire [7:0] ReceivedWordDebug;
 	reg [22:0] blink;
 
-	initial begin
-	CRCReg = TestFileChecksum;
-	b_counter = TestFileChecksum;
-	blink = 23'b00000000000000000000000;
-	end
-
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_sync
-		RxLocal <= Rx;
+		if (!resetn)
+			RxLocal <= 1'b1;
+		else
+			RxLocal <= Rx;
 	end// CLK;
 
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_com_en
-		if (ComState == WaitForStartBit) begin
-			ComCount <= ComRate/2;// @ 25 MHz
-			ComTick <= 1'b0;
-		end else if (ComCount==0) begin
-			ComCount <= ComRate;
-			ComTick <= 1'b1;
+		if (!resetn) begin
+			ComCount <= 0;
+			ComTick <= 0;
 		end else begin
-			ComCount <= ComCount - 1;
-			ComTick <= 1'b0;
+			if (ComState == WaitForStartBit) begin
+				ComCount <= ComRate/2;// @ 25 MHz
+				ComTick <= 1'b0;
+			end else if (ComCount==0) begin
+				ComCount <= ComRate;
+				ComTick <= 1'b1;
+			end else begin
+				ComCount <= ComCount - 1;
+				ComTick <= 1'b0;
+			end
 		end
 	end
 
-	always @ (posedge CLK)
+	always @ (posedge CLK, negedge resetn)
 	begin : P_COM
-		case(ComState)
-		WaitForStartBit: begin
-			if (RxLocal==1'b0) begin
-				ComState <= DelayAfterStartBit;
-				ReceivedWord <= 0;
+		if (!resetn) begin
+			ComState <= WaitForStartBit;
+			ReceivedWord <= 8'b0;
+			ID_Reg <= 24'b0;
+			Start_Reg <= 32'b0;
+			Command_Reg <= 8'b0;
+		end else begin
+			case(ComState)
+			WaitForStartBit: begin
+				if (RxLocal==1'b0) begin
+					ComState <= DelayAfterStartBit;
+					ReceivedWord <= 0;
+				end
 			end
-		end
-		DelayAfterStartBit: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit0;
+			DelayAfterStartBit: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit0;
+				end
 			end
-		end
-		GetBit0: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit1;
-				ReceivedWord[0] <= RxLocal;
+			GetBit0: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit1;
+					ReceivedWord[0] <= RxLocal;
+				end
 			end
-		end
-		GetBit1: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit2;
-				ReceivedWord[1] <= RxLocal;
+			GetBit1: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit2;
+					ReceivedWord[1] <= RxLocal;
+				end
 			end
-		end
-		GetBit2: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit3;
-				ReceivedWord[2] <= RxLocal;
+			GetBit2: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit3;
+					ReceivedWord[2] <= RxLocal;
+				end
 			end
-		end
-		GetBit3: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit4;
-				ReceivedWord[3] <= RxLocal;
+			GetBit3: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit4;
+					ReceivedWord[3] <= RxLocal;
+				end
 			end
-		end
-		GetBit4: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit5;
-				ReceivedWord[4] <= RxLocal;
+			GetBit4: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit5;
+					ReceivedWord[4] <= RxLocal;
+				end
 			end
-		end
-		GetBit5: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit6;
-				ReceivedWord[5] <= RxLocal;
+			GetBit5: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit6;
+					ReceivedWord[5] <= RxLocal;
+				end
 			end
-		end
-		GetBit6: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetBit7;
-				ReceivedWord[6] <= RxLocal;
+			GetBit6: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetBit7;
+					ReceivedWord[6] <= RxLocal;
+				end
 			end
-		end
-		GetBit7: begin
-			if (ComTick==1'b1) begin
-				ComState <= GetStopBit;
-				ReceivedWord[7] <= RxLocal;
+			GetBit7: begin
+				if (ComTick==1'b1) begin
+					ComState <= GetStopBit;
+					ReceivedWord[7] <= RxLocal;
+				end
 			end
-		end
-		GetStopBit: begin
-			if (ComTick==1'b1) begin
-				ComState <= WaitForStartBit;
+			GetStopBit: begin
+				if (ComTick==1'b1) begin
+					ComState <= WaitForStartBit;
+				end
 			end
-		end
-		endcase
-// scan order:
-// <-to_modules_scan_in <- LSB_W0..MSB_W0 <- LSB_W1.... <- LSB_W7 <- from_modules_scan_out
-// W8(7..1)
-		if (ComState==GetStopBit && ComTick==1'b1) begin
-			case (PresentState)
-				GetID_00: ID_Reg[23:16] <= ReceivedWord;
-				GetID_AA: ID_Reg[15:8] <= ReceivedWord;
-				GetID_FF: ID_Reg[7:0] <= ReceivedWord;
-//         when GetSize0 => Size_Reg(15 downto 8) <= ReceivedWord;
-//         when GetSize1 => Size_Reg(7 downto 0) <= ReceivedWord;
-//         when GetCRC_H => CRC_Reg(15 downto 8) <= ReceivedWord;
-//         when GetCRC_L => CRC_Reg(7 downto 0) <= ReceivedWord;
-				GetCommand: Command_Reg <= ReceivedWord;
-				GetData: Data_Reg <= ReceivedWord;
 			endcase
+	// scan order:
+	// <-to_modules_scan_in <- LSB_W0..MSB_W0 <- LSB_W1.... <- LSB_W7 <- from_modules_scan_out
+	// W8(7..1)
+			if (ComState==GetStopBit && ComTick==1'b1) begin
+				case (PresentState)
+					GetID_00: ID_Reg[23:16] <= ReceivedWord;
+					GetID_AA: ID_Reg[15:8] <= ReceivedWord;
+					GetID_FF: ID_Reg[7:0] <= ReceivedWord;
+	//         when GetSize0 => Size_Reg(15 downto 8) <= ReceivedWord;
+	//         when GetSize1 => Size_Reg(7 downto 0) <= ReceivedWord;
+	//         when GetCRC_H => CRC_Reg(15 downto 8) <= ReceivedWord;
+	//         when GetCRC_L => CRC_Reg(7 downto 0) <= ReceivedWord;
+					GetCommand: Command_Reg <= ReceivedWord;
+					GetData: Data_Reg <= ReceivedWord;
+				endcase
+			end
 		end
 	end//CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_FSM
-		case(PresentState)
-		Idle: begin
-			if (ComState==WaitForStartBit && RxLocal==1'b0) begin 
-				PresentState <= GetID_00;
+		if (!resetn) begin
+			PresentState <= Idle;
+		end else begin
+			case(PresentState)
+			Idle: begin
+				if (ComState==WaitForStartBit && RxLocal==1'b0) begin 
+					PresentState <= GetID_00;
+				end
 			end
-		end
-		GetID_00: begin
-			if (TimeToSend==1'b1) begin 
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin
-				PresentState <= GetID_AA;
+			GetID_00: begin
+				if (TimeToSend==1'b1) begin 
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin
+					PresentState <= GetID_AA;
+				end
 			end
-		end
-		GetID_AA: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin
-				PresentState <= GetID_FF;
+			GetID_AA: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin
+					PresentState <= GetID_FF;
+				end
 			end
-		end
-		GetID_FF: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin 
-				PresentState <= GetCommand;
+			GetID_FF: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin 
+					PresentState <= GetCommand;
+				end
 			end
-		end
-//		GetSize1:
-//        if TimeToSend=1'b1 begin PresentState<=Idle;
-//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetSize0; end if;
-//		GetSize0:
-//        if TimeToSend=1'b1 begin PresentState<=Idle;
-//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetCommand; end if;
-		GetCommand: begin
-			if (TimeToSend==1'b1) begin
-				PresentState<=Idle;
-			end else if (ComState==GetStopBit && ComTick==1'b1) begin 
-				PresentState <= EvalCommand;
+	//		GetSize1:
+	//        if TimeToSend=1'b1 begin PresentState<=Idle;
+	//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetSize0; end if;
+	//		GetSize0:
+	//        if TimeToSend=1'b1 begin PresentState<=Idle;
+	//        elsif ComState=GetStopBit && ComTick=1'b1 begin PresentState <= GetCommand; end if;
+			GetCommand: begin
+				if (TimeToSend==1'b1) begin
+					PresentState<=Idle;
+				end else if (ComState==GetStopBit && ComTick==1'b1) begin 
+					PresentState <= EvalCommand;
+				end
 			end
-		end
-		EvalCommand: begin
-			if (ID_Reg==24'h00AAFF && (Command_Reg[6:0]=={3'b000,4'h1} || Command_Reg[6:0]=={3'b000,4'h2})) begin
-				PresentState <= GetData;
-			end else begin
-				PresentState <= Idle;
+			EvalCommand: begin
+				if (ID_Reg==24'h00AAFF && (Command_Reg[6:0]=={3'b000,4'h1} || Command_Reg[6:0]=={3'b000,4'h2})) begin
+					PresentState <= GetData;
+				end else begin
+					PresentState <= Idle;
+				end
 			end
-		end
-		GetData: begin
-			if (TimeToSend==1'b1) begin 
-				PresentState<=Idle; 
+			GetData: begin
+				if (TimeToSend==1'b1) begin 
+					PresentState<=Idle; 
+				end
 			end
+			endcase
 		end
-		endcase
 	end//CLK
 	assign Command = Command_Reg;
 
 	if (Mode==0 || Mode==1) begin : L_hexmode// mode [0:auto|1:hex|2:bin]
 		assign HexValue = ASCII2HEX(ReceivedWord);
-		always @ (posedge CLK)
+		always @ (posedge CLK, negedge resetn)
 		begin
-			if (PresentState!=GetData) begin
+			if (!resetn) begin
 				ReceiveState <= HighNibble;
-			end else if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
-				if(ReceiveState==HighNibble) begin
-					ReceiveState <= LowNibble;
-				end
-			end else begin
-			  ReceiveState <= HighNibble;
-			end
-		//end// CLK
-			if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
-				if(ReceiveState==HighNibble) begin
-					HighReg <= HexValue[3:0];
-					HexWriteStrobe <= 1'b0;
-				end else begin// LowNibble
-					HexData <= {HighReg,HexValue[3:0]};
-					HexWriteStrobe <= 1'b1;
-				end
-			end else begin
+				HexData <= 8'b0;
+				HighReg <= 4'b0;
 				HexWriteStrobe <= 1'b0;
+			end else begin
+				if (PresentState!=GetData) begin
+					ReceiveState <= HighNibble;
+				end else if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
+					if(ReceiveState==HighNibble) begin
+						ReceiveState <= LowNibble;
+					end
+				end else begin
+				  ReceiveState <= HighNibble;
+				end
+			//end// CLK
+				if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0) begin
+					if(ReceiveState==HighNibble) begin
+						HighReg <= HexValue[3:0];
+						HexWriteStrobe <= 1'b0;
+					end else begin// LowNibble
+						HexData <= {HighReg,HexValue[3:0]};
+						HexWriteStrobe <= 1'b1;
+					end
+				end else begin
+					HexWriteStrobe <= 1'b0;
+				end
 			end
 		end// CLK
 	end
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_checksum
-		if (PresentState==GetCommand) begin // init before data arrives 
-			CRCReg <= 0;
-			b_counter <= 0;
-		end else if (Mode==1 || (Mode==0 && Command_Reg[7]==1'b1)) begin // mode [0:auto|1:hex|2:bin]
-			// if hex mode or if auto mode with detected hex mode in the command register
-			if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0 && PresentState==GetData && ReceiveState==LowNibble) begin
-				CRCReg <= CRCReg + {HighReg,HexValue[3:0]};
-				b_counter <= b_counter+1;
-			end
-		end else begin// binary mode
-			if (ComState==GetStopBit && ComTick==1'b1 && (PresentState==GetData)) begin
-				CRCReg <= CRCReg + ReceivedWord;
-				b_counter <= b_counter +1;
-			end
-		end// checksum computation
-
-		if (PresentState==GetData) begin
-			ReceiveLED <= 1'b1; // receive process in progress
-		end else if ((PresentState==Idle) && (CRCReg!=TestFileChecksum)) begin
-			//ReceiveLED <= blink(blink'high);
-			ReceiveLED <= blink[22];
+		if (!resetn) begin
+			CRCReg <= TestFileChecksum;
+			b_counter <= TestFileChecksum;
+			blink <= 23'b0;
 		end else begin
-			ReceiveLED <= 1'b0; // receive process was OK
+			if (PresentState==GetCommand) begin // init before data arrives 
+				CRCReg <= 0;
+				b_counter <= 0;
+			end else if (Mode==1 || (Mode==0 && Command_Reg[7]==1'b1)) begin // mode [0:auto|1:hex|2:bin]
+				// if hex mode or if auto mode with detected hex mode in the command register
+				if (ComState==GetStopBit && ComTick==1'b1 && HexValue[4]==1'b0 && PresentState==GetData && ReceiveState==LowNibble) begin
+					CRCReg <= CRCReg + {HighReg,HexValue[3:0]};
+					b_counter <= b_counter+1;
+				end
+			end else begin// binary mode
+				if (ComState==GetStopBit && ComTick==1'b1 && (PresentState==GetData)) begin
+					CRCReg <= CRCReg + ReceivedWord;
+					b_counter <= b_counter +1;
+				end
+			end// checksum computation
+
+			if (PresentState==GetData) begin
+				ReceiveLED <= 1'b1; // receive process in progress
+			end else if ((PresentState==Idle) && (CRCReg!=TestFileChecksum)) begin
+				//ReceiveLED <= blink(blink'high);
+				ReceiveLED <= blink[22];
+			end else begin
+				ReceiveLED <= 1'b0; // receive process was OK
+			end
+
+			blink <= blink-1;
 		end
-
-		blink <= blink-1;
-
 	end //CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_bus
-		if (PresentState==EvalCommand) begin
+		if (!resetn) begin
 			LocalWriteStrobe <= 1'b0;
-		end else if (PresentState==GetData && ComState==GetStopBit && ComTick==1'b1) begin
-			LocalWriteStrobe <= 1'b1;
+			ByteWriteStrobe <= 1'b0;
 		end else begin
-			LocalWriteStrobe <= 1'b0;
-		end
+			if (PresentState==EvalCommand) begin
+				LocalWriteStrobe <= 1'b0;
+			end else if (PresentState==GetData && ComState==GetStopBit && ComTick==1'b1) begin
+				LocalWriteStrobe <= 1'b1;
+			end else begin
+				LocalWriteStrobe <= 1'b0;
+			end
 
-		if (Mode==2 || (Mode==0 && Command_Reg[7]==1'b0)) begin // mode [0:auto|1:hex|2:bin]
-		// if binary mode or if auto mode with detected binary mode in the command register
-			ByteWriteStrobe <= LocalWriteStrobe; // delay Strobe to ensure that data is valid when applying CLK
-													// should further prevent glitches in ICAP CLK
-		end else begin
-			ByteWriteStrobe <= HexWriteStrobe;
+			if (Mode==2 || (Mode==0 && Command_Reg[7]==1'b0)) begin // mode [0:auto|1:hex|2:bin]
+			// if binary mode or if auto mode with detected binary mode in the command register
+				ByteWriteStrobe <= LocalWriteStrobe; // delay Strobe to ensure that data is valid when applying CLK
+														// should further prevent glitches in ICAP CLK
+			end else begin
+				ByteWriteStrobe <= HexWriteStrobe;
+			end
 		end
 	end// CLK
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_WordMode
-		if (PresentState==EvalCommand) begin
+		if (!resetn) begin
 			GetWordState <= Word0;
-			WriteData <= 0;
-		end else begin
-			case(GetWordState)
-			Word0: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[31:24] <= ReceivedByte;
-					GetWordState <= Word1;
-				end
-			end
-			Word1: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[23:16] <= ReceivedByte;
-					GetWordState <= Word2;
-				end
-			end
-			Word2: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[15:8] <= ReceivedByte;
-					GetWordState <= Word3;
-				end
-			end
-			Word3: begin
-				if (ByteWriteStrobe==1'b1) begin
-					WriteData[7:0] <= ReceivedByte;
-					GetWordState <= Word0;
-				end
-			end
-			endcase
-		end
-
-		if (ByteWriteStrobe==1'b1 && GetWordState==Word3) begin
-			WriteStrobe <= 1'b1;
-		end else begin
+			WriteData <= 32'b0;
 			WriteStrobe <= 1'b0;
+		end else begin
+			if (PresentState==EvalCommand) begin
+				GetWordState <= Word0;
+				WriteData <= 0;
+			end else begin
+				case(GetWordState)
+				Word0: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[31:24] <= ReceivedByte;
+						GetWordState <= Word1;
+					end
+				end
+				Word1: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[23:16] <= ReceivedByte;
+						GetWordState <= Word2;
+					end
+				end
+				Word2: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[15:8] <= ReceivedByte;
+						GetWordState <= Word3;
+					end
+				end
+				Word3: begin
+					if (ByteWriteStrobe==1'b1) begin
+						WriteData[7:0] <= ReceivedByte;
+						GetWordState <= Word0;
+					end
+				end
+				endcase
+			end
+
+			if (ByteWriteStrobe==1'b1 && GetWordState==Word3) begin
+				WriteStrobe <= 1'b1;
+			end else begin
+				WriteStrobe <= 1'b0;
+			end
 		end
 	end// CLK
 
@@ -398,18 +436,23 @@ module config_UART #(
 	// ReceivedWordDebug <= Data_Reg when (Mode="bin" OR (Mode="auto" && Command_Reg(7)=1'b0)) else HexData;
 	assign ComActive = (PresentState==GetData) ? 1'b1 : 1'b0;
 
-	always @(posedge CLK)
+	always @(posedge CLK, negedge resetn)
 	begin : P_TimeOut
-		if (PresentState==Idle || ComState==GetStopBit) begin
-		//Init TimeOut
+		if (!resetn) begin
 			TimeToSendCounter <= TimeToSendValue;
-			TimeToSend <= 1'b0;
-		end else if (TimeToSendCounter>0) begin
-			TimeToSendCounter <= TimeToSendCounter - 1;
-			TimeToSend <= 1'b0;
+			TimeToSendCounter <= 1'b0;
 		end else begin
-			TimeToSendCounter <= TimeToSendCounter;
-			TimeToSend <= 1'b1; // force FSM to go back to idle when inactive
+			if (PresentState==Idle || ComState==GetStopBit) begin
+			//Init TimeOut
+				TimeToSendCounter <= TimeToSendValue;
+				TimeToSend <= 1'b0;
+			end else if (TimeToSendCounter>0) begin
+				TimeToSendCounter <= TimeToSendCounter - 1;
+				TimeToSend <= 1'b0;
+			end else begin
+				TimeToSendCounter <= TimeToSendCounter;
+				TimeToSend <= 1'b1; // force FSM to go back to idle when inactive
+			end
 		end
 	end//CLK
 

--- a/fabric_generator/fabulous_top_wrapper_temp/eFPGA_v3_top_sky130_with_BRAM_template.v
+++ b/fabric_generator/fabulous_top_wrapper_temp/eFPGA_v3_top_sky130_with_BRAM_template.v
@@ -21,7 +21,7 @@
 	input   user_clock2
 ); */
 
-module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, SelfWriteStrobe, SelfWriteData, Rx, ComActive, ReceiveLED, s_clk, s_data);
+module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, resetn, SelfWriteStrobe, SelfWriteData, Rx, ComActive, ReceiveLED, s_clk, s_data);
 
 	localparam include_eFPGA = 1;
 	localparam NumberOfRows = 16;
@@ -41,6 +41,7 @@ module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, SelfWriteStr
 	output wire [64-1:0] B_config_C;
 
 	input wire CLK; // This clock can go to the CPU (connects to the fabric LUT output flops
+	input wire resetn; // active low async reset for all the config logic
 
 	// CPU configuration port
 	input wire SelfWriteStrobe; // must decode address and write enable
@@ -216,6 +217,7 @@ module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, SelfWriteStr
 
 Config Config_inst (
 	.CLK(CLK),
+	.resetn(resetn),
 	.Rx(Rx),
 	.ComActive(ComActive),
 	.ReceiveLED(ReceiveLED),


### PR DESCRIPTION
Init values are ignored for ASIC synthesis and so dangerous to rely on. Instead, add async resets everywhere so we can start the config logic in a known good state. This is intended as an alternative solution to #71, and generally to better comply with VLSI good practice.

@ruck314 can you confirm this fixes the Cadence Genus synthesis?