### PR TITLE
:fabric_gen: Fix VHDL ConfigMem gets instantiated twice per tile

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -877,15 +877,6 @@ class FabricGenerator:
                     f"Could not find {tile.name}_ConfigMem.vhdl in {basePath} config_mem generation first"
                 )
 
-            if (
-                self.fabric.configBitMode == ConfigBitMode.FRAME_BASED
-                and tile.globalConfigBits > 0
-            ):
-                if os.path.exists(f"{basePath}/{tile.name}_ConfigMem.vhdl"):
-                    self.writer.addComponentDeclarationForFile(
-                        f"{basePath}/{tile.name}_ConfigMem.vhdl"
-                    )
-
         # VHDL signal declarations
         self.writer.addComment("signal declarations", onNewLine=True)
         # BEL port wires


### PR DESCRIPTION
Remove the double call of addComponentDeclarationForFile, which caused the ConfigMem for a VHDL tile got instantiated twice, while the tile code was generated.

@KelvinChung2000: I'm not sure how this affects with the shift register based configuration type. Could you please check, if I should rather remove the upper "addComponentDeclarationForFile" call in the generateTile function?