### PR TITLE
Add updated emulation support to refactored FABulous

### DIFF
--- a/FABulous.py
+++ b/FABulous.py
@@ -200,6 +200,17 @@ To run the complete FABulous flow with the default project, run the following co
             self.fabricLoaded = True
 
     def preloop(self) -> None:
+
+        def wrap_with_except_handling(fun_to_wrap):
+            def inter(*args, **varargs):
+                try:
+                    fun_to_wrap(*args, **varargs)
+                except:
+                    import traceback
+                    traceback.print_exc()
+                    sys.exit(1)
+            return inter
+
         tcl = tk.Tcl()
         script = ""
         if self.script != "":
@@ -208,7 +219,7 @@ To run the complete FABulous flow with the default project, run the following co
             for fun in dir(self.__class__):
                 if fun.startswith("do_"):
                     name = fun.strip("do_")
-                    tcl.createcommand(name, getattr(self, fun))
+                    tcl.createcommand(name, wrap_with_except_handling(getattr(self, fun)))
 
         # os.chdir(args.project_dir)
         tcl.eval(script)

--- a/fabric_files/FABulous_project_template_verilog/Test/fabulous_tb.v
+++ b/fabric_files/FABulous_project_template_verilog/Test/fabulous_tb.v
@@ -53,6 +53,7 @@ module fab_tb;
         $dumpfile("fab_tb.fst");
         $dumpvars(0, fab_tb);
 `endif
+`ifndef EMULATION
         $readmemh("bitstream.hex", bitstream);
         #100;
         resetn = 1'b0;
@@ -69,6 +70,7 @@ module fab_tb;
             SelfWriteStrobe <= 1'b0;
             repeat (2) @(posedge CLK);
         end
+`endif
         repeat (100) @(posedge CLK);
         O_top = 28'b1; // reset
         repeat (5) @(posedge CLK);

--- a/fabric_files/FABulous_project_template_verilog/Test/run_emulation_sim.sh
+++ b/fabric_files/FABulous_project_template_verilog/Test/run_emulation_sim.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -ex
+DESIGN=counter
+BITSTREAM=test_design/${DESIGN}.bin
+VERILOG=../../fabric_generator/verilog_output
+MAX_BITBYTES=16384
+
+rm -rf tmp
+mkdir tmp
+for i in $(find ../Tile -type f -name "*.v") $(find ../Fabric -type f -name "*.v")
+do 
+    cp $i tmp/
+done
+
+iverilog -D EMULATION -s fab_tb -o fab_tb.vvp test_design/${DESIGN}.vh tmp/* test_design/${DESIGN}.v fabulous_tb.v 
+vvp fab_tb.vvp
+rm -rf tmp

--- a/fabric_generator/code_generation_VHDL.py
+++ b/fabric_generator/code_generation_VHDL.py
@@ -125,7 +125,7 @@ class VHDLWriter(codeGenerator):
         self._add(
             f"{left} <= {right}( {widthL} downto {widthR} );", indentLevel)
 
-    def addInstantiation(self, compName, compInsName, portsPairs, paramPairs=[], indentLevel=0):
+    def addInstantiation(self, compName, compInsName, portsPairs, paramPairs=[], emulateParamPairs=[], indentLevel=0):
         self._add(f"{compInsName} : {compName}", indentLevel=indentLevel)
         if paramPairs:
             connectPair = []
@@ -211,3 +211,16 @@ CONFout <= ConfigBits(ConfigBits'high);
 
     """
         self._add(template, indentLevel)
+
+
+    def addPreprocIfDef(self, macro, indentLevel=0):
+        assert False, "preprocessor not supported in VHDL"
+
+    def addPreprocIfNotDef(self, macro, indentLevel=0):
+        assert False, "preprocessor not supported in VHDL"
+
+    def addPreprocElse(self, indentLevel=0):
+        assert False, "preprocessor not supported in VHDL"
+
+    def addPreprocEndif(self, indentLevel=0):
+        assert False, "preprocessor not supported in VHDL"

--- a/fabric_generator/code_generation_Verilog.py
+++ b/fabric_generator/code_generation_Verilog.py
@@ -41,7 +41,10 @@ class VerilogWriter(codeGenerator):
         self._add(")", indentLevel)
 
     def addParameter(self, name, type, value, indentLevel=0):
-        self._add(f"parameter {name}={value},", indentLevel)
+        if type.startswith("["):
+            self._add(f"parameter {type} {name}={value},", indentLevel)
+        else:
+            self._add(f"parameter {name}={value},", indentLevel)
 
     def addPortStart(self, indentLevel=0):
         self._add(f"(", indentLevel)
@@ -90,7 +93,7 @@ class VerilogWriter(codeGenerator):
     def addLogicEnd(self, indentLevel=0):
         pass
 
-    def addInstantiation(self, compName, compInsName, portsPairs, paramPairs=[], indentLevel=0):
+    def addInstantiation(self, compName, compInsName, portsPairs, paramPairs=[], emulateParamPairs=[], indentLevel=0):
         if paramPairs:
             port = [f".{i[0]}({i[1]})" for i in paramPairs]
             self._add(
@@ -99,6 +102,18 @@ class VerilogWriter(codeGenerator):
             self._add(
                 (",\n"f"{' ':<{4*(indentLevel + 1)}}").join(port), indentLevel=indentLevel + 1)
             self._add(")", indentLevel=indentLevel+1)
+            self._add(f"{compInsName}", indentLevel=indentLevel+1)
+            self._add("(", indentLevel=indentLevel+1)
+        elif emulateParamPairs:
+            port = [f".{i[0]}({i[1]})" for i in emulateParamPairs]
+            self._add(
+                f"{compName}", indentLevel=indentLevel)
+            self._add("`ifdef EMULATION", indentLevel=0)
+            self._add("#(", indentLevel=indentLevel+1)
+            self._add(
+                (",\n"f"{' ':<{4*(indentLevel + 1)}}").join(port), indentLevel=indentLevel + 1)
+            self._add(")", indentLevel=indentLevel+1)
+            self._add("`endif", indentLevel=0)
             self._add(f"{compInsName}", indentLevel=indentLevel+1)
             self._add("(", indentLevel=indentLevel+1)
         else:
@@ -174,3 +189,15 @@ class VerilogWriter(codeGenerator):
     def addAssignVector(self, left, right, widthL, widthR, indentLevel=0):
         self._add(
             f"assign {left} = {right}[{widthL}:{widthR}];", indentLevel)
+
+    def addPreprocIfDef(self, macro, indentLevel=0):
+        self._add(f"`ifdef {macro}", indentLevel)
+
+    def addPreprocIfNotDef(self, macro, indentLevel=0):
+        self._add(f"`ifndef {macro}", indentLevel)
+
+    def addPreprocElse(self, indentLevel=0):
+        self._add("`else", indentLevel)
+
+    def addPreprocEndif(self, indentLevel=0):
+        self._add("`endif", indentLevel)

--- a/fabric_generator/code_generator.py
+++ b/fabric_generator/code_generator.py
@@ -309,7 +309,7 @@ class codeGenerator(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def addInstantiation(self, compName: str, compInsName: str, portsPairs: List[Tuple[str, str]], paramPairs: List[Tuple[str, str]] = [], indentLevel=0):
+    def addInstantiation(self, compName: str, compInsName: str, portsPairs: List[Tuple[str, str]], paramPairs: List[Tuple[str, str]] = [], emulateParamPairs: List[Tuple[str, str]] = [], indentLevel=0):
         """
         Add an instantiation. This will line up the ports and signals. So ports[0] will have signals[0] and so on. This is also the same case for paramPorts and paramSignals.
 
@@ -347,6 +347,7 @@ class codeGenerator(abc.ABC):
             signals (List[str]): list of signals of the component
             paramPorts (List[str], optional): list of parameter ports of the component. Defaults to [].
             paramSignals (List[str], optional): list of parameter signals of the component. Defaults to [].
+            emulateParamPairs (List[str], optional): list of parameter signals of the component in emulation mode only. Defaults to [].
             indentLevel (int, optional): The indentation Level. Defaults to 0.
 
         Raises:
@@ -421,6 +422,67 @@ class codeGenerator(abc.ABC):
             right : The right hand side of the assign statement.
             widthL : The start index of the vector. Can be a string.
             widthR : The end index of the vector. Can be a string.
+            indentLevel (int, optional): The indentation Level. Defaults to 0.
+        """
+        pass
+
+    @abc.abstractmethod
+    def addPreprocIfDef(self, macro, indentLevel=0):
+        """
+        Add a preprocessor "ifdef"
+
+        Examples :
+            | Verilog: `ifdef **macro**
+            | VHDL: unsupported
+
+        Args:
+            macro : The macro to check for
+            indentLevel (int, optional): The indentation Level. Defaults to 0.
+        """
+        pass
+
+
+    @abc.abstractmethod
+    def addPreprocIfNotDef(self, macro, indentLevel=0):
+        """
+        Add a preprocessor "ifndef"
+
+        Examples :
+            | Verilog: `ifndef **macro**
+            | VHDL: unsupported
+
+        Args:
+            macro : The macro to check for
+            indentLevel (int, optional): The indentation Level. Defaults to 0.
+        """
+        pass
+
+    @abc.abstractmethod
+    def addPreprocElse(self, indentLevel=0):
+        """
+        Add a preprocessor "else"
+
+        Examples :
+            | Verilog: `else
+            | VHDL: unsupported
+
+        Args:
+            macro : The macro to check for
+            indentLevel (int, optional): The indentation Level. Defaults to 0.
+        """
+        pass
+
+    @abc.abstractmethod
+    def addPreprocEndif(self, indentLevel=0):
+        """
+        Add a preprocessor "endif"
+
+        Examples :
+            | Verilog: `endif
+            | VHDL: unsupported
+
+        Args:
+            macro : The macro to check for
             indentLevel (int, optional): The indentation Level. Defaults to 0.
         """
         pass


### PR DESCRIPTION
This re-adds updated support for emulation; which enables fast testing of a bitstream against the fabric in simulation or on hardware by passing the bitstream via macros/parameters rather than simulating the entire configuration logic.

Compared to pre-refactor FABulous, there are two improvements:
 - Tiles with custom permuted bitstream layouts work properly (e.g. the LUT4AB)
 - The bitstream is passed through the hierarchy as a parameter rather than a wire, which will enable pre-flattening optimisations with Yosys, important for some of my future plans (like a cxxrtl sim experiment I did with the MPW2 demo design).

The first commit in the series is not related to the emulation but made debugging this along the way a lot easier, because I could actually see what exceptions occurred rather than just a generic Tcl error.

@KelvinChung2000 would you be able to take a look at this one?