### PR TITLE
Add FASM to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx == 4.3.0
 sphinx_materialdesign_theme == 0.1.11
 sphinxcontrib-bibtex == 2.4.0
 sphinx-prompt == 1.5.0
+fasm >= 0.0.2


### PR DESCRIPTION
Adds the `fasm` Python library to the docs requirements to try and fix the build failures, as discussed in #86.