### PR TITLE
Include autogenerated code docs in sidebar

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,6 +39,7 @@ Contents
    FPGA-to-bitstream/index
    simulation/index
    gallery/index
+   references/index
    definitions
    contact
    publications

--- a/docs/source/references/index.rst
+++ b/docs/source/references/index.rst
@@ -1,0 +1,12 @@
+References
+==========
+
+.. toctree::
+   :maxdepth: 1
+   
+   code_generator
+   fabric
+   fabric_gen
+   file_parser
+   model_gen_npnr
+   model_gen_vpr


### PR DESCRIPTION
Currently the autogenerated code documentation added in #50 isn't accessible anywhere, as there are no links to it in the sidebar - this adds links to the contents of `docs/references`.