### PR TITLE
Fail docs CI on warning

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,4 +14,4 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        build-command: "sphinx-build -M html source build -T -W --keep-going"
+        build-command: "sphinx-build -M html source build -T -E -W --keep-going"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,3 +14,4 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
+        build-command: "sphinx-build -M html source build -T -W --keep-going"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -14,4 +14,3 @@ jobs:
     - uses: ammaraskar/sphinx-action@master
       with:
         docs-folder: "docs/"
-        build-command: "sphinx-build -M html source build -T -E -W --keep-going"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -T -W --keep-going
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build


### PR DESCRIPTION
As mentioned in #98, our Read the Docs setup fails builds when they produce warnings - this keeps resulting in build failures on our Read the Docs site flying under the radar, as the CI is still passing. This passes a custom build command to the action we use to build the docs for CI that is the same as that run by the Makefile, save for the addition of a few flags Read the Docs gives - this means CI should now fail for builds that will fail on Read the Docs.

An alternative to this is to update the docs Makefile so that these flags are always provided, but maybe it's preferred that warnings don't affect users building them locally just because that's what Read the Docs happens to do. Equally though, you could argue that we don't want local doc builds out of sync with what's online - what's your opinion @gatecat?