### PR TITLE
Fix __repr__ function of Fabric

### DIFF
--- a/fabric_generator/fabric.py
+++ b/fabric_generator/fabric.py
@@ -571,8 +571,8 @@ class Fabric():
 
     def __repr__(self) -> str:
         fabric = ""
-        for i in range(self.numberOfColumns):
-            for j in range(self.numberOfRows):
+        for i in range(self.numberOfRows):
+            for j in range(self.numberOfColumns):
                 if self.tile[i][j] is None:
                     fabric += "Null".ljust(15)+"\t"
                 else:


### PR DESCRIPTION
The numberOfColumns and numberOfRows attributes are switched, leading to an OutOfBoundsError for non-square-shaped fabrics; and to square-shaped fabrics being printed on their side. 