### PR TITLE
Move `maxWidth.txt` handling to `FABulous.py`

### DIFF
--- a/FABulous.py
+++ b/FABulous.py
@@ -524,11 +524,20 @@ To run the complete FABulous flow with the default project, run the following co
         with open(f"{self.projectDir}/{metaDataDir}/architecture.xml", "w") as f:
             f.write(vprModel)
 
-        vprRoutingResource = self.fabricGen.genModelVPRRoutingResource()
+        routingResourceInfo = self.fabricGen.genModelVPRRoutingResource()
+        # Write the routing resource graph
+        vprRoutingResource = routingResourceInfo[0]
         logger.info(
             f"Output file: {self.projectDir}/{metaDataDir}/routing_resource.xml")
         with open(f"{self.projectDir}/{metaDataDir}/routing_resource.xml", "w") as f:
             f.write(vprRoutingResource)
+
+        # Write maxWidth.txt
+        vprMaxWidth = routingResourceInfo[1]
+        logger.info(
+            f"Output file: {self.projectDir}/{metaDataDir}/maxWidth.txt")
+        with open(f"{self.projectDir}/{metaDataDir}/maxWidth.txt", "w") as f:
+            f.write(str(vprMaxWidth))
 
         vprConstrain = self.fabricGen.genModelVPRConstrains()
         logger.info(

--- a/fabric_generator/model_generation_vpr.py
+++ b/fabric_generator/model_generation_vpr.py
@@ -258,7 +258,7 @@ def genVPRModel(fabric: Fabric, customXMLfile: str = "") -> str:
     return ET.tostring(root, encoding="unicode")
 
 
-def genVPRRoutingResourceGraph(fabric: Fabric) -> str:
+def genVPRRoutingResourceGraph(fabric: Fabric) -> (str, int):
     root = ET.Element("rr_graph")
     root.attrib = {"tool_name": "vpr",
                    "tool_version": "82a3c72",
@@ -640,11 +640,7 @@ def genVPRRoutingResourceGraph(fabric: Fabric) -> str:
 
     ET.indent(root, space="  ")
 
-    with open(".FABulous/maxWidth.txt", "w") as f:
-        logger.info("Output file: ./.FABulous/maxWidth.txt")
-        f.write(f"{maxWidth}")
-
-    return ET.tostring(root, encoding="unicode")
+    return ET.tostring(root, encoding="unicode"), maxWidth
 
 
 def genVPRConstrainsXML(fabric: Fabric) -> str:


### PR DESCRIPTION
This should fix the issue noted in #104 - `genVPRRoutingResourceGraph` has no knowledge of the project directory so can't write to the `.FABulous` directory to create the `maxWidth.txt` file. This just adds the max width as part of a return tuple so that the file handling can be done in `FABulous.py` as is done elsewhere.