### PR TITLE
Switch to upstream Yosys synthesis pass

### DIFF
--- a/docs/source/FPGA-to-bitstream/Yosys compilation.rst
+++ b/docs/source/FPGA-to-bitstream/Yosys compilation.rst
@@ -13,21 +13,21 @@ To build you may use the Makefile wrapper in the clone repository (https://githu
 User guide
 ----------
 
-A pre-defined Yosys TCL script is under ``$FAB_ROOT/nextpnr/fabulous/synth/synth_fabulous_dffesr.tcl`` for FABulous version3. If the output file, denoted below as ``<JSON_or_BLIF_file>``, has a ``.blif`` file extension, then output will be produced in the Berkeley Logic Interchange Format (BLIF) and will be synthesised appropriately for the VPR flow. Otherwise, output will be produced as JSON, synthesised for the nextpnr flow.
+FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell. If synthesizing for the nextpnr flow, run the following commands:
 
 .. code-block:: console
 
-	yosys -p "tcl <path/to/TCL/File>/synth_fabulous_dffesr.tcl <K-LUT> <top_module> <JSON_or_BLIF_file>" <benchmark_netlist>
+        $ read_verilog <Verilog design file>
+        $ synth_fabulous
+        $ write_json <output JSON file>
 
-+---------------------+-------------------------------------------------------------------+
-| <K-LUT>             | Number of LUT inputs, 4 is for LUT4                               |
-+---------------------+-------------------------------------------------------------------+
-| <top_module>        | The name of top module in the benchmark                           |
-+---------------------+-------------------------------------------------------------------+
-| <JSON_file>         | User can define the name of output JSON file with ``.json`` format|
-+---------------------+-------------------------------------------------------------------+
-| <benchmark_netlist> | Benchmark RTL netlist in verilog format                           |
-+---------------------+-------------------------------------------------------------------+
+If you are synthesizing for use in the VPR flow, then run the following commands:
+
+.. code-block:: console
+
+        $ read_verilog <Verilog design file>
+        $ synth_fabulous -vpr
+        $ write_blif <output BLIF file>
 
 * For any clocked benchmark, a clock tile blackbox module must be instantiated in the top module for clock generation.
 
@@ -35,16 +35,4 @@ A pre-defined Yosys TCL script is under ``$FAB_ROOT/nextpnr/fabulous/synth/synth
 
         wire clk;
         (* keep *) Global_Clock inst_clk (.CLK(clk));
-
-Example
--------
-
-The following are simple commands to synthesise the netlist ``sequential_16bit_en`` into JSON netlist.
-
-.. code-block:: console
-
-	yosys -p "tcl ../synth/synth_fabulous_dffesr.tcl 4 sequential_16bit_en sequential_16bit_en.json" sequential_16bit_en.v
-
-
-
 

--- a/docs/source/FPGA-to-bitstream/Yosys compilation.rst
+++ b/docs/source/FPGA-to-bitstream/Yosys compilation.rst
@@ -13,21 +13,9 @@ To build you may use the Makefile wrapper in the clone repository (https://githu
 User guide
 ----------
 
-FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell. If synthesizing for the nextpnr flow, run the following commands:
+FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell. If synthesizing for the nextpnr flow, run this command: ``yosys -p "synth_fabulous -top <toplevel> -json <out.json>" <files.v>``. 
 
-.. code-block:: console
-
-        $ read_verilog <Verilog design file>
-        $ synth_fabulous
-        $ write_json <output JSON file>
-
-If you are synthesizing for use in the VPR flow, then run the following commands:
-
-.. code-block:: console
-
-        $ read_verilog <Verilog design file>
-        $ synth_fabulous -vpr
-        $ write_blif <output BLIF file>
+If you are synthesizing for use in the VPR flow, then run this command: ``yosys -p "synth_fabulous -top <toplevel> -blif <out.blif> -vpr" <files.v>``.
 
 * For any clocked benchmark, a clock tile blackbox module must be instantiated in the top module for clock generation.
 

--- a/docs/source/FPGA_CAD-tools/yosys.rst
+++ b/docs/source/FPGA_CAD-tools/yosys.rst
@@ -1,37 +1,7 @@
 Yosys models
 ============
 
-** Yosys models files, all can be found under ``$FAB_ROOT/nextpnr/fabulous/synth``
-
-.. code-block:: console
-   :emphasize-lines: 14,15
-
-        set LUT_K 4
-        if {$argc > 0} { set LUT_K [lindex $argv 0] }
-        yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims_ff.v
-        yosys hierarchy -check -top [lindex $argv 1]
-        yosys proc
-        yosys flatten
-        yosys tribuf -logic
-        yosys deminout
-        yosys synth -run coarse
-        yosys memory_map
-        yosys opt -full
-        yosys techmap -map +/techmap.v
-        yosys opt -fast
-        yosys dfflegalize -cell \$_DFF_P_ 0 -cell \$_DFFE_PP_ 0 -cell \$_SDFF_PP?_ 0 -cell \$_SDFFCE_PP?P_ 0 -cell \$_DLATCH_?_ x
-        yosys techmap -map [file dirname [file normalize $argv0]]/ff_map.v
-        yosys opt_expr -mux_undef
-        yosys simplemap
-        yosys techmap -map [file dirname [file normalize $argv0]]/latches_map.v
-        yosys abc -lut $LUT_K -dress
-        yosys clean
-        yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map_ff.v
-        yosys clean
-        yosys hierarchy -check
-        yosys stat
-
-        if {$argc > 1} { yosys write_json [lindex $argv 2] }
+** Yosys models files, all can be found in the :`Yosys repository <https://github.com/YosysHQ/yosys>`_: under ``$YOSYS_ROOT/techlibs/fabulous/`` **
 
 +---------------+-----------------------------------------------------------------------+
 | File Name     | Description                                                           |
@@ -45,7 +15,7 @@ Yosys models
 | cells_map_ff.v| LUT-4 technology mapping (can be modified to LUT-6)                   |
 +---------------+-----------------------------------------------------------------------+
 
-The ``synth_fabulous_dffesr.tcl`` is built for FABulous version3. Compared to the previous two versions, the new version supports **ENABLE** and **SET/RESET** functions in D-type Flip-flops (DFF) (Line 14 and 15 of TCL script). Under line 14, Yosys represents cells ``$_DFF_P_``, ``$_DFFE_PP_``, ``$_SDFF_PP?_`` and ``$_SDFFCE_PP?P_`` for DFFs (More DFF cells definitions can be found in the 
+The current synthesis pass is built for FABulous version3. Unlike the previous two versions, the new version supports **ENABLE** and **SET/RESET** functions in D-type Flip-flops (DFF). In the pass, Yosys represents cells ``$_DFF_P_``, ``$_DFFE_PP_``, ``$_SDFF_PP?_`` and ``$_SDFFCE_PP?P_`` for DFFs (More DFF cells definitions can be found in the 
 `Yosys manual <https://github.com/YosysHQ/yosys-manual-build/releases/download/manual/manual.pdf>`_
 Chapter 5.2). User should also define different types of DFF in the ``ff_map.v`` for DFF technology mapping.
 

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -26,13 +26,18 @@ The following packages need to be installed for the CAD toolchain
 
 :`Yosys <https://github.com/YosysHQ/yosys>`_:
  version > 0.10
-:`nextpnr <https://github.com/YosysHQ/nextpnr>`_ "generic" architecture:
- version >= 0.5
 
-Both can be obtained prebuilt for multiple operating systems from `OSS CAD suite <https://github.com/YosysHQ/oss-cad-suite-build/releases/>`_.
 
 .. note:: In the following, :term:`$FAB_ROOT` means the root directory of the Fabulous source code tree.
 
+:nextpnr-fabulous:
+
+.. code-block:: console
+
+   cd $FAB_ROOT/nextpnr
+   cmake . -DARCH=fabulous
+   make -j$(nproc)
+   sudo make install
 
 Building Fabric
 ---------------
@@ -54,15 +59,20 @@ Generating Bitstream
 
 Nextpnr models can be found under ``$FAB_ROOT/fabric_generator/npnroutput``
 
-Inside ``$FAB_ROOT/fabric_files/fabric_icarus_example`` is an example of building a small test design and simulating the fabric with the produced bitstream.
+To run nextpnr compilation
+ 
+.. code-block:: console
+
+   cd $FAB_ROOT/nextpnr/fabulous/fab_arch/
+   ./fabulous_flow.sh <benchmark_name>
+
+Example:
 
 .. code-block:: console
 
-   cd $FAB_ROOT/fabric_files/fabric_icarus_example
-   ./build_test_design.sh
-   ./run_simulation.sh
+   ./fabulous_flow.sh sequential_16bit_en
 
-An example of using "emulation" and avoiding the need for simulating the slow configuration interface and configuration memory can be found inside ``$FAB_ROOT/fabric_files/fabric_emulation_example``.
+The output <benchmark_name>_output.bin can be used in further simulation.
 
 VPR models can be found under ``$FAB_ROOT/fabric_generator/vproutput``
 


### PR DESCRIPTION
This makes the documentation changes I proposed in the #79 discussion, removing discussion of the previous synthesis script and giving instructions to use the pass that is now upstream in Yosys. If we merge this, then we can probably also get rid of all the synthesis stuff in the nextpnr fork. I think I've covered everywhere the old script was mentioned, but let me know if I've missed anything! I also suspect that the page on Yosys models (`docs/source/FPGA_CAD-tools/yosys.rst`) is pretty old, so it would be great if you could check that it's still accurate @gatecat.

