### PR TITLE
docs: Escape backticks in Verilog definitions

### DIFF
--- a/fabric_generator/code_generator.py
+++ b/fabric_generator/code_generator.py
@@ -432,7 +432,7 @@ class codeGenerator(abc.ABC):
         Add a preprocessor "ifdef"
 
         Examples :
-            | Verilog: `ifdef **macro**
+            | Verilog: \`ifdef **macro**
             | VHDL: unsupported
 
         Args:
@@ -448,7 +448,7 @@ class codeGenerator(abc.ABC):
         Add a preprocessor "ifndef"
 
         Examples :
-            | Verilog: `ifndef **macro**
+            | Verilog: \`ifndef **macro**
             | VHDL: unsupported
 
         Args:
@@ -463,7 +463,7 @@ class codeGenerator(abc.ABC):
         Add a preprocessor "else"
 
         Examples :
-            | Verilog: `else
+            | Verilog: \`else
             | VHDL: unsupported
 
         Args:
@@ -478,7 +478,7 @@ class codeGenerator(abc.ABC):
         Add a preprocessor "endif"
 
         Examples :
-            | Verilog: `endif
+            | Verilog: \`endif
             | VHDL: unsupported
 
         Args:


### PR DESCRIPTION
The docs are currently failing to build on Read the Docs due to some Verilog examples in docstrings that contain macro operations. The backticks in these are interpreted as the beginning of an inline block, and Sphinx protests as they never get closed. This just escapes the backticks to avoid the warnings (as warnings cause build fails with our current Read the Docs config - I should update CI to do the same!)