### PR TITLE
Fix outdated simulation docs

### DIFF
--- a/docs/source/simulation/simulation.rst
+++ b/docs/source/simulation/simulation.rst
@@ -1,49 +1,13 @@
 Simulation setup
 ================
 
-A simulation example can be found under ``$FAB_ROOT/fabric_files/fabric_icarus_example/``. This has been tested using the open source Icarus Verillog simulator.
+The following series of commands can be used to easily run a simulation with a test bitstream loaded, using Icarus Verilog:
 
-To setup the simulation enviroment, an eFPGA top module to instantiate the fabric and the `configuration module`_ are required, as in the example ``eFPGA_v2_top_sky130_sim.v``
-
-.. code-block:: verilog
-        
-        module eFPGA_top (I_top, T_top, O_top, A_config_C, B_config_C, CLK, SelfWriteStrobe, SelfWriteData, Rx, ComActive, ReceiveLED, s_clk, s_data);
-        ...
-        Config Config_inst (...);
-        //All Frame data register modules
-        ...
-        //All Frame select modules
-        ...
-        eFPGA Inst_eFPGA(
-        .Tile_X0Y1_A_I_top(I_top[23]),
-        .Tile_X0Y1_B_I_top(I_top[22]),
-        .Tile_X0Y2_A_I_top(I_top[21]),
-        .Tile_X0Y2_B_I_top(I_top[20]),
-        .Tile_X0Y3_A_I_top(I_top[19]),
-        .Tile_X0Y3_B_I_top(I_top[18]),
-        .Tile_X0Y4_A_I_top(I_top[17]),
-        .Tile_X0Y4_B_I_top(I_top[16]),
-        .Tile_X0Y5_A_I_top(I_top[15]),
-        .Tile_X0Y5_B_I_top(I_top[14]),
-        .Tile_X0Y6_A_I_top(I_top[13]),
-        .Tile_X0Y6_B_I_top(I_top[12]),
-        .Tile_X0Y7_A_I_top(I_top[11]),
-        .Tile_X0Y7_B_I_top(I_top[10]),
-        .Tile_X0Y8_A_I_top(I_top[9]),
-        .Tile_X0Y8_B_I_top(I_top[8]),
-        .Tile_X0Y9_A_I_top(I_top[7]),
-        .Tile_X0Y9_B_I_top(I_top[6]),
-        .Tile_X0Y10_A_I_top(I_top[5]),
-        .Tile_X0Y10_B_I_top(I_top[4]),
-        .Tile_X0Y11_A_I_top(I_top[3]),
-        .Tile_X0Y11_B_I_top(I_top[2]),
-        .Tile_X0Y12_A_I_top(I_top[1]),
-        .Tile_X0Y12_B_I_top(I_top[0]),
-        ...
-        );
-        endmodule
-
-Next, you can assign the input signals to ``O_top`` and the output signals to ``I_top`` under the ``fabulous_tb.v`` testbench. IO mappings are fixed for the top-level user design in the ``test_design/io_wrapper.v``. You will need to modify the number and position of bel mappings in this file if you have changed the height of the fabric from the default of 14 (2 IOs per tile give 28 IO total).
+```
+cd demo/Test
+./build_test_design.sh
+./run_simulation.sh
+```
 
 FABulous comes with 3 different simulation methods _`configuration module`,
 


### PR DESCRIPTION
This gets rid of some outdated references to simulation in the docs, closing #134 