### PR TITLE
geometry_gen:fabric_geometry: Fix indexing error for smaller fabrics

### DIFF
--- a/geometry_generator/fabric_geometry.py
+++ b/geometry_generator/fabric_geometry.py
@@ -101,7 +101,7 @@ class FabricGeometry:
             maxWidth = 0
             maxSmRelX = 0
             maxSmWidth = 0
-            for i in range(self.fabric.numberOfColumns):
+            for i in range(self.fabric.numberOfRows):
                 maxWidth = max(maxWidth, tileGeometries[i][j].width)
                 maxSmRelX = max(maxSmRelX, tileGeometries[i][j].smGeometry.relX)
                 maxSmWidth = max(maxSmWidth, tileGeometries[i][j].smGeometry.width)


### PR DESCRIPTION
Fix an indexing error in geometry generation that caused FABulous to crash when the fabric had fewer tiles on the Y axis than on the X axis.