### PR TITLE
Add exception handling for the synthesis CLI commands

### DIFF
--- a/FABulous.py
+++ b/FABulous.py
@@ -696,8 +696,11 @@ To run the complete FABulous flow with the default project, run the following co
                   "-p", f"synth_fabulous -top top_wrapper -json {self.projectDir}/{path}/{name}.json",
                   f"{self.projectDir}/{args[0]}",
                   f"{self.projectDir}/{path}/top_wrapper.v", ]
-        sp.run(runCmd, check=True)
-        logger.info("Synthesis completed")
+        try:
+            sp.run(runCmd, check=True)
+            logger.info("Synthesis completed")
+        except sp.CalledProcessError:
+            logger.error("Synthesis failed")
 
     def complete_synthesis_npnr(self, text, *ignored):
         return self._complete_path(text)
@@ -716,8 +719,11 @@ To run the complete FABulous flow with the default project, run the following co
                   "-p", f"synth_fabulous -top top_wrapper -blif {self.projectDir}/{path}/{name}.blif -vpr",
                   f"{self.projectDir}/{args[0]}",
                   f"{self.projectDir}/{path}/top_wrapper.v", ]
-        sp.run(runCmd, check=True)
-        logger.info("Synthesis completed")
+        try:
+            sp.run(runCmd, check=True)
+            logger.info("Synthesis completed")
+        except sp.CalledProcessError:
+            logger.error("Synthesis failed")
 
     def complete_synthesis_blif(self, text, *ignored):
         return self._complete_path(text)


### PR DESCRIPTION
The CLI always crashed when there was an error during synthesis (e.g. file not found or error in files). The traceback also "hid" the error with its output a few lines above. Now the user just gets notified that the synthesis failed, the error is just above the short logging message and the CLI does not crash so the user does not have to restart FABulous and reload the fabric after fixing the error. If it was just a typo in the path or file, the mistake can just be corrected from the history without completely retyping the command which is necessary after restarting FABulous.