### PR TITLE
Fix rendering of simulation doc commands

### DIFF
--- a/docs/source/simulation/simulation.rst
+++ b/docs/source/simulation/simulation.rst
@@ -3,11 +3,11 @@ Simulation setup
 
 The following series of commands can be used to easily run a simulation with a test bitstream loaded, using Icarus Verilog:
 
-```
-cd demo/Test
-./build_test_design.sh
-./run_simulation.sh
-```
+.. code-block:: console
+
+        cd demo/Test
+        ./build_test_design.sh
+        ./run_simulation.sh
 
 FABulous comes with 3 different simulation methods _`configuration module`,
 


### PR DESCRIPTION
Just switches the formatting of the changes in #136 as I accidentally used MD instead of RST formatting and didn't catch it as my local installation is playing up. Sorry!