### PR TITLE
Dim calculation fix + small fixes

### DIFF
--- a/fabric_generator/fabric.py
+++ b/fabric_generator/fabric.py
@@ -584,7 +584,7 @@ class Fabric():
         fabric += f"numberOfRows: {self.numberOfRows}\n"
         fabric += f"configBitMode: {self.configBitMode}\n"
         fabric += f"frameBitsPerRow: {self.frameBitsPerRow}\n"
-        fabric += f"frameBitsPerColumn: {self.maxFramesPerCol}\n"
+        fabric += f"maxFramesPerCol: {self.maxFramesPerCol}\n"
         fabric += f"package: {self.package}\n"
         fabric += f"generateDelayInSwitchMatrix: {self.generateDelayInSwitchMatrix}\n"
         fabric += f"multiplexerStyle: {self.multiplexerStyle}\n"

--- a/geometry_generator/fabric_geometry.py
+++ b/geometry_generator/fabric_geometry.py
@@ -153,10 +153,30 @@ class FabricGeometry:
 
         # this step is for figuring out the fabric dimensions
         # as tile dimensions are fixed by now.
-        bottomRightTile = self.fabric.tile[-1][-1]
-        bottomRightTileGeom = self.tileGeomMap[bottomRightTile.name]
-        self.width = self.tileLocs[-1][-1].x + bottomRightTileGeom.width
-        self.height = self.tileLocs[-1][-1].y + bottomRightTileGeom.height
+        # Because of the top left point of the fabric being
+        # the origin (0, 0), the fabrics dimensions can be
+        # figured out by determining the rightmost and
+        # bottommost points of the fabric.
+        rightMostX = 0
+        bottomMostY = 0
+        for i in range(self.fabric.numberOfRows):
+            tile = self.fabric.tile[i][-1]
+            if tile is not None:
+                tileGeom = self.tileGeomMap[tile.name]
+                tileLoc = self.tileLocs[i][-1]
+                tileRightmostX = tileLoc.x + tileGeom.width
+                rightMostX = max(rightMostX, tileRightmostX)
+
+        for j in range(self.fabric.numberOfColumns):
+            tile = self.fabric.tile[-1][j]
+            if tile is not None:
+                tileGeom = self.tileGeomMap[tile.name]
+                tileLoc = self.tileLocs[-1][j]
+                tileBottommostY = tileLoc.y + tileGeom.height
+                bottomMostY = max(bottomMostY, tileBottommostY)
+
+        self.width = rightMostX
+        self.height = bottomMostY
 
         # this step is for rearranging the switch matrices by setting 
         # the relX/relY appropriately. This is done to ensure that

--- a/geometry_generator/sm_geometry.py
+++ b/geometry_generator/sm_geometry.py
@@ -1,5 +1,5 @@
 from typing import List
-from fabric_generator.fabric import Port, Tile, Direction, Side
+from fabric_generator.fabric import Port, Tile, Direction, Side, IO
 from geometry_generator.geometry_obj import Border
 from geometry_generator.bel_geometry import BelGeometry
 from geometry_generator.port_geometry import PortGeometry, PortType
@@ -186,7 +186,7 @@ class SmGeometry:
                     firstPort.destinationName,
                     firstPort.wireCount,
                     firstPortName,
-                    firstPort.inOut,
+                    IO.INOUT,
                     firstPort.sideOfTile
                 )
                 mergedJumpPorts.append(mergedPort)


### PR DESCRIPTION
Fix of width/height calculation of the fabrics geometry, plus some tiny fixes

To calculate the fabrics width/height, the bottom right tile was used - tile generation starts at (0, 0), thus the location and dimensions of this tile was used to determine the overall width and height of the fabric by using its location and width/height. However, the tile can be a NULL-Tile, rendering it useless for determining the dimensions of the fabric. This fix should resolve the issue.