### PR TITLE
Print traceback on error inside FABulous Shell

### DIFF
--- a/FABulous.py
+++ b/FABulous.py
@@ -43,6 +43,7 @@ import logging
 import tkinter as tk
 from pathlib import PurePosixPath, PureWindowsPath
 import platform
+import traceback
 readline.set_completer_delims(' \t\n')
 histfile = ""
 histfile_size = 1000
@@ -274,6 +275,7 @@ To run the complete FABulous flow with the default project, run the following co
         try:
             return super().onecmd(line)
         except:
+            print(traceback.format_exc())
             return False
 
     # override the emptyline method, so empty command will just do nothing


### PR DESCRIPTION
If an error/exception occurs inside the FABulous Shell it is not printed, only `False` is returned:

```
    def onecmd(self, line):
        try:
            return super().onecmd(line)
        except:
            return False
```

You can easily test this by adding a syntax error to e.g. the `do_load_fabric` function:

```
    def do_load_fabric(self, args=""):
        "load csv file and generate an internal representation of the fabric"
        args = self.parse(args)
        asdf
        ....
```

The FABulous shell does not indicate that an error has occurred:

```
FABulous> load_fabric
FABulous> 
```

This PR fixes that:

```
FABulous> load_fabric
Traceback (most recent call last):
  File "/home/leo/Projects/FABulous_fix/FABulous.py", line 276, in onecmd
    return super().onecmd(line)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/cmd.py", line 217, in onecmd
    return func(arg)
           ^^^^^^^^^
  File "/home/leo/Projects/FABulous_fix/FABulous.py", line 318, in do_load_fabric
    asdf
NameError: name 'asdf' is not defined

FABulous> 
```