### PR TITLE
Match wire names in the documentation of the wire shifting example

### DIFF
--- a/docs/source/fabric_definition.rst
+++ b/docs/source/fabric_definition.rst
@@ -329,7 +329,7 @@ The switch matrices see only the ``wires`` amount of wires, regardless of the sp
 
    TILE, CLB                  
    #direction  source_name  X-offset  Y-offset  destination_name  wires
-   EAST,       E1B,         6,        0,        E1E,              2
+   EAST,       E6B,         6,        0,        E6E,              2
 
 .. figure:: figs/wire_nesting_indexing.*
   :alt: Wire nesting and wire indexing


### PR DESCRIPTION
The source and destination names in the wire shifting example did not match to the names in the corresponding image on the [fabric definition](https://fabulous.readthedocs.io/en/latest/fabric_definition.html) page for the wire shifting example.