### PR TITLE
Fix minor typos and remove unnecessary flag in setup guide

### DIFF
--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -13,7 +13,7 @@ The following packages need to be installed for generating fabric HDLs
 
 .. code-block:: console
 
-    git clone --recurse-submodules https://github.com/FPGA-Research-Manchester/FABulous
+    git clone https://github.com/FPGA-Research-Manchester/FABulous
 
 :Python: 
  version >= 3.9

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,8 +4,7 @@ import sys
 
 # -- Project information
 
-# project = 'FABulous Dokumentation'
-project = 'FABulous Dokumentation'
+project = 'FABulous Documentation'
 copyright = '2021, University of Manchester'
 author = 'Jing, Nguyen, Bea, Bardia, Dirk'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,6 @@ requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]
-name = "FABulous Dokumentation"
+name = "FABulous Documentation"
 authors = [{name = "Jing, Nguyen, Bea, Bardia, Dirk", email = "dirk.koch@manchester.ac.uk"}]
 dynamic = ["version", "description"]


### PR DESCRIPTION
This just fixes a couple of English->German typos and removes an unnecessary flag in the docs (since we no longer have any submodules)