### PR TITLE
Remove obsolete nextpnr submodule

### DIFF
--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -80,8 +80,6 @@ jobs:
         mv -f *.list ./list_files
         mkdir -p csv_output
         mv -f *.csv ./csv_output
-        cp ./npnroutput/{bel.txt,pips.txt,meta_data.txt} ../nextpnr/fabulous/fab_arch/
-        cp ./csv_output/fabric.csv ../nextpnr/fabulous/fab_arch/
     - name: Run simulation smoketest
       run: |
         cd fabric_files/fabric_icarus_example
@@ -132,6 +130,4 @@ jobs:
         mv -f *.list ./list_files
         mkdir -p csv_output
         mv -f *.csv ./csv_output
-        cp ./npnroutput/{bel.txt,pips.txt,meta_data.txt} ../nextpnr/fabulous/fab_arch/
-        cp ./csv_output/fabric.csv ../nextpnr/fabulous/fab_arch/
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "nextpnr"]
-	path = nextpnr
-	url = https://github.com/FPGA-Research-Manchester/nextpnr.git
-	branch = fabulous

--- a/fabric_cad/bit_gen.py
+++ b/fabric_cad/bit_gen.py
@@ -1,0 +1,315 @@
+# Python 3
+from array import array
+import re
+import sys
+from contextlib import redirect_stdout
+from io import StringIO
+import math
+import os
+import numpy
+import pickle
+import csv
+from fasm import * #Remove this line if you do not have the fasm library installed and will not be generating a bitstream
+	
+def replace(string, substitutions):
+	substrings = sorted(substitutions, key=len, reverse=True)
+	regex = re.compile('|'.join(map(re.escape, substrings)))
+	return regex.sub(lambda match: substitutions[match.group(0)], string)
+	
+def bitstring_to_bytes(s):
+    return int(s, 2).to_bytes((len(s) + 7) // 8, byteorder='big')
+
+def hexstring_to_bytes(s):
+    v = int(s, 0)
+    b = bytearray()
+    while v:
+        b.append(v & 0xff)
+        v >>= 8
+    return bytes(b[::-1])
+
+#CAD methods from summer vacation project 2020
+
+
+#Method to generate bitstream in the output format - more detail at the end
+def genBitstream(fasmFile: str, specFile: str, bitstreamFile: str):
+	lGen = parse_fasm_filename(fasmFile)
+	canonStr = fasm_tuple_to_string(lGen, True)
+	canonList = list(parse_fasm_string(canonStr))
+
+	specDict = pickle.load(open(specFile,"rb"))
+	tileDict = {}
+	tileDict_No_Mask = {}
+
+	FrameBitsPerRow = specDict["ArchSpecs"]["FrameBitsPerRow"]
+	#MaxFramesPerCol = specDict["ArchSpecs"]["FrameBitsPerRow"]
+	MaxFramesPerCol = specDict["ArchSpecs"]["MaxFramesPerCol"]
+
+	#Change this so it has the actual right dimensions, initialised as an empty bitstream
+	for tile in specDict["TileMap"].keys():
+		#bitStream = [0]*(MaxFramesPerCol*FrameBitsPerRow)
+		tileDict[tile] = [0]*(MaxFramesPerCol*FrameBitsPerRow)
+		tileDict_No_Mask[tile] = [0]*(MaxFramesPerCol*FrameBitsPerRow)
+
+	###NOTE: SOME OF THE FOLLOWING METHODS HAVE BEEN CHANGED DUE TO A MODIFIED BITSTREAM SPEC FORMAT
+	#Please bear in mind that the tilespecs are now mapped by tile loc and not by cell type
+
+	for line in canonList:
+		if 'CLK' in set_feature_to_str(line.set_feature):
+			continue
+		if (line.set_feature):
+			tileVals = set_feature_to_str(line.set_feature).split(".")
+			#print(tileVals)
+			tileLoc = tileVals[0]
+			featureName = ".".join((tileVals[1], tileVals[2]))
+			#print(featureName)
+			if tileLoc not in specDict["TileMap"].keys():
+				raise Exception("Tile found in fasm file not found in bitstream spec")
+			tileType = specDict["TileMap"][tileLoc]	#Set the necessary bits high 
+			if featureName in specDict["TileSpecs"][tileLoc].keys():
+				if specDict["TileSpecs"][tileLoc][featureName]:
+					for bitIndex in specDict["TileSpecs"][tileLoc][featureName]:
+						tileDict[tileLoc][bitIndex] = int(specDict["TileSpecs"][tileLoc][featureName][bitIndex])
+					for bitIndex_No_Mask in specDict["TileSpecs_No_Mask"][tileLoc][featureName]:
+						#print(isinstance(bitIndex_No_Mask, int))
+						#print(isinstance(specDict["TileSpecs_No_Mask"][tileLoc][featureName][bitIndex_No_Mask], int))
+						#if 'X1Y2' in tileLoc:
+						#	print(tileDict_No_Mask[tileLoc])
+						#	print(featureName)
+						#	print(specDict["TileSpecs_No_Mask"][tileLoc][featureName])
+						#	print(bitIndex_No_Mask)
+						tileDict_No_Mask[tileLoc][bitIndex_No_Mask] = int(specDict["TileSpecs_No_Mask"][tileLoc][featureName][bitIndex_No_Mask])
+
+			else:
+				#print(specDict["TileSpecs"][tileLoc].keys())
+				print(tileType)
+				print(tileLoc)
+				print(featureName)
+				raise Exception("Feature found in fasm file was not found in the bitstream spec")
+
+
+	#Write output string and introduce mask
+	coordsRE = re.compile("X(\d*)Y(\d*)")
+	num_columns = 0
+	for tileKey in tileDict:
+		coordsMatch = coordsRE.match(tileKey)
+		if int(coordsMatch.group(1)) > num_columns:
+		    num_columns = int(coordsMatch.group(1))
+	num_columns = num_columns+1
+	#concatenatedTileDict = {}
+	outStr = ""
+	#bitStr = "00AAFF01\n"
+	#bitStr = hexstring_to_bytes("0xFAB0FAB1")
+	bitStr = bytes.fromhex('00AAFF01000000010000000000000000FAB0FAB1')
+	bit_array = [[b'' for x in range(20)] for y in range(num_columns)]
+	bit_array_check = [['' for x in range(20)] for y in range(num_columns)]
+
+	#default_hex = ['0','0','0','0','0','0','0','0']
+
+	verilog_str = ''
+	vhdl_str = 'library IEEE;\nuse IEEE.STD_LOGIC_1164.ALL;\n\npackage emulate_bitstream is\n'
+	for tileKey in tileDict_No_Mask:
+		if specDict["TileMap"][tileKey] == "NULL" or len(specDict["FrameMap"][specDict["TileMap"][tileKey]]) == 0:
+			continue
+		verilog_str += "//"+tileKey+", "+specDict["TileMap"][tileKey]+"\n"
+		verilog_str += "`define Tile_"+tileKey+"_Emulate_Bitstream "+str(MaxFramesPerCol*FrameBitsPerRow)+"'b"
+
+		vhdl_str += "--"+tileKey+", "+specDict["TileMap"][tileKey]+"\n"
+		vhdl_str += "constant Tile_"+tileKey+"_Emulate_Bitstream : std_logic_vector("+str(MaxFramesPerCol*FrameBitsPerRow)+'-1 downto 0) := "'
+
+		for i in range((MaxFramesPerCol*FrameBitsPerRow)-1,-1,-1):
+			verilog_str += str(tileDict_No_Mask[tileKey][i])
+			vhdl_str += str(tileDict_No_Mask[tileKey][i])
+		verilog_str += "\n"
+		vhdl_str += '";\n'
+	vhdl_str += "end package emulate_bitstream;"
+
+	for tileKey in tileDict:
+		coordsMatch = coordsRE.match(tileKey)
+		curStr = ",".join((tileKey, specDict["TileMap"][tileKey], coordsMatch.group(1), coordsMatch.group(2)))
+		curStr += "\n"
+		bitPos = 0
+
+		if specDict["TileMap"][tileKey] == "NULL":
+			continue
+		#elif 'term' in specDict["TileMap"][tileKey]:
+			#continue
+		for frameIndex in range(len(specDict["FrameMap"][specDict["TileMap"][tileKey]])):
+			#print (tileDict[tileKey]) #:FrameBitsPerRow*frameIndex
+			frame_bit_row = (''.join(map(str, (tileDict[tileKey][FrameBitsPerRow*frameIndex:(FrameBitsPerRow*frameIndex)+FrameBitsPerRow]))))[::-1]
+			curStr += ",".join(("frame"+str(frameIndex), str(frameIndex), str(FrameBitsPerRow), frame_bit_row))
+			curStr += "\n"
+
+			#bit_hex = hex(int(frame_bit_row,2)).replace("0x","")
+			bit_hex = bitstring_to_bytes(frame_bit_row)
+
+			#bit_hex_full = default_hex.copy()
+			
+			#for i in range(len(bit_hex)):
+			    #bit_hex_full[8-len(bit_hex)+i] = bit_hex[i]
+			    
+			#bit_array[int(coordsMatch.group(1))][frameIndex] = ''.join(bit_hex_full) + "\n" + bit_array[int(coordsMatch.group(1))][frameIndex]
+			#bit_array[int(coordsMatch.group(1))][frameIndex] = frame_bit_row + "\n" + bit_array[int(coordsMatch.group(1))][frameIndex]
+			#print(frameIndex)
+			bit_array[int(coordsMatch.group(1))][frameIndex] = bit_hex + bit_array[int(coordsMatch.group(1))][frameIndex] 
+			bit_array_check[int(coordsMatch.group(1))][frameIndex] = bit_array_check[int(coordsMatch.group(1))][frameIndex] + frame_bit_row
+
+			#frame = specDict["FrameMap"][specDict["TileMap"][tileKey]][frameIndex]
+			#for char in frame:
+				#curStr += ","
+				#if char == '0':
+					#curStr += "0"
+				#else:
+					#curStr += str(tileDict[tileKey][bitPos])
+					#bitPos += 1
+			#if tileKey == 'X3Y8':
+			 #print(*specDict["FrameMap"])
+			 #print(*tileDict[tileKey][0:10],sep = ",")
+			 #print(*frame)
+			 #print('\n')
+			 #print(curStr)
+			 #print('\n')
+
+		#concatenatedTileDict[tileKey] = curStr
+		outStr += curStr + "\n"
+	#print(num_columns)
+	for i in range(num_columns):
+		for j in range(20):
+		    bin_temp = "{0:b}".format(i).zfill(5)[::-1]
+		    frame_select = ['0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0','0']
+		    #bitStr += "X"+str(i)+", frame"+str(j)+"\n"
+
+		    for k in range(-5,0,1):
+		        frame_select[k] = bin_temp[k]
+		    #frame_select[22+i] = '1'
+		    frame_select[j] = '1'
+		    #frame_select_temp = hex(int((''.join(frame_select))[::-1],2)).replace("0x","")
+		    frame_select_temp = (''.join(frame_select))[::-1]
+		    #bit_hex_full = default_hex.copy()
+		    #for k in range(len(frame_select_temp)):
+		        #bit_hex_full[8-len(frame_select_temp)+k] = frame_select_temp[k]
+		    #bitStr += ''.join(bit_hex_full)+"\n"
+		    #bitStr += frame_select_temp+"\n"
+
+		    bitStr += bitstring_to_bytes(frame_select_temp)
+		    bitStr += bit_array[i][j]
+
+		    #if '1' in bit_array_check[i][j]:
+		        #bitStr += bitstring_to_bytes(frame_select_temp)
+		        #bitStr += bit_array[i][j]
+		    #else:
+		        #continue
+		    		    
+	#Note - format in output file is line by line:
+	#Tile Loc, Tile Type, X, Y, bits...... \n 
+	#Each line is one tile
+	print(outStr, file = open(bitstreamFile.replace("bin","fasm"), "w+"))
+	print(verilog_str, file = open(bitstreamFile.replace("bin","vh"), "w+"))
+	print(vhdl_str, file = open(bitstreamFile.replace("bin","vhd"), "w+"))
+	#print(bitStr, file = open(bitstreamFile, "w+"))
+	#with open(bitstreamFile.replace("bit","bin"), 'bw+') as f:
+	with open(bitstreamFile, 'bw+') as f:
+	 f.write(bitStr)
+
+
+#This class represents individual tiles in the architecture
+class Tile:
+	tileType = ""
+	bels = []
+	wires = [] 
+	atomicWires = [] #For storing single wires (to handle cascading and termination)
+	pips = []
+	belPorts = set()
+	matrixFileName = ""
+	pipMuxes_MapSourceToSinks= []
+	pipMuxes_MapSinkToSources= []
+
+	x = -1 #Init with negative values to ease debugging
+	y = -1
+	
+	def __init__(self, inType):
+		self.tileType = inType
+
+	def genTileLoc(self, separate = False):
+		if (separate):
+			return("X" + str(self.x), "Y" + str(self.y))
+		return "X" + str(self.x) + "Y" + str(self.y)
+
+
+#This class represents the fabric as a whole
+class Fabric:
+	tiles = []
+	height = 0
+	width = 0
+	cellTypes = []
+
+
+	def __init__(self, inHeight, inWidth):
+		self.width = inWidth
+		self.height = inHeight
+
+	def getTileByCoords(self, x: int, y: int):
+		for row in self.tiles:
+			for tile in row:
+				if tile.x == x and tile.y == y:
+					return tile
+		return None
+
+	def getTileByLoc(self, loc: str):
+		for row in self.tiles:
+			for tile in row:
+				if tile.genTileLoc == loc:
+					return tile
+		return None
+
+	def getTileAndWireByWireDest(self, loc: str, dest: str, jumps: bool = True):
+		for row in self.tiles:
+			for tile in row:
+				for wire in tile.wires:
+					if not jumps:
+						if wire["direction"] == "JUMP":
+							continue
+					for i in range(int(wire["wire-count"])):
+						desty = tile.y + int(wire["yoffset"])
+						destx = tile.x + int(wire["xoffset"])
+						desttileLoc = f"X{destx}Y{desty}"
+
+						if (desttileLoc == loc) and (wire["destination"] + str(i) == dest):
+							return (tile, wire, i)
+
+		return None
+	
+#####################################################################################
+# Main
+#####################################################################################
+
+#Strip arguments
+caseProcessedArguments = list(map(lambda x: x.strip(), sys.argv))
+processedArguments = list(map(lambda x: x.lower(), caseProcessedArguments))
+flagRE = re.compile("-\S*")
+
+if ('-genBitstream'.lower() in str(sys.argv).lower()):
+	argIndex = processedArguments.index('-genBitstream'.lower())
+	
+	if len(processedArguments) <= argIndex + 3:
+		raise ValueError('\nError: -genBitstream expect three file names - the fasm file, the spec file and the output file')
+	elif (flagRE.match(caseProcessedArguments[argIndex + 1])
+		or flagRE.match(caseProcessedArguments[argIndex + 2]) 
+		or flagRE.match(caseProcessedArguments[argIndex + 3])):
+		raise ValueError('\nError: -genBitstream expect three file names, but found a flag in the arguments:'
+			f' {caseProcessedArguments[argIndex + 1]}, {caseProcessedArguments[argIndex + 2]}, {caseProcessedArguments[argIndex + 3]}\n')
+
+	FasmFileName  = caseProcessedArguments[argIndex + 1]
+	SpecFileName  = caseProcessedArguments[argIndex + 2]
+	OutFileName  = caseProcessedArguments[argIndex + 3]
+
+	genBitstream(FasmFileName, SpecFileName, OutFileName)
+
+
+
+if ('-help'.lower() in str(sys.argv).lower()) or ('-h' in str(sys.argv).lower()):
+	print('')	
+	print('Options/Switches')	
+	print('	 -genBitstream foo.fasm spec.txt bitstream.txt - generates a bitstream - the first file is the fasm file, the second is the bitstream spec and the third is the fasm file to write to')
+	
+
+

--- a/fabric_cad/synth/cells_map.v
+++ b/fabric_cad/synth/cells_map.v
@@ -1,0 +1,29 @@
+module \$lut (A, Y);
+  parameter WIDTH = 0;
+  parameter LUT = 0;
+
+  input [WIDTH-1:0] A;
+  output Y;
+
+  generate
+    if (WIDTH == 1) begin
+      LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]));
+
+    end else
+    if (WIDTH == 2) begin
+      LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
+
+    end else
+    if (WIDTH == 3) begin
+      LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+
+    end else
+    if (WIDTH == 4) begin
+      LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+    end else begin
+      wire _TECHMAP_FAIL_ = 1;
+    end
+  endgenerate
+endmodule
+
+module  \$_DFF_P_ (input D, C, output Q); LUTFF _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C)); endmodule

--- a/fabric_cad/synth/cells_map_ff.v
+++ b/fabric_cad/synth/cells_map_ff.v
@@ -1,0 +1,54 @@
+module \$lut (A, Y);
+  parameter WIDTH = 0;
+  parameter LUT = 0;
+
+  input [WIDTH-1:0] A;
+  output Y;
+
+  generate
+    if (WIDTH == 1) begin
+      LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]));
+
+    end else
+    if (WIDTH == 2) begin
+      LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]));
+
+    end else
+    if (WIDTH == 3) begin
+      LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+
+    end else
+    if (WIDTH == 4) begin
+      LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.O(Y), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+    end else begin
+      wire _TECHMAP_FAIL_ = 1;
+    end
+  endgenerate
+endmodule
+
+/* module  \$_DFF_P_ (input D, C, output Q); LUTFF _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C)); endmodule
+module  \$_DFF_N_ (input D, C, output Q); SB_DFFN _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C)); endmodule
+module  \$_DFF_P_ (input D, C, output Q); SB_DFF  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C)); endmodule
+
+module  \$_DFFE_NP_ (input D, C, E, output Q); SB_DFFNE _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E)); endmodule
+module  \$_DFFE_PP_ (input D, C, E, output Q); SB_DFFE  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E)); endmodule
+
+module  \$_DFF_NP0_ (input D, C, R, output Q); SB_DFFNR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .R(R)); endmodule
+module  \$_DFF_NP1_ (input D, C, R, output Q); SB_DFFNS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .S(R)); endmodule
+module  \$_DFF_PP0_ (input D, C, R, output Q); SB_DFFR  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .R(R)); endmodule
+module  \$_DFF_PP1_ (input D, C, R, output Q); SB_DFFS  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .S(R)); endmodule
+
+module  \$_DFFE_NP0P_ (input D, C, E, R, output Q); SB_DFFNER _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .R(R)); endmodule
+module  \$_DFFE_NP1P_ (input D, C, E, R, output Q); SB_DFFNES _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .S(R)); endmodule
+module  \$_DFFE_PP0P_ (input D, C, E, R, output Q); SB_DFFER  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .R(R)); endmodule
+module  \$_DFFE_PP1P_ (input D, C, E, R, output Q); SB_DFFES  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .S(R)); endmodule
+
+module  \$_SDFF_NP0_ (input D, C, R, output Q); SB_DFFNSR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .R(R)); endmodule
+module  \$_SDFF_NP1_ (input D, C, R, output Q); SB_DFFNSS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .S(R)); endmodule
+module  \$_SDFF_PP0_ (input D, C, R, output Q); SB_DFFSR  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .R(R)); endmodule
+module  \$_SDFF_PP1_ (input D, C, R, output Q); SB_DFFSS  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .S(R)); endmodule
+
+module  \$_SDFFCE_NP0P_ (input D, C, E, R, output Q); SB_DFFNESR _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .R(R)); endmodule
+module  \$_SDFFCE_NP1P_ (input D, C, E, R, output Q); SB_DFFNESS _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .S(R)); endmodule
+module  \$_SDFFCE_PP0P_ (input D, C, E, R, output Q); SB_DFFESR  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .R(R)); endmodule
+module  \$_SDFFCE_PP1P_ (input D, C, E, R, output Q); SB_DFFESS  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .E(E), .S(R)); endmodule */

--- a/fabric_cad/synth/ff_map.v
+++ b/fabric_cad/synth/ff_map.v
@@ -1,0 +1,26 @@
+module  \$_DFF_P_ (input D, C, output Q); LUTFF _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C)); endmodule
+//module  \$_DFF_N_ (input D, C, output Q); SB_DFFN _TECHMAP_REPLACE_ (.D(D), .O(Q), .C(C)); endmodule
+//module  \$_DFF_P_ (input D, C, output Q); SB_DFF  _TECHMAP_REPLACE_ (.D(D), .O(Q), .C(C)); endmodule
+
+//module  \$_DFFE_NP_ (input D, C, E, output Q); SB_DFFNE _TECHMAP_REPLACE_ (.D(D), .O(Q), .C(C), .E(E)); endmodule
+module  \$_DFFE_PP_ (input D, C, E, output Q); LUTFF_E  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E)); endmodule
+
+//module  \$_DFF_NP0_ (input D, C, R, output Q); SB_DFFNR _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .R(R)); endmodule
+//module  \$_DFF_NP1_ (input D, C, R, output Q); SB_DFFNS _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .S(R)); endmodule
+//module  \$_DFF_PP0_ (input D, C, R, output Q); LUTFF_R  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .R(R)); endmodule
+//module  \$_DFF_PP1_ (input D, C, R, output Q); LUTFF_S  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .S(R)); endmodule
+
+//module  \$_DFFE_NP0P_ (input D, C, E, R, output Q); SB_DFFNER _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .R(R)); endmodule
+//module  \$_DFFE_NP1P_ (input D, C, E, R, output Q); SB_DFFNES _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .S(R)); endmodule
+//module  \$_DFFE_PP0P_ (input D, C, E, R, output Q); LUTFF_ER  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .R(R)); endmodule
+//module  \$_DFFE_PP1P_ (input D, C, E, R, output Q); LUTFF_ES  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .S(R)); endmodule
+
+//module  \$_SDFF_NP0_ (input D, C, R, output Q); SB_DFFNSR _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .R(R)); endmodule
+//module  \$_SDFF_NP1_ (input D, C, R, output Q); SB_DFFNSS _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .S(R)); endmodule
+module  \$_SDFF_PP0_ (input D, C, R, output Q); LUTFF_SR  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .R(R)); endmodule
+module  \$_SDFF_PP1_ (input D, C, R, output Q); LUTFF_SS  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .S(R)); endmodule
+
+//module  \$_SDFFCE_NP0P_ (input D, C, E, R, output Q); SB_DFFNESR _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .R(R)); endmodule
+//module  \$_SDFFCE_NP1P_ (input D, C, E, R, output Q); SB_DFFNESS _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .S(R)); endmodule
+module  \$_SDFFCE_PP0P_ (input D, C, E, R, output Q); LUTFF_ESR  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .R(R)); endmodule
+module  \$_SDFFCE_PP1P_ (input D, C, E, R, output Q); LUTFF_ESS  _TECHMAP_REPLACE_ (.D(D), .O(Q), .CLK(C), .E(E), .S(R)); endmodule

--- a/fabric_cad/synth/latches_map.v
+++ b/fabric_cad/synth/latches_map.v
@@ -1,0 +1,11 @@
+module \$_DLATCH_N_ (E, D, Q);
+  wire [1023:0] _TECHMAP_DO_ = "simplemap; opt";
+  input E, D;
+  output Q = !E ? D : Q;
+endmodule
+
+module \$_DLATCH_P_ (E, D, Q);
+  wire [1023:0] _TECHMAP_DO_ = "simplemap; opt";
+  input E, D;
+  output Q = E ? D : Q;
+endmodule

--- a/fabric_cad/synth/prims.v
+++ b/fabric_cad/synth/prims.v
@@ -1,0 +1,335 @@
+// LUT and DFF are combined to a GENERIC_SLICE
+
+/*module LUT #(
+	parameter K = 4,
+	parameter [2**K-1:0] INIT = 0
+) (
+	input [K-1:0] I,
+	output Q
+);
+	wire [K-1:0] I_pd;
+
+	genvar ii;
+	generate
+		for (ii = 0; ii < K; ii = ii + 1'b1)
+			assign I_pd[ii] = (I[ii] === 1'bz) ? 1'b0 : I[ii];
+	endgenerate
+
+	assign Q = INIT[I_pd];
+endmodule*/
+
+module LUT1(output O, input I0);
+  parameter [1:0] INIT = 0;
+  assign O = I0 ? INIT[1] : INIT[0];
+endmodule
+
+module LUT2(output O, input I0, I1);
+  parameter [3:0] INIT = 0;
+  wire [ 1: 0] s1 = I1 ? INIT[ 3: 2] : INIT[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUT3(output O, input I0, I1, I2);
+  parameter [7:0] INIT = 0;
+  wire [ 3: 0] s2 = I2 ? INIT[ 7: 4] : INIT[ 3: 0];
+  wire [ 1: 0] s1 = I1 ?   s2[ 3: 2] :   s2[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUT4(output O, input I0, I1, I2, I3);
+  parameter [15:0] INIT = 0;
+  wire [ 7: 0] s3 = I3 ? INIT[15: 8] : INIT[ 7: 0];
+  wire [ 3: 0] s2 = I2 ?   s3[ 7: 4] :   s3[ 3: 0];
+  wire [ 1: 0] s1 = I1 ?   s2[ 3: 2] :   s2[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUTFF(input CLK, D, output reg O);
+initial O = 1'b0;
+always @ (posedge CLK) begin
+	O <= D;
+end
+endmodule
+
+module FABULOUS_LC #(
+	parameter K = 4,
+	parameter [2**K-1:0] INIT = 0,
+	parameter DFF_ENABLE = 1'b0
+) (
+	input CLK,
+	input [K-1:0] I,
+	output O,
+	output Q
+);
+	wire f_wire;
+	
+	//LUT #(.K(K), .INIT(INIT)) lut_i(.I(I), .Q(f_wire));
+        generate
+        if (K == 1) begin
+          LUT1 #(.INIT(INIT)) lut1 (.O(f_wire), .I0(A[0]));
+        end else
+        if (K == 2) begin
+          LUT2 #(.INIT(INIT)) lut2 (.O(f_wire), .I0(A[0]), .I1(A[1]));
+        end else
+        if (K == 3) begin
+          LUT3 #(.INIT(INIT)) lut3 (.O(f_wire), .I0(A[0]), .I1(A[1]), .I2(A[2]));
+        end else
+        if (K == 4) begin
+          LUT4 #(.INIT(INIT)) lut4 (.O(f_wire), .I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]));
+        end
+        endgenerate
+        
+	LUTFF dff_i(.CLK(CLK), .D(f_wire), .Q(Q));
+
+	assign O = f_wire;
+endmodule
+
+(* blackbox *)
+module Global_Clock (output CLK);
+	//initial CLK = 0;
+	//always #10 CLK = ~CLK;
+endmodule
+
+(* blackbox *)
+module InPass4_frame_config (output O0, O1, O2, O3);
+
+endmodule
+
+
+(* blackbox *)
+module OutPass4_frame_config (input I0, I1, I2, I3);
+
+endmodule
+
+(* blackbox *)
+module IO_1_bidirectional_frame_config_pass (input T, I, output Q, O);
+endmodule
+
+
+module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5, C4, C3, C2, C1, C0, Q19, Q18, Q17, Q16, Q15, Q14, Q13, Q12, Q11, Q10, Q9, Q8, Q7, Q6, Q5, Q4, Q3, Q2, Q1, Q0, clr, CLK);
+	parameter ConfigBits = 6'b000000;
+	//parameter NoConfigBits = 6;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+	// IMPORTANT: this has to be in a dedicated line
+	input A7;// operand A
+	input A6;
+	input A5;
+	input A4;
+	input A3;
+	input A2;
+	input A1;
+	input A0;
+	input B7;// operand B
+	input B6;
+	input B5;
+	input B4;
+	input B3;
+	input B2;
+	input B1;
+	input B0;
+	input C19;// operand C
+	input C18;
+	input C17;
+	input C16;
+	input C15;
+	input C14;
+	input C13;
+	input C12;
+	input C11;
+	input C10;
+	input C9;
+	input C8;
+	input C7;
+	input C6;
+	input C5;
+	input C4;
+	input C3;
+	input C2;
+	input C1;
+	input C0;
+	output Q19;// result
+	output Q18;
+	output Q17;
+	output Q16;
+	output Q15;
+	output Q14;
+	output Q13;
+	output Q12;
+	output Q11;
+	output Q10;
+	output Q9;
+	output Q8;
+	output Q7;
+	output Q6;
+	output Q5;
+	output Q4;
+	output Q3;
+	output Q2;
+	output Q1;
+	output Q0;
+
+	input clr;
+	input CLK; // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
+
+
+	wire [7:0] A;		// port A read data 
+	wire [7:0] B;		// port B read data 
+	wire [19:0] C;		// port B read data 
+	reg [7:0] A_reg;		// port A read data register
+	reg [7:0] B_reg;		// port B read data register
+	reg [19:0] C_reg;		// port B read data register
+	wire [7:0] OPA;		// port A 
+	wire [7:0] OPB;		// port B 
+	wire [19:0] OPC;		// port B  
+	reg [19:0] ACC ;		// accumulator register
+	wire [19:0] sum;// port B read data register
+	wire [19:0] sum_in;// port B read data register
+	wire [15:0] product;
+	wire [19:0] product_extended;
+
+	assign A = {A7,A6,A5,A4,A3,A2,A1,A0};
+	assign B = {B7,B6,B5,B4,B3,B2,B1,B0};
+	assign C = {C19,C18,C17,C16,C15,C14,C13,C12,C11,C10,C9,C8,C7,C6,C5,C4,C3,C2,C1,C0};
+
+	assign OPA = ConfigBits[0] ? A_reg : A;
+	assign OPB = ConfigBits[1] ? B_reg : B;
+	assign OPC = ConfigBits[2] ? C_reg : C;
+
+	assign sum_in = ConfigBits[3] ? ACC : OPC;// we can
+
+	assign product = OPA * OPB;
+
+// The sign extension was not tested
+	assign product_extended = ConfigBits[4] ? {product[15],product[15],product[15],product[15],product} : {4'b0000,product};
+
+	assign sum = product_extended + sum_in;
+
+	assign Q19	= ConfigBits[5] ? ACC[19] : sum[19];
+	assign Q18	= ConfigBits[5] ? ACC[18] : sum[18];
+	assign Q17	= ConfigBits[5] ? ACC[17] : sum[17];
+	assign Q16	= ConfigBits[5] ? ACC[16] : sum[16];
+	assign Q15	= ConfigBits[5] ? ACC[15] : sum[15];
+	assign Q14	= ConfigBits[5] ? ACC[14] : sum[14];
+	assign Q13	= ConfigBits[5] ? ACC[13] : sum[13];
+	assign Q12	= ConfigBits[5] ? ACC[12] : sum[12];
+	assign Q11	= ConfigBits[5] ? ACC[11] : sum[11];
+	assign Q10	= ConfigBits[5] ? ACC[10] : sum[10];
+	assign Q9	= ConfigBits[5] ? ACC[9] : sum[9];
+	assign Q8	= ConfigBits[5] ? ACC[8] : sum[8];
+	assign Q7	= ConfigBits[5] ? ACC[7] : sum[7];
+	assign Q6	= ConfigBits[5] ? ACC[6] : sum[6];
+	assign Q5	= ConfigBits[5] ? ACC[5] : sum[5];
+	assign Q4	= ConfigBits[5] ? ACC[4] : sum[4];
+	assign Q3	= ConfigBits[5] ? ACC[3] : sum[3];
+	assign Q2	= ConfigBits[5] ? ACC[2] : sum[2];
+	assign Q1	= ConfigBits[5] ? ACC[1] : sum[1];
+	assign Q0	= ConfigBits[5] ? ACC[0] : sum[0];
+
+	always @ (posedge CLK)
+	begin
+		A_reg <= A;
+		B_reg <= B;
+		C_reg <= C;
+		if (clr == 1'b1) begin
+			ACC <= 20'b00000000000000000000;
+		end else begin
+			ACC <= sum;
+		end
+	end
+
+endmodule
+
+module RegFile_32x4 (D0, D1, D2, D3, W_ADR0, W_ADR1, W_ADR2, W_ADR3, W_ADR4, W_en, AD0, AD1, AD2, AD3, A_ADR0, A_ADR1, A_ADR2, A_ADR3, A_ADR4, BD0, BD1, BD2, BD3, B_ADR0, B_ADR1, B_ADR2, B_ADR3, B_ADR4, CLK);
+	//parameter NoConfigBits = 2;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+	parameter ConfigBits = 2'b00;
+	// IMPORTANT: this has to be in a dedicated line
+	input D0; // Register File write port
+	input D1;
+	input D2;
+	input D3;
+	input W_ADR0;
+	input W_ADR1;
+	input W_ADR2;
+	input W_ADR3;
+	input W_ADR4;
+	input W_en;
+	
+	output AD0;// Register File read port A
+	output AD1;
+	output AD2;
+	output AD3;
+	input A_ADR0;
+	input A_ADR1;
+	input A_ADR2;
+	input A_ADR3;
+	input A_ADR4;
+
+	output BD0;//Register File read port B
+	output BD1;
+	output BD2;
+	output BD3;
+	input B_ADR0;
+	input B_ADR1;
+	input B_ADR2;
+	input B_ADR3;
+	input B_ADR4;
+
+	input CLK;// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	
+	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
+	
+
+	//type memtype is array (31 downto 0) of std_logic_vector(3 downto 0); // 32 entries of 4 bit
+	//signal mem : memtype := (others => (others => '0'));
+	reg [3:0] mem [31:0];
+
+	wire [4:0] W_ADR;// write address
+	wire [4:0] A_ADR;// port A read address
+	wire [4:0] B_ADR;// port B read address
+
+	wire [3:0] D;		// write data
+	wire [3:0] AD;		// port A read data
+	wire [3:0] BD;		// port B read data
+
+	reg [3:0] AD_reg;		// port A read data register
+	reg [3:0] BD_reg;		// port B read data register
+	
+	integer i;
+
+	assign W_ADR = {W_ADR4,W_ADR3,W_ADR2,W_ADR1,W_ADR0};
+	assign A_ADR = {A_ADR4,A_ADR3,A_ADR2,A_ADR1,A_ADR0};
+	assign B_ADR = {B_ADR4,B_ADR3,B_ADR2,B_ADR1,B_ADR0};
+
+	assign D = {D3,D2,D1,D0};
+	
+	initial begin
+		for (i=0; i<32; i=i+1) begin
+			mem[i] = 4'b0000;
+		end
+	end
+
+	always @ (posedge CLK) begin : P_write
+		if (W_en == 1'b1) begin
+			mem[W_ADR] <= D ;
+		end
+	end
+
+	assign AD = mem[A_ADR];
+	assign BD = mem[B_ADR];
+
+	always @ (posedge UserCLK) begin
+		AD_reg <= AD;
+		BD_reg <= BD;
+	end
+
+	assign AD0 = ConfigBits[0] ? AD_reg[0] : AD[0];
+	assign AD1 = ConfigBits[0] ? AD_reg[1] : AD[1];
+	assign AD2 = ConfigBits[0] ? AD_reg[2] : AD[2];
+	assign AD3 = ConfigBits[0] ? AD_reg[3] : AD[3];
+
+	assign BD0 = ConfigBits[1] ? BD_reg[0] : BD[0];
+	assign BD1 = ConfigBits[1] ? BD_reg[1] : BD[1];
+	assign BD2 = ConfigBits[1] ? BD_reg[2] : BD[2];
+	assign BD3 = ConfigBits[1] ? BD_reg[3] : BD[3];
+
+endmodule

--- a/fabric_cad/synth/prims_ff.v
+++ b/fabric_cad/synth/prims_ff.v
@@ -1,0 +1,575 @@
+// LUT and DFF are combined to a GENERIC_SLICE
+
+/*module LUT #(
+	parameter K = 4,
+	parameter [2**K-1:0] INIT = 0
+) (
+	input [K-1:0] I,
+	output Q
+);
+	wire [K-1:0] I_pd;
+
+	genvar ii;
+	generate
+		for (ii = 0; ii < K; ii = ii + 1'b1)
+			assign I_pd[ii] = (I[ii] === 1'bz) ? 1'b0 : I[ii];
+	endgenerate
+
+	assign Q = INIT[I_pd];
+endmodule*/
+
+module LUT1(output O, input I0);
+  parameter [1:0] INIT = 0;
+  assign O = I0 ? INIT[1] : INIT[0];
+endmodule
+
+module LUT2(output O, input I0, I1);
+  parameter [3:0] INIT = 0;
+  wire [ 1: 0] s1 = I1 ? INIT[ 3: 2] : INIT[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUT3(output O, input I0, I1, I2);
+  parameter [7:0] INIT = 0;
+  wire [ 3: 0] s2 = I2 ? INIT[ 7: 4] : INIT[ 3: 0];
+  wire [ 1: 0] s1 = I1 ?   s2[ 3: 2] :   s2[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUT4(output O, input I0, I1, I2, I3);
+  parameter [15:0] INIT = 0;
+  wire [ 7: 0] s3 = I3 ? INIT[15: 8] : INIT[ 7: 0];
+  wire [ 3: 0] s2 = I2 ?   s3[ 7: 4] :   s3[ 3: 0];
+  wire [ 1: 0] s1 = I1 ?   s2[ 3: 2] :   s2[ 1: 0];
+  assign O = I0 ? s1[1] : s1[0];
+endmodule
+
+module LUTFF(input CLK, D, output reg O);
+initial O = 1'b0;
+always @ (posedge CLK) begin
+	O <= D;
+end
+endmodule
+
+module FABULOUS_LC #(
+	parameter K = 4,
+	parameter [2**K-1:0] INIT = 0,
+	parameter DFF_ENABLE = 1'b0,
+	parameter IOmux = 1'b0,
+	parameter SET_NORESET = 1'b0
+) (
+	input CLK,
+	input I0,
+	input I1,
+	input I2,
+	input I3,
+	input SR,
+	input EN,
+	output O,
+	output Q,
+	input Ci,
+	output Co
+);
+	wire f_wire;
+	wire I0_mux;
+	
+	assign I0_mux = IOmux ? Ci : I0;
+	
+	//LUT #(.K(K), .INIT(INIT)) lut_i(.I(I), .Q(f_wire));
+        generate
+        if (K == 1) begin
+          LUT1 #(.INIT(INIT)) lut1 (.O(f_wire), .I0(I0_mux));
+        end else
+        if (K == 2) begin
+          LUT2 #(.INIT(INIT)) lut2 (.O(f_wire), .I0(I0_mux), .I1(I1));
+        end else
+        if (K == 3) begin
+          LUT3 #(.INIT(INIT)) lut3 (.O(f_wire), .I0(I0_mux), .I1(I2), .I2(I2));
+        end else
+        if (K == 4) begin
+          LUT4 #(.INIT(INIT)) lut4 (.O(f_wire), .I0(I0_mux), .I1(I1), .I2(I2), .I3(I3));
+        end
+        endgenerate
+		
+	
+	assign Co = (Ci & A[1]) | (Ci & A[2]) | (A[1] & A[2]);
+
+	if (SET_NORESET) begin
+		LUTFF_ESS dffs_i(.CLK(CLK), .E(EN), .S(SR), .D(f_wire), .O(Q));
+	end else begin
+		LUTFF_ESR dffr_i(.CLK(CLK), .E(EN), .R(SR), .D(f_wire), .O(Q));
+	end
+	
+	assign O = f_wire;
+endmodule
+
+(* blackbox *)
+module Global_Clock (output CLK);
+	//initial CLK = 0;
+	//always #10 CLK = ~CLK;
+endmodule
+
+(* blackbox *)
+module InPass4_frame_config (output O0, O1, O2, O3);
+
+endmodule
+
+
+(* blackbox *)
+module OutPass4_frame_config (input I0, I1, I2, I3);
+
+endmodule
+
+(* blackbox *)
+module IO_1_bidirectional_frame_config_pass (input T, I, output Q, O);
+endmodule
+
+
+module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5, C4, C3, C2, C1, C0, Q19, Q18, Q17, Q16, Q15, Q14, Q13, Q12, Q11, Q10, Q9, Q8, Q7, Q6, Q5, Q4, Q3, Q2, Q1, Q0, clr, CLK);
+	parameter ConfigBits = 6'b000000;
+	//parameter NoConfigBits = 6;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+	// IMPORTANT: this has to be in a dedicated line
+	input A7;// operand A
+	input A6;
+	input A5;
+	input A4;
+	input A3;
+	input A2;
+	input A1;
+	input A0;
+	input B7;// operand B
+	input B6;
+	input B5;
+	input B4;
+	input B3;
+	input B2;
+	input B1;
+	input B0;
+	input C19;// operand C
+	input C18;
+	input C17;
+	input C16;
+	input C15;
+	input C14;
+	input C13;
+	input C12;
+	input C11;
+	input C10;
+	input C9;
+	input C8;
+	input C7;
+	input C6;
+	input C5;
+	input C4;
+	input C3;
+	input C2;
+	input C1;
+	input C0;
+	output Q19;// result
+	output Q18;
+	output Q17;
+	output Q16;
+	output Q15;
+	output Q14;
+	output Q13;
+	output Q12;
+	output Q11;
+	output Q10;
+	output Q9;
+	output Q8;
+	output Q7;
+	output Q6;
+	output Q5;
+	output Q4;
+	output Q3;
+	output Q2;
+	output Q1;
+	output Q0;
+
+	input clr;
+	input CLK; // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
+
+
+	wire [7:0] A;		// port A read data 
+	wire [7:0] B;		// port B read data 
+	wire [19:0] C;		// port B read data 
+	reg [7:0] A_reg;		// port A read data register
+	reg [7:0] B_reg;		// port B read data register
+	reg [19:0] C_reg;		// port B read data register
+	wire [7:0] OPA;		// port A 
+	wire [7:0] OPB;		// port B 
+	wire [19:0] OPC;		// port B  
+	reg [19:0] ACC ;		// accumulator register
+	wire [19:0] sum;// port B read data register
+	wire [19:0] sum_in;// port B read data register
+	wire [15:0] product;
+	wire [19:0] product_extended;
+
+	assign A = {A7,A6,A5,A4,A3,A2,A1,A0};
+	assign B = {B7,B6,B5,B4,B3,B2,B1,B0};
+	assign C = {C19,C18,C17,C16,C15,C14,C13,C12,C11,C10,C9,C8,C7,C6,C5,C4,C3,C2,C1,C0};
+
+	assign OPA = ConfigBits[0] ? A_reg : A;
+	assign OPB = ConfigBits[1] ? B_reg : B;
+	assign OPC = ConfigBits[2] ? C_reg : C;
+
+	assign sum_in = ConfigBits[3] ? ACC : OPC;// we can
+
+	assign product = OPA * OPB;
+
+// The sign extension was not tested
+	assign product_extended = ConfigBits[4] ? {product[15],product[15],product[15],product[15],product} : {4'b0000,product};
+
+	assign sum = product_extended + sum_in;
+
+	assign Q19	= ConfigBits[5] ? ACC[19] : sum[19];
+	assign Q18	= ConfigBits[5] ? ACC[18] : sum[18];
+	assign Q17	= ConfigBits[5] ? ACC[17] : sum[17];
+	assign Q16	= ConfigBits[5] ? ACC[16] : sum[16];
+	assign Q15	= ConfigBits[5] ? ACC[15] : sum[15];
+	assign Q14	= ConfigBits[5] ? ACC[14] : sum[14];
+	assign Q13	= ConfigBits[5] ? ACC[13] : sum[13];
+	assign Q12	= ConfigBits[5] ? ACC[12] : sum[12];
+	assign Q11	= ConfigBits[5] ? ACC[11] : sum[11];
+	assign Q10	= ConfigBits[5] ? ACC[10] : sum[10];
+	assign Q9	= ConfigBits[5] ? ACC[9] : sum[9];
+	assign Q8	= ConfigBits[5] ? ACC[8] : sum[8];
+	assign Q7	= ConfigBits[5] ? ACC[7] : sum[7];
+	assign Q6	= ConfigBits[5] ? ACC[6] : sum[6];
+	assign Q5	= ConfigBits[5] ? ACC[5] : sum[5];
+	assign Q4	= ConfigBits[5] ? ACC[4] : sum[4];
+	assign Q3	= ConfigBits[5] ? ACC[3] : sum[3];
+	assign Q2	= ConfigBits[5] ? ACC[2] : sum[2];
+	assign Q1	= ConfigBits[5] ? ACC[1] : sum[1];
+	assign Q0	= ConfigBits[5] ? ACC[0] : sum[0];
+
+	always @ (posedge CLK)
+	begin
+		A_reg <= A;
+		B_reg <= B;
+		C_reg <= C;
+		if (clr == 1'b1) begin
+			ACC <= 20'b00000000000000000000;
+		end else begin
+			ACC <= sum;
+		end
+	end
+
+endmodule
+
+module RegFile_32x4 (D0, D1, D2, D3, W_ADR0, W_ADR1, W_ADR2, W_ADR3, W_ADR4, W_en, AD0, AD1, AD2, AD3, A_ADR0, A_ADR1, A_ADR2, A_ADR3, A_ADR4, BD0, BD1, BD2, BD3, B_ADR0, B_ADR1, B_ADR2, B_ADR3, B_ADR4, CLK);
+	//parameter NoConfigBits = 2;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+	parameter ConfigBits = 2'b00;
+	// IMPORTANT: this has to be in a dedicated line
+	input D0; // Register File write port
+	input D1;
+	input D2;
+	input D3;
+	input W_ADR0;
+	input W_ADR1;
+	input W_ADR2;
+	input W_ADR3;
+	input W_ADR4;
+	input W_en;
+	
+	output AD0;// Register File read port A
+	output AD1;
+	output AD2;
+	output AD3;
+	input A_ADR0;
+	input A_ADR1;
+	input A_ADR2;
+	input A_ADR3;
+	input A_ADR4;
+
+	output BD0;//Register File read port B
+	output BD1;
+	output BD2;
+	output BD3;
+	input B_ADR0;
+	input B_ADR1;
+	input B_ADR2;
+	input B_ADR3;
+	input B_ADR4;
+
+	input CLK;// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	
+	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
+	
+
+	//type memtype is array (31 downto 0) of std_logic_vector(3 downto 0); // 32 entries of 4 bit
+	//signal mem : memtype := (others => (others => '0'));
+	reg [3:0] mem [31:0];
+
+	wire [4:0] W_ADR;// write address
+	wire [4:0] A_ADR;// port A read address
+	wire [4:0] B_ADR;// port B read address
+
+	wire [3:0] D;		// write data
+	wire [3:0] AD;		// port A read data
+	wire [3:0] BD;		// port B read data
+
+	reg [3:0] AD_reg;		// port A read data register
+	reg [3:0] BD_reg;		// port B read data register
+	
+	integer i;
+
+	assign W_ADR = {W_ADR4,W_ADR3,W_ADR2,W_ADR1,W_ADR0};
+	assign A_ADR = {A_ADR4,A_ADR3,A_ADR2,A_ADR1,A_ADR0};
+	assign B_ADR = {B_ADR4,B_ADR3,B_ADR2,B_ADR1,B_ADR0};
+
+	assign D = {D3,D2,D1,D0};
+	
+	initial begin
+		for (i=0; i<32; i=i+1) begin
+			mem[i] = 4'b0000;
+		end
+	end
+
+	always @ (posedge CLK) begin : P_write
+		if (W_en == 1'b1) begin
+			mem[W_ADR] <= D ;
+		end
+	end
+
+	assign AD = mem[A_ADR];
+	assign BD = mem[B_ADR];
+
+	always @ (posedge UserCLK) begin
+		AD_reg <= AD;
+		BD_reg <= BD;
+	end
+
+	assign AD0 = ConfigBits[0] ? AD_reg[0] : AD[0];
+	assign AD1 = ConfigBits[0] ? AD_reg[1] : AD[1];
+	assign AD2 = ConfigBits[0] ? AD_reg[2] : AD[2];
+	assign AD3 = ConfigBits[0] ? AD_reg[3] : AD[3];
+
+	assign BD0 = ConfigBits[1] ? BD_reg[0] : BD[0];
+	assign BD1 = ConfigBits[1] ? BD_reg[1] : BD[1];
+	assign BD2 = ConfigBits[1] ? BD_reg[2] : BD[2];
+	assign BD3 = ConfigBits[1] ? BD_reg[3] : BD[3];
+
+endmodule
+
+module LUTFF_E (
+	output reg O,
+	input CLK, E, D
+);
+	initial O = 1'b0;
+	always @(posedge CLK)
+		if (E)
+			O <= D;
+endmodule
+
+module LUTFF_SR (
+	output reg O,
+	input CLK, R, D
+);
+	initial O = 1'b0;
+	always @(posedge CLK)
+		if (R)
+			O <= 0;
+		else
+			O <= D;
+endmodule
+
+module LUTFF_SS (
+	output reg O,
+	input CLK, S, D
+);
+	initial O = 1'b0;
+	always @(posedge CLK)
+		if (S)
+			O <= 1;
+		else
+			O <= D;
+endmodule
+
+module LUTFF_ESR (
+	output reg O,
+	input CLK, E, R, D
+);
+	initial O = 1'b0;
+	always @(posedge CLK)
+		if (E) begin
+			if (R)
+				O <= 0;
+			else
+				O <= D;
+		end
+endmodule
+
+module LUTFF_ESS (
+	output reg O,
+	input CLK, E, S, D
+);
+	initial O = 1'b0;
+	always @(posedge CLK)
+		if (E) begin
+			if (S)
+				O <= 1;
+			else
+				O <= D;
+		end
+endmodule
+
+/* module LUTFF_R (
+	output Q,
+	input C, R, D
+);
+	always @(posedge CLK, posedge R)
+		if (R)
+			Q <= 0;
+		else
+			Q <= D;
+endmodule */
+
+
+
+/* module LUTFF_S (
+	output Q,
+	input C, S, D
+);
+	always @(posedge CLK, posedge S)
+		if (S)
+			Q <= 1;
+		else
+			Q <= D;
+endmodule */
+
+
+
+/* module LUTFF_ER (
+	output Q,
+	input C, E, R, D
+);
+	always @(posedge CLK, posedge R)
+		if (R)
+			Q <= 0;
+		else if (E)
+			Q <= D;
+endmodule */
+
+
+
+/* module LUTFF_ES (
+	output Q,
+	input C, E, S, D
+);
+	always @(posedge CLK, posedge S)
+		if (S)
+			Q <= 1;
+		else if (E)
+			Q <= D;
+endmodule */
+
+/* module LUTFFN (
+	output Q,
+	input C, D
+);
+	always @(negedge C)
+		Q <= D;
+endmodule
+
+module LUTFFNE (
+	output Q,
+	input C, E, D
+);
+	always @(negedge C)
+		if (E)
+			Q <= D;
+endmodule
+
+module LUTFFNSR (
+	output Q,
+	input C, R, D
+);
+	always @(negedge C)
+		if (R)
+			Q <= 0;
+		else
+			Q <= D;
+endmodule
+
+module LUTFFNR (
+	output Q,
+	input C, R, D
+);
+	always @(negedge C, posedge R)
+		if (R)
+			Q <= 0;
+		else
+			Q <= D;
+endmodule
+
+module LUTFFNSS (
+	output Q,
+	input C, S, D
+);
+	always @(negedge C)
+		if (S)
+			Q <= 1;
+		else
+			Q <= D;
+endmodule
+
+module LUTFFNS (
+	output Q,
+	input C, S, D
+);
+	always @(negedge C, posedge S)
+		if (S)
+			Q <= 1;
+		else
+			Q <= D;
+endmodule
+
+module LUTFFNESR (
+	output Q,
+	input C, E, R, D
+);
+	always @(negedge C)
+		if (E) begin
+			if (R)
+				Q <= 0;
+			else
+				Q <= D;
+		end
+endmodule
+
+module LUTFFNER (
+	output Q,
+	input C, E, R, D
+);
+	always @(negedge C, posedge R)
+		if (R)
+			Q <= 0;
+		else if (E)
+			Q <= D;
+endmodule
+
+module LUTFFNESS (
+	output Q,
+	input C, E, S, D
+);
+	always @(negedge C)
+		if (E) begin
+			if (S)
+				Q <= 1;
+			else
+				Q <= D;
+		end
+endmodule
+
+module LUTFFNES (
+	output Q,
+	input C, E, S, D
+);
+	always @(negedge C, posedge S)
+		if (S)
+			Q <= 1;
+		else if (E)
+			Q <= D;
+endmodule */

--- a/fabric_cad/synth/synth_fabulous.tcl
+++ b/fabric_cad/synth/synth_fabulous.tcl
@@ -1,0 +1,33 @@
+# Usage
+# tcl synth_generic.tcl {K} {out.json}
+
+set LUT_K 4
+if {$argc > 0} { set LUT_K [lindex $argv 0] }
+set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
+yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims.v
+yosys hierarchy -check -top [lindex $argv 1]
+yosys proc
+#yosys flatten
+yosys tribuf -logic
+yosys deminout
+yosys synth -run coarse
+yosys memory_map
+yosys opt -full
+yosys techmap -map +/techmap.v
+yosys opt -fast
+yosys dfflegalize -cell \$_DFF_P_ 0 -cell \$_DLATCH_?_ x
+yosys techmap -map [file dirname [file normalize $argv0]]/latches_map.v
+yosys abc -lut $LUT_K -dress
+yosys clean
+if {!$for_vpr} {yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map.v}
+yosys clean
+yosys hierarchy -check
+yosys stat
+
+if {$argc > 1} {
+        if {$for_vpr} { 
+                yosys write_blif [lindex $argv 2] 
+        } else { 
+                yosys write_json [lindex $argv 2] 
+        }
+}

--- a/fabric_cad/synth/synth_fabulous_dffesr.tcl
+++ b/fabric_cad/synth/synth_fabulous_dffesr.tcl
@@ -1,0 +1,37 @@
+# Usage
+# tcl synth_generic.tcl {K} {out.json}
+
+set LUT_K 4
+if {$argc > 0} { set LUT_K [lindex $argv 0] }
+set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
+yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims_ff.v
+yosys hierarchy -check -top [lindex $argv 1]
+yosys proc
+#yosys flatten
+yosys tribuf -logic
+yosys deminout
+yosys synth -run coarse
+yosys memory_map
+yosys opt -full
+yosys techmap -map +/techmap.v
+yosys opt -fast
+#yosys dfflegalize -cell \$_DFF_P_ 0 -cell \$_DFFE_PP_ 0 -cell \$_SDFF_PP1_ 0 -cell \$_SDFF_PP0_ 0 -cell \$_SDFFCE_PP1P_ 0 -cell \$_SDFFCE_PP0P_ 0 -cell \$_DLATCH_?_ x
+yosys dfflegalize -cell \$_DFF_P_ 0 -cell \$_DFFE_PP_ 0 -cell \$_SDFF_PP?_ 0 -cell \$_SDFFCE_PP?P_ 0 -cell \$_DLATCH_?_ x
+yosys techmap -map [file dirname [file normalize $argv0]]/ff_map.v
+yosys opt_expr -mux_undef
+yosys simplemap
+yosys techmap -map [file dirname [file normalize $argv0]]/latches_map.v
+yosys abc -lut $LUT_K -dress
+yosys clean
+if {!$for_vpr} {yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map_ff.v}
+yosys clean
+yosys hierarchy -check
+yosys stat
+
+if {$argc > 1} {
+        if {$for_vpr} { 
+                yosys write_blif [lindex $argv 2] 
+        } else { 
+                yosys write_json [lindex $argv 2] 
+        }
+}

--- a/fabric_files/fabric_emulation_example/build_test_design.sh
+++ b/fabric_files/fabric_emulation_example/build_test_design.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SYNTH_TCL=../../nextpnr/fabulous/synth/synth_fabulous.tcl
-BIT_GEN=../../nextpnr/fabulous/fab_arch/bit_gen.py
+SYNTH_TCL=../../fabric_cad/synth/synth_fabulous.tcl
+BIT_GEN=../../fabric_cad/bit_gen.py
 
 if [[ -z "${DESIGN}" ]]; then
 	DESIGN=shiftreg

--- a/fabric_files/fabric_ghdl_example/build_test_design.sh
+++ b/fabric_files/fabric_ghdl_example/build_test_design.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SYNTH_TCL=../../nextpnr/fabulous/synth/synth_fabulous.tcl
-BIT_GEN=../../nextpnr/fabulous/fab_arch/bit_gen.py
+SYNTH_TCL=../../fabric_cad/synth/synth_fabulous.tcl
+BIT_GEN=../../fabric_cad/bit_gen.py
 
 
 DESIGN=counter

--- a/fabric_files/fabric_icarus_example/build_test_design.sh
+++ b/fabric_files/fabric_icarus_example/build_test_design.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SYNTH_TCL=../../nextpnr/fabulous/synth/synth_fabulous.tcl
-BIT_GEN=../../nextpnr/fabulous/fab_arch/bit_gen.py
+SYNTH_TCL=../../fabric_cad/synth/synth_fabulous.tcl
+BIT_GEN=../../fabric_cad/bit_gen.py
 
 
 DESIGN=counter

--- a/fabric_generator/run_fab_flow.sh
+++ b/fabric_generator/run_fab_flow.sh
@@ -85,6 +85,3 @@ mv -f *.list ./list_files
 
 mkdir -p csv_output
 mv -f *.csv ./csv_output
-
-cp ./npnroutput/{bel.txt,pips.txt,meta_data.txt} ../nextpnr/fabulous/fab_arch/
-cp ./csv_output/fabric.csv ../nextpnr/fabulous/fab_arch/

--- a/fabric_generator/run_fab_flow_nextpnr.sh
+++ b/fabric_generator/run_fab_flow_nextpnr.sh
@@ -77,6 +77,3 @@ mv -f *.list ./list_files
 
 mkdir -p csv_output
 mv -f *.csv ./csv_output
-
-cp npnroutput/{bel.txt,pips.txt,template.v,meta_data.txt} ../nextpnr/fabulous/fab_arch/
-cp csv_output/fabric.csv ../nextpnr/fabulous/fab_arch/

--- a/fabric_generator/run_fab_flow_nextpnr_pair.sh
+++ b/fabric_generator/run_fab_flow_nextpnr_pair.sh
@@ -76,6 +76,3 @@ mv -f *.list ./list_files
 
 mkdir -p csv_output
 mv -f *.csv ./csv_output
-
-cp npnroutput/{bel.txt,pips.txt,template.v,meta_data.txt} ../nextpnr/fabulous/fab_arch/
-cp csv_output/fabric.csv ../nextpnr/fabulous/fab_arch/


### PR DESCRIPTION
Move the remaining useful files (synthesis and bit gen) out of the nextpnr repo; and then remove the now-unnecessary submodule, with nextpnr support having landed upstream some months ago.