### PR TITLE
docs: Update out of date documentation

### DIFF
--- a/docs/source/FPGA-to-bitstream/Yosys compilation.rst
+++ b/docs/source/FPGA-to-bitstream/Yosys compilation.rst
@@ -40,7 +40,7 @@ file is located at ``user_design/sequential_16bit_en.v`` then the result of the 
 
 Manual Synthesis
 ^^^^^^^^^^^^^^^^
-A pre-defined Yosys TCL script is under ``$FAB_ROOT/nextpnr/fabulous/synth/synth_fabulous.tcl`` for FABulous version3. If the output file, denoted below as ``<JSON_or_BLIF_file>``, has a ``.blif`` file extension, then the output will be produced in the Berkeley Logic Interchange Format (BLIF) and will be synthesised appropriately for the VPR flow. Otherwise, the output will be produced as JSON, synthesised for the nextpnr flow.
+FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell. If synthesizing for the nextpnr flow, run this command: ``yosys -p "synth_fabulous -top <toplevel> -json <out.json>" <files.v>``.
 
 If you are synthesizing for use in the VPR flow, then run this command: ``yosys -p "synth_fabulous -top <toplevel> -blif <out.blif> -vpr" <files.v>``.
 

--- a/docs/source/FPGA_CAD-tools/nextpnr.rst
+++ b/docs/source/FPGA_CAD-tools/nextpnr.rst
@@ -1,7 +1,7 @@
 Nextpnr models
 ==============
 
-After the FABulous flow has run successfully, ``bel.txt`` and ``pips.txt`` are copied to ``$FAB_ROOT/nextpnr/fabulous/fab_arch``.
+After the FABulous flow has run successfully, the ``bel.txt`` and ``pips.txt`` which describe your fabric can be found in the directory ``$FAB_ROOT/<project-dir>/.FABulous``.
 
 ``bel.txt`` is the primitive description file in order of tiles
 
@@ -29,8 +29,6 @@ After the FABulous flow has run successfully, ``bel.txt`` and ``pips.txt`` are c
 +====+======+======+======+==============+====================================================+
 |X1Y1|X1    |Y1    |A     |FABULOUS_LC   |LA_I0,LA_I1,LA_I2,LA_I3,LA_Ci,LA_SR,LA_EN,LA_O,LA_Co|
 +----+------+------+------+--------------+----------------------------------------------------+
-
-To any changes in the primitives, user should also modify the architecture description in nextpnr files located at ``$FAB_ROOT/nextpnr/fabulous``.
 
 **arch.cc** 
 

--- a/docs/source/FPGA_CAD-tools/yosys.rst
+++ b/docs/source/FPGA_CAD-tools/yosys.rst
@@ -1,7 +1,7 @@
 Yosys models
 ============
 
-** Yosys models files, all can be found in the :`Yosys repository <https://github.com/YosysHQ/yosys>`_: under ``$YOSYS_ROOT/techlibs/fabulous/`` **
+All Yosys model files can be found in the `Yosys repository <https://github.com/YosysHQ/yosys>`_ under ``$YOSYS_ROOT/techlibs/fabulous/``. These files are listed below.
 
 +---------------+-----------------------------------------------------------------------+
 | File Name     | Description                                                           |


### PR DESCRIPTION
Looks like a couple of bits in the docs are out of date post-refactor - there's some outdated information about where to find the nextpnr architecture description files, and some Yosys instructions that seem to have been reverted back to out-of-date information by accident when resolving merge conflicts on the refactor. Also a small cleanup/rephrase in some Yosys doc text that had some unnecessary characters.