### PR TITLE
Fix docs build failing due to RTD deprecated attribute

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ python:
   # Install our python package before building the docs
   install:
     - requirements: docs/requirements.txt
-  system_packages: true  
   
 #conda:
 #  environment: docs/environment.yml


### PR DESCRIPTION
[Our most recent docs build failed](https://readthedocs.org/projects/fabulous/builds/21823928/) as the system packages attribute that we set in `.readthedocs.yaml` is now deprecated. This just gets rid of the attribute which should hopefully fix it!