### PR TITLE
Vhdl simulation

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -46,6 +46,7 @@ readline.set_completer_delims(" \t\n")
 histfile = ""
 histfile_size = 1000
 
+simulation_decide = 0  # for verilog
 MAX_BITBYTES = 16384
 
 logger = logging.getLogger(__name__)
@@ -101,6 +102,15 @@ def copy_verilog_files(src, dst):
     for root, _, files in os.walk(src):
         for file in files:
             if file.endswith(".v"):
+                source_path = os.path.join(root, file)
+                destination_path = os.path.join(dst, file)
+                shutil.copy(source_path, destination_path)
+
+
+def copy_vhdl_files(src, dst):
+    for root, _, files in os.walk(src):
+        for file in files:
+            if file.endswith(".vhdl"):
                 source_path = os.path.join(root, file)
                 destination_path = os.path.join(dst, file)
                 shutil.copy(source_path, destination_path)
@@ -1097,52 +1107,76 @@ To run the complete FABulous flow with the default project, run the following co
             )
             return
 
-        design_file = top_module + ".v"
-        top_module_tb = top_module + "_tb"
-        test_bench = top_module_tb + ".v"
-        vvp_file = top_module_tb + ".vvp"
         bitstream_hex = top_module + ".hex"
-
-        tmp_dir = f"{self.projectDir}/{path}/tmp/"
-        os.makedirs(f"{self.projectDir}/{path}/tmp", exist_ok=True)
-        copy_verilog_files(f"{self.projectDir}/Tile/", tmp_dir)
-        copy_verilog_files(f"{self.projectDir}/Fabric/", tmp_dir)
-        file_list = [
-            os.path.join(tmp_dir, filename) for filename in os.listdir(tmp_dir)
-        ]
-
-        try:
-            runCmd = [
-                "iverilog",
-                "-D",
-                f"{defined_option}",
-                "-s",
-                f"{top_module_tb}",
-                "-o",
-                f"{self.projectDir}/{path}/{vvp_file}",
-                *file_list,
-                f"{self.projectDir}/{path}/{design_file}",
-                f"{self.projectDir}/Test/{test_bench}",
-            ]
-            sp.run(runCmd, check=True)
-
-        except sp.CalledProcessError:
-            logger.error("Simulation failed")
-            remove_dir(f"{self.projectDir}/{path}/tmp")
-            return
 
         make_hex(
             f"{self.projectDir}/{path}/{bitstream}",
             f"{self.projectDir}/{path}/{bitstream_hex}",
         )
 
-        try:
-            runCmd = ["vvp", f"{self.projectDir}/{path}/{vvp_file}"]
-            sp.run(runCmd, check=True)
-        except sp.CalledProcessError:
-            logger.error("Simulation failed")
-            remove_dir(f"{self.projectDir}/{path}/tmp")
-            return
+        if simulation_decide == 0:
+            design_file = top_module + ".v"
+            top_module_tb = top_module + "_tb"
+            test_bench = top_module_tb + ".v"
+            vvp_file = top_module_tb + ".vvp"
+
+            tmp_dir = f"{self.projectDir}/{path}/tmp/"
+            os.makedirs(f"{self.projectDir}/{path}/tmp", exist_ok=True)
+            copy_verilog_files(f"{self.projectDir}/Tile/", tmp_dir)
+            copy_verilog_files(f"{self.projectDir}/Fabric/", tmp_dir)
+            file_list = [
+                os.path.join(tmp_dir, filename) for filename in os.listdir(tmp_dir)
+            ]
+
+            try:
+                runCmd = [
+                    "iverilog",
+                    "-D",
+                    f"{defined_option}",
+                    "-s",
+                    f"{top_module_tb}",
+                    "-o",
+                    f"{self.projectDir}/{path}/{vvp_file}",
+                    *file_list,
+                    f"{self.projectDir}/{path}/{design_file}",
+                    f"{self.projectDir}/Test/{test_bench}",
+                ]
+                sp.run(runCmd, check=True)
+
+            except sp.CalledProcessError:
+                logger.error("Simulation failed")
+                remove_dir(f"{self.projectDir}/{path}/tmp")
+                return
+
+            try:
+                runCmd = ["vvp", f"{self.projectDir}/{path}/{vvp_file}"]
+                sp.run(runCmd, check=True)
+            except sp.CalledProcessError:
+                logger.error("Simulation failed")
+                remove_dir(f"{self.projectDir}/{path}/tmp")
+                return
+
+        elif simulation_decide == 1:
+            script_path = f"{self.projectDir}/Test/vhdl_simulation.sh"
+            design_file = top_module + ".vhdl"
+            top_module_tb = top_module + "_tb"
+            test_bench = top_module_tb + ".vhdl"
+
+            # tmp_dir = f"{self.projectDir}/{path}/tmp/"
+            # os.makedirs(f"{self.projectDir}/{path}/tmp", exist_ok=True)
+            # copy_vhdl_files(f"{self.projectDir}/Fabric/", tmp_dir)
+            # copy_vhdl_files(f"{self.projectDir}/Tile/", tmp_dir)
+            # file_list = [
+            #     os.path.join(tmp_dir, filename) for filename in os.listdir(tmp_dir)
+            # ]
+
+            try:
+                runCmd = [script_path, optional_arg, top_module, self.projectDir]
+                sp.run(runCmd, check=True)
+            except sp.CalledProcessError:
+                logger.error("Simulation failed")
+                #  remove_dir(f"{self.projectDir}/{path}/tmp")
+                return
 
         remove_dir(f"{self.projectDir}/{path}/tmp")
         logger.info("Simulation finished")
@@ -1227,6 +1261,7 @@ To run the complete FABulous flow with the default project, run the following co
 
 
 def main():
+    global simulation_decide
     if sys.version_info < (3, 9, 0):
         print("Need Python 3.9 or above to run FABulous")
         exit(-1)
@@ -1293,8 +1328,10 @@ def main():
         writer = VerilogWriter()
         if args.writer == "vhdl":
             writer = VHDLWriter()
+            simulation_decide = 1  # for vhdl simulation
         if args.writer == "verilog":
             writer = VerilogWriter()
+            simulation_decide = 0  # for verilog simulation
 
         fabShell = FABulousShell(
             FABulous(writer, fabricCSV=args.csv), args.project_dir, args.script

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -752,7 +752,7 @@ To run the complete FABulous flow with the default project, run the following co
             raise TypeError(
                 f"do_synthesis_npnr takes exactly one argument ({len(args)} given)"
             )
-        
+
         logger.info(f"Running synthesis that targeting Nextpnr with design {args[0]}")
         path = get_path(args[0])
         parent = path.parent
@@ -770,17 +770,19 @@ To run the complete FABulous flow with the default project, run the following co
             return
 
         json_file = top_module_name + ".json"
-        
+
         if path.suffix == ".v":
             runCmd = [
                 "yosys",
                 "-p",
                 f"synth_fabulous -top top_wrapper -json {self.projectDir}/{parent}/{json_file}",
                 f"{self.projectDir}/{parent}/{file_name}",
-                top_wrapper_path
+                top_wrapper_path,
             ]
             try:
-                logger.info(f"Running Yosys with the following command: {' '.join(runCmd)}")
+                logger.info(
+                    f"Running Yosys with the following command: {' '.join(runCmd)}"
+                )
                 sp.run(runCmd, check=True)
                 logger.info("Synthesis completed")
             except sp.CalledProcessError:
@@ -788,23 +790,24 @@ To run the complete FABulous flow with the default project, run the following co
                 raise SynthesisError
 
         else:
-            #using yosys ghdl plugin for vhdl synthesis
+            # using yosys ghdl plugin for vhdl synthesis
             runCmd = [
                 "yosys",
-                "-m", "ghdl",
-                "-p", f"ghdl {self.projectDir}/{parent}/{file_name} -e top; read_verilog {top_wrapper_path}; synth_fabulous -top top_wrapper -json {self.projectDir}/{parent}/{json_file}"
+                "-m",
+                "ghdl",
+                "-p",
+                f"ghdl {self.projectDir}/{parent}/{file_name} -e top; read_verilog {top_wrapper_path}; synth_fabulous -top top_wrapper -json {self.projectDir}/{parent}/{json_file}",
             ]
 
             try:
-                logger.info(f"Running Yosys with the following command: {' '.join(runCmd)}")
+                logger.info(
+                    f"Running Yosys with the following command: {' '.join(runCmd)}"
+                )
                 sp.run(runCmd, check=True)
                 logger.info("Synthesis completed")
             except sp.CalledProcessError:
                 logger.error("Synthesis failed")
                 raise SynthesisError
-
-       
-
 
     def complete_synthesis_npnr(self, text, *ignored):
         return self._complete_path(text)
@@ -1315,4 +1318,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/BlockRAM_1KB.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/BlockRAM_1KB.vhdl
@@ -1,5 +1,5 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -23,10 +23,10 @@ entity BlockRAM_1KB is
     C4 : in std_logic;
     C5 : in std_logic;
     clk : in std_logic;
-    rd_addr : in std_logic_vector(7 downto 0);
-    rd_data : out std_logic_vector(31 downto 0);
-    wr_addr : in std_logic_vector(7 downto 0);
-    wr_data : in std_logic_vector(31 downto 0)
+    rd_addr : in STD_LOGIC_VECTOR(7 downto 0);
+    rd_data : out STD_LOGIC_VECTOR(31 downto 0);
+    wr_addr : in STD_LOGIC_VECTOR(7 downto 0);
+    wr_data : in STD_LOGIC_VECTOR(31 downto 0)
   );
 end entity; 
 
@@ -72,6 +72,8 @@ begin
   rd_port_configuration <= C2 & C3;
   wr_addr_topbits <= wr_data(READ_ADDRESS_MSB_FROM_DATALSB + 1 downto READ_ADDRESS_MSB_FROM_DATALSB);
   
+
+
   -- Generated from instantiation at BlockRAM_1KB.v:75
   memory_cell: sram_1rw1r_32_256_8_sky130
     port map (
@@ -101,12 +103,12 @@ begin
   process (wr_port_configuration, wr_data, wr_addr_topbits) is
   begin
     muxedDataIn <= "UUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU";
-    if wr_port_configuration = X"00000000" then
+    if wr_port_configuration = "00" then
       mem_wr_mask <= X"f";
       muxedDataIn <= wr_data;
     else
-      if wr_port_configuration = X"00000001" then
-        if wr_addr_topbits = X"00000000" then
+      if wr_port_configuration = "01" then
+        if wr_addr_topbits = "00" then
           mem_wr_mask <= X"3";
           muxedDataIn(0 + 15 downto 0) <= wr_data(0 + 15 downto 0);
         else
@@ -114,16 +116,16 @@ begin
           muxedDataIn(16 + 15 downto 16) <= wr_data(0 + 15 downto 0);
         end if;
       else
-        if wr_port_configuration = X"00000002" then
-          if wr_addr_topbits = X"00000000" then
+        if wr_port_configuration = "10" then
+          if wr_addr_topbits = "00" then
             mem_wr_mask <= X"1";
             muxedDataIn(0 + 7 downto 0) <= wr_data(0 + 7 downto 0);
           else
-            if wr_addr_topbits = X"00000001" then
+            if wr_addr_topbits = "01" then
               mem_wr_mask <= X"2";
               muxedDataIn(8 + 7 downto 8) <= wr_data(0 + 7 downto 0);
             else
-              if wr_addr_topbits = X"00000002" then
+              if wr_addr_topbits = "10" then
                 mem_wr_mask <= X"4";
                 muxedDataIn(16 + 7 downto 16) <= wr_data(0 + 7 downto 0);
               else
@@ -141,7 +143,7 @@ begin
   process (clk) is
   begin
     if rising_edge(clk) then
-      rd_dout_sel <= wr_data(READ_ADDRESS_MSB_FROM_DATALSB + 1 downto READ_ADDRESS_MSB_FROM_DATALSB);
+      rd_dout_sel <= wr_data(24 + 1 downto 24);
     end if;
   end process;
   
@@ -149,24 +151,24 @@ begin
   process (mem_dout, rd_port_configuration, rd_dout_sel) is
   begin
     rd_dout_muxed <= mem_dout;
-    if rd_port_configuration = X"00000000" then
+    if rd_port_configuration = "00" then
       rd_dout_muxed <= mem_dout;
     else
-      if rd_port_configuration = X"00000001" then
-        if (std_logic_vector'("0000000000000000000000000000000") & rd_dout_sel(0)) = X"00000000" then
-          rd_dout_muxed(0 + 15 downto 0) <= mem_dout(0 + 15 downto 0);
+      if rd_port_configuration = "01" then
+        if (rd_dout_sel(0)) = '0' then
+          rd_dout_muxed(15 downto 0) <= mem_dout(15 downto 0);
         else
           rd_dout_muxed(0 + 15 downto 0) <= mem_dout(16 + 15 downto 16);
         end if;
       else
-        if rd_port_configuration = X"00000002" then
-          if rd_dout_sel = X"00000000" then
+        if rd_port_configuration = "10" then
+          if rd_dout_sel = "00" then
             rd_dout_muxed(0 + 7 downto 0) <= mem_dout(0 + 7 downto 0);
           else
-            if rd_dout_sel = X"00000001" then
+            if rd_dout_sel = "01" then
               rd_dout_muxed(0 + 7 downto 0) <= mem_dout(8 + 7 downto 8);
             else
-              if rd_dout_sel = X"00000002" then
+              if rd_dout_sel = "10" then
                 rd_dout_muxed(0 + 7 downto 0) <= mem_dout(16 + 7 downto 16);
               else
                 rd_dout_muxed(0 + 7 downto 0) <= mem_dout(24 + 7 downto 24);
@@ -177,6 +179,7 @@ begin
       end if;
     end if;
   end process;
+  
   
   -- Generated from always process in BlockRAM_1KB (BlockRAM_1KB.v:116)
   process (clk) is
@@ -231,7 +234,6 @@ end entity;
 --   RAM_DEPTH = 256
 architecture from_verilog of sram_1rw1r_32_256_8_sky130 is
 begin
-  dout0 <= (others => 'Z');
-  dout1 <= (others => 'Z');
+  dout0 <= (others => '0');
+  dout1 <= (others => '0');
 end architecture;
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/Frame_Data_Reg.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/Frame_Data_Reg.vhdl
@@ -1,11 +1,14 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-
+-- Generated from Verilog module Frame_Data_Reg (Frame_Data_Reg.v:1)
+--   FrameBitsPerRow = 32
+--   Row = 1
+--   RowSelectWidth = 5
 entity Frame_Data_Reg is
   generic (
     RowSelectWidth : integer := 5;
@@ -20,13 +23,16 @@ entity Frame_Data_Reg is
   );
 end entity; 
 
-
+-- Generated from Verilog module Frame_Data_Reg (Frame_Data_Reg.v:1)
+--   FrameBitsPerRow = 32
+--   Row = 1
+--   RowSelectWidth = 5
 architecture from_verilog of Frame_Data_Reg is
   signal FrameData_O_Reg : std_logic_vector(31 downto 0);
 begin
   FrameData_O <= FrameData_O_Reg;
   
-  -- Generated from always process in Frame_Data_Reg (Frame_Data_Reg_template.v:10)
+  -- Generated from always process in Frame_Data_Reg (Frame_Data_Reg.v:10)
   process (CLK) is
   begin
     if rising_edge(CLK) then
@@ -36,4 +42,3 @@ begin
     end if;
   end process;
 end architecture;
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/Frame_Select.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/Frame_Select.vhdl
@@ -1,11 +1,14 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-
+-- Generated from Verilog module Frame_Select (Frame_Select.v:1)
+--   Col = 18
+--   FrameSelectWidth = 5
+--   MaxFramesPerCol = 20
 entity Frame_Select is
   generic (
     FrameSelectWidth : integer := 5;
@@ -20,20 +23,22 @@ entity Frame_Select is
   );
 end entity; 
 
-
+-- Generated from Verilog module Frame_Select (Frame_Select.v:1)
+--   Col = 18
+--   FrameSelectWidth = 5
+--   MaxFramesPerCol = 20
 architecture from_verilog of Frame_Select is
-  signal FrameStrobe_O_Reg : std_logic_vector(19 downto 0);
+  signal FrameStrobe_O_Reg : std_logic_vector(MaxFramesPerCol-1 downto 0);
 begin
   FrameStrobe_O <= FrameStrobe_O_Reg;
   
-  -- Generated from always process in Frame_Select (Frame_Select_template.v:11)
+  -- Generated from always process in Frame_Select (Frame_Select.v:11)
   process (FrameStrobe, FrameSelect, FrameStrobe_I) is
   begin
     if (FrameStrobe = '1') and to_integer(unsigned(FrameSelect)) = Col then
       FrameStrobe_O_Reg <= FrameStrobe_I;
     else
-      FrameStrobe_O_Reg <= X"00000";
+      FrameStrobe_O_Reg <= (others => '0');
     end if;
   end process;
 end architecture;
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/bitbang.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/bitbang.vhdl
@@ -1,5 +1,5 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -13,6 +13,7 @@ entity bitbang is
     active : out std_logic;
     clk : in std_logic;
     data : out std_logic_vector(31 downto 0);
+    resetn : in std_logic;
     s_clk : in std_logic;
     s_data : in std_logic;
     strobe : out std_logic
@@ -26,64 +27,84 @@ architecture from_verilog of bitbang is
   signal active_Reg : std_logic;
   signal data_Reg : std_logic_vector(31 downto 0);
   signal strobe_Reg : std_logic;
-  signal local_strobe : std_logic;  -- Declared at bitbang.v:17
-  signal old_local_strobe : std_logic;  -- Declared at bitbang.v:18
-  signal s_clk_sample : std_logic_vector(3 downto 0);  -- Declared at bitbang.v:12
-  signal s_data_sample : std_logic_vector(3 downto 0);  -- Declared at bitbang.v:11
-  signal serial_control : std_logic_vector(15 downto 0);  -- Declared at bitbang.v:15
-  signal serial_data : std_logic_vector(31 downto 0);  -- Declared at bitbang.v:14
+  signal local_strobe : std_logic;  -- Declared at bitbang.v:18
+  signal old_local_strobe : std_logic;  -- Declared at bitbang.v:19
+  signal s_clk_sample : std_logic_vector(3 downto 0);  -- Declared at bitbang.v:13
+  signal s_data_sample : std_logic_vector(3 downto 0);  -- Declared at bitbang.v:12
+  signal serial_control : std_logic_vector(15 downto 0);  -- Declared at bitbang.v:16
+  signal serial_data : std_logic_vector(31 downto 0);  -- Declared at bitbang.v:15
 begin
   active <= active_Reg;
   data <= data_Reg;
   strobe <= strobe_Reg;
   
-  -- Generated from always process in bitbang (bitbang.v:20)
-  process (clk) is
+  -- Generated from always process in bitbang (bitbang.v:21)
+  p_input_sync: process (resetn, clk) is
   begin
-    if rising_edge(clk) then
-      s_data_sample <= s_data_sample(0 + 2 downto 0) & s_data;
-      s_clk_sample <= s_clk_sample(0 + 2 downto 0) & s_clk;
-    end if;
-  end process;
-  
-  -- Generated from always process in bitbang (bitbang.v:26)
-  process (clk) is
-  begin
-    if rising_edge(clk) then
-      if (s_clk_sample(3) = '0') and (s_clk_sample(2) = '1') then
-        serial_data <= serial_data(0 + 30 downto 0) & s_data_sample(3);
-      end if;
-      if (s_clk_sample(3) = '1') and (s_clk_sample(2) = '0') then
-        serial_control <= serial_control(0 + 14 downto 0) & s_data_sample(3);
+    if falling_edge(resetn) or rising_edge(clk) then
+      if (not resetn) = '1' then
+        s_data_sample <= X"0";
+        s_clk_sample <= X"0";
+      else
+        s_data_sample <= s_data_sample(0 + 2 downto 0) & s_data;
+        s_clk_sample <= s_clk_sample(0 + 2 downto 0) & s_clk;
       end if;
     end if;
   end process;
   
-  -- Generated from always process in bitbang (bitbang.v:39)
-  process (clk) is
+  -- Generated from always process in bitbang (bitbang.v:32)
+  p_in_shift: process (resetn, clk) is
   begin
-    if rising_edge(clk) then
-      local_strobe <= '0';
-      if serial_control = X"fab1" then
-        data_Reg <= serial_data;
-        local_strobe <= '1';
+    if falling_edge(resetn) or rising_edge(clk) then
+      if (not resetn) = '1' then
+        serial_data <= X"00000000";
+        serial_control <= X"0000";
+      else
+        if (s_clk_sample(3) = '0') and (s_clk_sample(2) = '1') then
+          serial_data <= serial_data(0 + 30 downto 0) & s_data_sample(3);
+        end if;
+        if (s_clk_sample(3) = '1') and (s_clk_sample(2) = '0') then
+          serial_control <= serial_control(0 + 14 downto 0) & s_data_sample(3);
+        end if;
       end if;
-      old_local_strobe <= local_strobe;
-      strobe_Reg <= local_strobe and (not old_local_strobe);
     end if;
   end process;
   
-  -- Generated from always process in bitbang (bitbang.v:54)
-  process (clk) is
+  -- Generated from always process in bitbang (bitbang.v:50)
+  p_parallel_load: process (resetn, clk) is
   begin
-    if rising_edge(clk) then
-      if serial_control = X"fab1" then
-        active_Reg <= '1';
+    if falling_edge(resetn) or rising_edge(clk) then
+      if (not resetn) = '1' then
+        local_strobe <= '0';
+        data_Reg <= X"00000000";
+        old_local_strobe <= '0';
+        strobe_Reg <= '0';
+      else
+        local_strobe <= '0';
+        if serial_control = X"fab1" then
+          data_Reg <= serial_data;
+          local_strobe <= '1';
+        end if;
+        old_local_strobe <= local_strobe;
+        strobe_Reg <= local_strobe and (not old_local_strobe);
       end if;
-      if serial_control = X"fab0" then
+    end if;
+  end process;
+  
+  -- Generated from always process in bitbang (bitbang.v:72)
+  active_FSM: process (resetn, clk) is
+  begin
+    if falling_edge(resetn) or rising_edge(clk) then
+      if (not resetn) = '1' then
         active_Reg <= '0';
+      else
+        if serial_control = X"fab1" then
+          active_Reg <= '1';
+        end if;
+        if serial_control = X"fab0" then
+          active_Reg <= '0';
+        end if;
       end if;
     end if;
   end process;
 end architecture;
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/config_UART.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/config_UART.vhdl
@@ -1,5 +1,5 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
@@ -35,6 +35,10 @@ use ieee.numeric_std.all;
 --   Word2 = 2
 --   Word3 = 3
 entity config_UART is
+  generic(
+      ComRate : integer := 217;
+      Mode : integer := 0
+  );
   port (
     CLK : in std_logic;
     ComActive : out std_logic;
@@ -42,7 +46,8 @@ entity config_UART is
     ReceiveLED : out std_logic;
     Rx : in std_logic;
     WriteData : out unsigned(31 downto 0);
-    WriteStrobe : out std_logic
+    WriteStrobe : out std_logic;
+    resetn : in std_logic
   );
 end entity; 
 
@@ -84,44 +89,45 @@ architecture from_verilog of config_UART is
   signal ReceiveLED_Reg : std_logic;
   signal WriteData_Reg : unsigned(31 downto 0);
   signal WriteStrobe_Reg : std_logic;
-  signal ByteWriteStrobe : std_logic;  -- Declared at config_UART.v:97
-  signal CRCReg : unsigned(19 downto 0) := X"4fb00";  -- Declared at config_UART.v:103
-  signal ComCount : unsigned(11 downto 0);  -- Declared at config_UART.v:62
-  signal ComState : unsigned(3 downto 0) := X"0";  -- Declared at config_UART.v:67
-  signal ComTick : std_logic;  -- Declared at config_UART.v:63
-  signal Command_Reg : unsigned(7 downto 0);  -- Declared at config_UART.v:77
-  signal Data_Reg : unsigned(7 downto 0);  -- Declared at config_UART.v:78
-  signal GetWordState : unsigned(1 downto 0) := "00";  -- Declared at config_UART.v:93
-  signal HexData : unsigned(7 downto 0);  -- Declared at config_UART.v:59
-  signal HexValue : unsigned(4 downto 0);  -- Declared at config_UART.v:58
-  signal HexWriteStrobe : std_logic;  -- Declared at config_UART.v:60
-  signal HighReg : unsigned(3 downto 0);  -- Declared at config_UART.v:57
-  signal ID_Reg : unsigned(23 downto 0);  -- Declared at config_UART.v:73
-  signal LocalWriteStrobe : std_logic;  -- Declared at config_UART.v:95
-  signal PresentState : unsigned(2 downto 0) := "000";  -- Declared at config_UART.v:88
-  signal ReceiveState : std_logic := '1';  -- Declared at config_UART.v:56
-  signal ReceivedByte : unsigned(7 downto 0);  -- Declared at config_UART.v:80
-  signal ReceivedWord : unsigned(7 downto 0);  -- Declared at config_UART.v:68
-  signal RxLocal : std_logic;  -- Declared at config_UART.v:69
-  signal TimeToSend : std_logic;  -- Declared at config_UART.v:82
-  signal TimeToSendCounter : unsigned(14 downto 0);  -- Declared at config_UART.v:83
-  signal tmp_ivl_10 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_13 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_15 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_18 : unsigned(31 downto 0);  -- Temporary created at config_UART.v:399
-  signal tmp_ivl_2 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_21 : unsigned(28 downto 0);  -- Temporary created at config_UART.v:399
-  signal tmp_ivl_22 : unsigned(31 downto 0);  -- Temporary created at config_UART.v:87
-  signal tmp_ivl_24 : std_logic;  -- Temporary created at config_UART.v:399
-  signal tmp_ivl_26 : std_logic;  -- Temporary created at config_UART.v:399
-  signal tmp_ivl_28 : std_logic;  -- Temporary created at config_UART.v:399
-  signal tmp_ivl_4 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_7 : std_logic;  -- Temporary created at config_UART.v:396
-  signal tmp_ivl_8 : std_logic;  -- Temporary created at config_UART.v:396
-  signal b_counter : unsigned(19 downto 0) := X"4fb00";  -- Declared at config_UART.v:103
-  signal blink : unsigned(22 downto 0) := "00000000000000000000000";  -- Declared at config_UART.v:105
+  signal ByteWriteStrobe : std_logic;  -- Declared at config_UART.v:98
+  signal CRCReg : unsigned(19 downto 0);  -- Declared at config_UART.v:104
+  signal ComCount : unsigned(11 downto 0);  -- Declared at config_UART.v:63
+  signal ComState : unsigned(3 downto 0);  -- Declared at config_UART.v:68
+  signal ComTick : std_logic;  -- Declared at config_UART.v:64
+  signal Command_Reg : unsigned(7 downto 0);  -- Declared at config_UART.v:78
+  signal Data_Reg : unsigned(7 downto 0);  -- Declared at config_UART.v:79
+  signal GetWordState : unsigned(1 downto 0);  -- Declared at config_UART.v:94
+  signal HexData : unsigned(7 downto 0);  -- Declared at config_UART.v:60
+  signal HexValue : unsigned(4 downto 0);  -- Declared at config_UART.v:59
+  signal HexWriteStrobe : std_logic;  -- Declared at config_UART.v:61
+  signal HighReg : unsigned(3 downto 0);  -- Declared at config_UART.v:58
+  signal ID_Reg : unsigned(23 downto 0);  -- Declared at config_UART.v:74
+  signal LocalWriteStrobe : std_logic;  -- Declared at config_UART.v:96
+  signal PresentState : unsigned(2 downto 0);  -- Declared at config_UART.v:89
+  signal ReceiveState : std_logic;  -- Declared at config_UART.v:57
+  signal ReceivedByte : unsigned(7 downto 0);  -- Declared at config_UART.v:81
+  signal ReceivedWord : unsigned(7 downto 0);  -- Declared at config_UART.v:69
+  signal RxLocal : std_logic;  -- Declared at config_UART.v:70
+  signal Start_Reg : unsigned(31 downto 0);  -- Declared at config_UART.v:75
+  signal TimeToSend : std_logic;  -- Declared at config_UART.v:83
+  signal TimeToSendCounter : unsigned(14 downto 0);  -- Declared at config_UART.v:84
+  signal tmp_ivl_10 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_13 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_15 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_18 : unsigned(31 downto 0);  -- Temporary created at config_UART.v:437
+  signal tmp_ivl_2 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_21 : unsigned(28 downto 0);  -- Temporary created at config_UART.v:437
+  signal tmp_ivl_22 : unsigned(31 downto 0);  -- Temporary created at config_UART.v:88
+  signal tmp_ivl_24 : std_logic;  -- Temporary created at config_UART.v:437
+  signal tmp_ivl_26 : std_logic;  -- Temporary created at config_UART.v:437
+  signal tmp_ivl_28 : std_logic;  -- Temporary created at config_UART.v:437
+  signal tmp_ivl_4 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_7 : std_logic;  -- Temporary created at config_UART.v:434
+  signal tmp_ivl_8 : std_logic;  -- Temporary created at config_UART.v:434
+  signal b_counter : unsigned(19 downto 0);  -- Declared at config_UART.v:104
+  signal blink : unsigned(22 downto 0);  -- Declared at config_UART.v:106
   
-  -- Generated from function ASCII2HEX at config_UART.v:22
+  -- Generated from function ASCII2HEX at config_UART.v:23
   function ASCII2HEX (
     ASCII : unsigned(7 downto 0)
   ) 
@@ -199,10 +205,15 @@ begin
   tmp_ivl_4 <= '1';
   tmp_ivl_8 <= '0';
   
-  -- Generated from always process in L_hexmode (config_UART.v:278)
-  process (CLK) is
+  -- Generated from always process in L_hexmode (config_UART.v:293)
+  process (CLK, resetn) is
   begin
-    if rising_edge(CLK) then
+    if (not resetn) = '1' then
+      ReceiveState <= '1';
+      HexData <= X"00";
+      HighReg <= X"0";
+      HexWriteStrobe <= '0';
+    elsif rising_edge(CLK) then
       if Resize(PresentState, 32) /= X"00000006" then
         ReceiveState <= '1';
       else
@@ -227,111 +238,185 @@ begin
       end if;
     end if;
   end process;
-  -- Removed one empty process
   
-  -- Removed one empty process
-  
-  
-  -- Generated from always process in config_UART (config_UART.v:113)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:108)
+  P_sync: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      RxLocal <= Rx;
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
+        RxLocal <= '1';
+      else
+        RxLocal <= Rx;
+      end if;
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:118)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:116)
+  P_com_en: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      if Resize(ComState, 32) = X"00000000" then
-        ComCount <= X"06c";
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
+        ComCount <= X"000";
         ComTick <= '0';
       else
-        if Resize(ComCount, 32) = X"00000000" then
-          ComCount <= X"0d9";
-          ComTick <= '1';
-        else
-          ComCount <= ComCount - X"001";
+        if Resize(ComState, 32) = X"00000000" then
+          ComCount <= X"06c";
           ComTick <= '0';
+        else
+          if Resize(ComCount, 32) = X"00000000" then
+            ComCount <= X"0d9";
+            ComTick <= '1';
+          else
+            ComCount <= ComCount - X"001";
+            ComTick <= '0';
+          end if;
         end if;
       end if;
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:132)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:135)
+  P_COM: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      case ComState is
-        when X"0" =>
-          if RxLocal = '0' then
-            ComState <= X"1";
-            ReceivedWord <= X"00";
-          end if;
-        when X"1" =>
-          if ComTick = '1' then
-            ComState <= X"2";
-          end if;
-        when X"2" =>
-          if ComTick = '1' then
-            ComState <= X"3";
-            ReceivedWord(0) <= RxLocal;
-          end if;
-        when X"3" =>
-          if ComTick = '1' then
-            ComState <= X"4";
-            ReceivedWord(1) <= RxLocal;
-          end if;
-        when X"4" =>
-          if ComTick = '1' then
-            ComState <= X"5";
-            ReceivedWord(2) <= RxLocal;
-          end if;
-        when X"5" =>
-          if ComTick = '1' then
-            ComState <= X"6";
-            ReceivedWord(3) <= RxLocal;
-          end if;
-        when X"6" =>
-          if ComTick = '1' then
-            ComState <= X"7";
-            ReceivedWord(4) <= RxLocal;
-          end if;
-        when X"7" =>
-          if ComTick = '1' then
-            ComState <= "1000";
-            ReceivedWord(5) <= RxLocal;
-          end if;
-        when X"8" =>
-          if ComTick = '1' then
-            ComState <= "1001";
-            ReceivedWord(6) <= RxLocal;
-          end if;
-        when X"9" =>
-          if ComTick = '1' then
-            ComState <= "1010";
-            ReceivedWord(7) <= RxLocal;
-          end if;
-        when X"a" =>
-          if ComTick = '1' then
-            ComState <= X"0";
-          end if;
-        when others =>
-          null;
-      end case;
-      if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
+        ComState <= X"0";
+        ReceivedWord <= X"00";
+        ID_Reg <= X"000000";
+        Start_Reg <= X"00000000";
+        Command_Reg <= X"00";
+      else
+        case ComState is
+          when X"0" =>
+            if RxLocal = '0' then
+              ComState <= X"1";
+              ReceivedWord <= X"00";
+            end if;
+          when X"1" =>
+            if ComTick = '1' then
+              ComState <= X"2";
+            end if;
+          when X"2" =>
+            if ComTick = '1' then
+              ComState <= X"3";
+              ReceivedWord(0) <= RxLocal;
+            end if;
+          when X"3" =>
+            if ComTick = '1' then
+              ComState <= X"4";
+              ReceivedWord(1) <= RxLocal;
+            end if;
+          when X"4" =>
+            if ComTick = '1' then
+              ComState <= X"5";
+              ReceivedWord(2) <= RxLocal;
+            end if;
+          when X"5" =>
+            if ComTick = '1' then
+              ComState <= X"6";
+              ReceivedWord(3) <= RxLocal;
+            end if;
+          when X"6" =>
+            if ComTick = '1' then
+              ComState <= X"7";
+              ReceivedWord(4) <= RxLocal;
+            end if;
+          when X"7" =>
+            if ComTick = '1' then
+              ComState <= "1000";
+              ReceivedWord(5) <= RxLocal;
+            end if;
+          when X"8" =>
+            if ComTick = '1' then
+              ComState <= "1001";
+              ReceivedWord(6) <= RxLocal;
+            end if;
+          when X"9" =>
+            if ComTick = '1' then
+              ComState <= "1010";
+              ReceivedWord(7) <= RxLocal;
+            end if;
+          when X"a" =>
+            if ComTick = '1' then
+              ComState <= X"0";
+            end if;
+          when others =>
+            null;
+        end case;
+        if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+          case PresentState is
+            when "001" =>
+              ID_Reg(16 + 7 downto 16) <= ReceivedWord;
+            when "010" =>
+              ID_Reg(8 + 7 downto 8) <= ReceivedWord;
+            when "011" =>
+              ID_Reg(0 + 7 downto 0) <= ReceivedWord;
+            when "100" =>
+              Command_Reg <= ReceivedWord;
+            when "110" =>
+              Data_Reg <= ReceivedWord;
+            when others =>
+              null;
+          end case;
+        end if;
+      end if;
+    end if;
+  end process;
+  
+  -- Generated from always process in config_UART (config_UART.v:229)
+  P_FSM: process (resetn, CLK) is
+  begin
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
+        PresentState <= "000";
+      else
         case PresentState is
+          when "000" =>
+            if (Resize(ComState, 32) = X"00000000") and (RxLocal = '0') then
+              PresentState <= "001";
+            end if;
           when "001" =>
-            ID_Reg(16 + 7 downto 16) <= ReceivedWord;
+            if TimeToSend = '1' then
+              PresentState <= "000";
+            else
+              if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+                PresentState <= "010";
+              end if;
+            end if;
           when "010" =>
-            ID_Reg(8 + 7 downto 8) <= ReceivedWord;
+            if TimeToSend = '1' then
+              PresentState <= "000";
+            else
+              if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+                PresentState <= "011";
+              end if;
+            end if;
           when "011" =>
-            ID_Reg(0 + 7 downto 0) <= ReceivedWord;
+            if TimeToSend = '1' then
+              PresentState <= "000";
+            else
+              if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+                PresentState <= "100";
+              end if;
+            end if;
           when "100" =>
-            Command_Reg <= ReceivedWord;
+            if TimeToSend = '1' then
+              PresentState <= "000";
+            else
+              if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
+                PresentState <= "101";
+              end if;
+            end if;
+          when "101" =>
+            if (ID_Reg = X"00aaff") and ((Command_Reg(0 + 6 downto 0) = "0000001") or (Command_Reg(0 + 6 downto 0) = "0000010")) then
+              PresentState <= "110";
+            else
+              PresentState <= "000";
+            end if;
           when "110" =>
-            Data_Reg <= ReceivedWord;
+            if TimeToSend = '1' then
+              PresentState <= "000";
+            end if;
           when others =>
             null;
         end case;
@@ -339,175 +424,139 @@ begin
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:218)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:326)
+  P_checksum: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      case PresentState is
-        when "000" =>
-          if (Resize(ComState, 32) = X"00000000") and (RxLocal = '0') then
-            PresentState <= "001";
-          end if;
-        when "001" =>
-          if TimeToSend = '1' then
-            PresentState <= "000";
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
+        CRCReg <= X"4fb00";
+        b_counter <= X"4fb00";
+        blink <= "00000000000000000000000";
+      else
+        if Resize(PresentState, 32) = X"00000004" then
+          CRCReg <= X"00000";
+          b_counter <= X"00000";
+        else
+          if False or (True and (Command_Reg(7) = '1')) then
+            if ((((Resize(ComState, 32) = X"0000000a") and (ComTick = '1')) and (HexValue(4) = '0')) and (Resize(PresentState, 32) = X"00000006")) and ((unsigned'("0000000000000000000000000000000") & ReceiveState) = X"00000000") then
+              CRCReg <= CRCReg + Resize((HighReg & HexValue(0 + 3 downto 0)), 20);
+              b_counter <= b_counter + X"00001";
+            end if;
           else
-            if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
-              PresentState <= "010";
+            if ((Resize(ComState, 32) = X"0000000a") and (ComTick = '1')) and (Resize(PresentState, 32) = X"00000006") then
+              CRCReg <= CRCReg + Resize(ReceivedWord, 20);
+              b_counter <= b_counter + X"00001";
             end if;
           end if;
-        when "010" =>
-          if TimeToSend = '1' then
-            PresentState <= "000";
+        end if;
+        if Resize(PresentState, 32) = X"00000006" then
+          ReceiveLED_Reg <= '1';
+        else
+          if (Resize(PresentState, 32) = X"00000000") and (CRCReg /= X"4fb00") then
+            ReceiveLED_Reg <= blink(22);
           else
-            if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
-              PresentState <= "011";
-            end if;
+            ReceiveLED_Reg <= '0';
           end if;
-        when "011" =>
-          if TimeToSend = '1' then
-            PresentState <= "000";
-          else
-            if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
-              PresentState <= "100";
-            end if;
-          end if;
-        when "100" =>
-          if TimeToSend = '1' then
-            PresentState <= "000";
-          else
-            if (Resize(ComState, 32) = X"0000000a") and (ComTick = '1') then
-              PresentState <= "101";
-            end if;
-          end if;
-        when "101" =>
-          if (ID_Reg = X"00aaff") and ((Command_Reg(0 + 6 downto 0) = "0000001") or (Command_Reg(0 + 6 downto 0) = "0000010")) then
-            PresentState <= "110";
-          else
-            PresentState <= "000";
-          end if;
-        when "110" =>
-          if TimeToSend = '1' then
-            PresentState <= "000";
-          end if;
-        when others =>
-          null;
-      end case;
+        end if;
+        blink <= blink - "00000000000000000000001";
+      end if;
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:304)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:362)
+  P_bus: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      if Resize(PresentState, 32) = X"00000004" then
-        CRCReg <= X"00000";
-        b_counter <= X"00000";
-      else
-        if False or (True and (Command_Reg(7) = '1')) then
-          if ((((Resize(ComState, 32) = X"0000000a") and (ComTick = '1')) and (HexValue(4) = '0')) and (Resize(PresentState, 32) = X"00000006")) and ((unsigned'("0000000000000000000000000000000") & ReceiveState) = X"00000000") then
-            CRCReg <= CRCReg + Resize((HighReg & HexValue(0 + 3 downto 0)), 20);
-            b_counter <= b_counter + X"00001";
-          end if;
-        else
-          if ((Resize(ComState, 32) = X"0000000a") and (ComTick = '1')) and (Resize(PresentState, 32) = X"00000006") then
-            CRCReg <= CRCReg + Resize(ReceivedWord, 20);
-            b_counter <= b_counter + X"00001";
-          end if;
-        end if;
-      end if;
-      if Resize(PresentState, 32) = X"00000006" then
-        ReceiveLED_Reg <= '1';
-      else
-        if (Resize(PresentState, 32) = X"00000000") and (CRCReg /= X"4fb00") then
-          ReceiveLED_Reg <= blink(22);
-        else
-          ReceiveLED_Reg <= '0';
-        end if;
-      end if;
-      blink <= blink - "00000000000000000000001";
-    end if;
-  end process;
-  
-  -- Generated from always process in config_UART (config_UART.v:335)
-  process (CLK) is
-  begin
-    if rising_edge(CLK) then
-      if Resize(PresentState, 32) = X"00000005" then
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
         LocalWriteStrobe <= '0';
+        ByteWriteStrobe <= '0';
       else
-        if ((Resize(PresentState, 32) = X"00000006") and (Resize(ComState, 32) = X"0000000a")) and (ComTick = '1') then
-          LocalWriteStrobe <= '1';
-        else
+        if Resize(PresentState, 32) = X"00000005" then
           LocalWriteStrobe <= '0';
+        else
+          if ((Resize(PresentState, 32) = X"00000006") and (Resize(ComState, 32) = X"0000000a")) and (ComTick = '1') then
+            LocalWriteStrobe <= '1';
+          else
+            LocalWriteStrobe <= '0';
+          end if;
         end if;
-      end if;
-      if False or (True and (Command_Reg(7) = '0')) then
-        ByteWriteStrobe <= LocalWriteStrobe;
-      else
-        ByteWriteStrobe <= HexWriteStrobe;
+        if False or (True and (Command_Reg(7) = '0')) then
+          ByteWriteStrobe <= LocalWriteStrobe;
+        else
+          ByteWriteStrobe <= HexWriteStrobe;
+        end if;
       end if;
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:354)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:386)
+  P_WordMode: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      if Resize(PresentState, 32) = X"00000005" then
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
         GetWordState <= "00";
         WriteData_Reg <= X"00000000";
-      else
-        case GetWordState is
-          when "00" =>
-            if ByteWriteStrobe = '1' then
-              WriteData_Reg(24 + 7 downto 24) <= ReceivedByte;
-              GetWordState <= "01";
-            end if;
-          when "01" =>
-            if ByteWriteStrobe = '1' then
-              WriteData_Reg(16 + 7 downto 16) <= ReceivedByte;
-              GetWordState <= "10";
-            end if;
-          when "10" =>
-            if ByteWriteStrobe = '1' then
-              WriteData_Reg(8 + 7 downto 8) <= ReceivedByte;
-              GetWordState <= "11";
-            end if;
-          when "11" =>
-            if ByteWriteStrobe = '1' then
-              WriteData_Reg(0 + 7 downto 0) <= ReceivedByte;
-              GetWordState <= "00";
-            end if;
-          when others =>
-            null;
-        end case;
-      end if;
-      if (ByteWriteStrobe = '1') and (Resize(GetWordState, 32) = X"00000003") then
-        WriteStrobe_Reg <= '1';
-      else
         WriteStrobe_Reg <= '0';
+      else
+        if Resize(PresentState, 32) = X"00000005" then
+          GetWordState <= "00";
+          WriteData_Reg <= X"00000000";
+        else
+          case GetWordState is
+            when "00" =>
+              if ByteWriteStrobe = '1' then
+                WriteData_Reg(24 + 7 downto 24) <= ReceivedByte;
+                GetWordState <= "01";
+              end if;
+            when "01" =>
+              if ByteWriteStrobe = '1' then
+                WriteData_Reg(16 + 7 downto 16) <= ReceivedByte;
+                GetWordState <= "10";
+              end if;
+            when "10" =>
+              if ByteWriteStrobe = '1' then
+                WriteData_Reg(8 + 7 downto 8) <= ReceivedByte;
+                GetWordState <= "11";
+              end if;
+            when "11" =>
+              if ByteWriteStrobe = '1' then
+                WriteData_Reg(0 + 7 downto 0) <= ReceivedByte;
+                GetWordState <= "00";
+              end if;
+            when others =>
+              null;
+          end case;
+        end if;
+        if (ByteWriteStrobe = '1') and (Resize(GetWordState, 32) = X"00000003") then
+          WriteStrobe_Reg <= '1';
+        else
+          WriteStrobe_Reg <= '0';
+        end if;
       end if;
     end if;
   end process;
   
-  -- Generated from always process in config_UART (config_UART.v:401)
-  process (CLK) is
+  -- Generated from always process in config_UART (config_UART.v:439)
+  P_TimeOut: process (resetn, CLK) is
   begin
-    if rising_edge(CLK) then
-      if (Resize(PresentState, 32) = X"00000000") or (Resize(ComState, 32) = X"0000000a") then
+    if falling_edge(resetn) or rising_edge(CLK) then
+      if (not resetn) = '1' then
         TimeToSendCounter <= "100000110001000";
-        TimeToSend <= '0';
+        TimeToSendCounter <= "000000000000000";
       else
-        if Resize(TimeToSendCounter, 32) > X"00000000" then
-          TimeToSendCounter <= TimeToSendCounter - "000000000000001";
+        if (Resize(PresentState, 32) = X"00000000") or (Resize(ComState, 32) = X"0000000a") then
+          TimeToSendCounter <= "100000110001000";
           TimeToSend <= '0';
         else
-          TimeToSendCounter <= TimeToSendCounter;
-          TimeToSend <= '1';
+          if Resize(TimeToSendCounter, 32) > X"00000000" then
+            TimeToSendCounter <= TimeToSendCounter - "000000000000001";
+            TimeToSend <= '0';
+          else
+            TimeToSendCounter <= TimeToSendCounter;
+            TimeToSend <= '1';
+          end if;
         end if;
       end if;
     end if;
   end process;
 end architecture;
-

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/eFPGA_Config.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/eFPGA_Config.vhdl
@@ -1,10 +1,15 @@
 -- This VHDL was converted from Verilog using the
--- Icarus Verilog VHDL Code Generator 11.0 (stable) ()
+-- Icarus Verilog VHDL Code Generator 13.0 (devel) (s20221226-518-g94d9d1951)
 
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
+-- Generated from Verilog module eFPGA_Config (eFPGA_Config.v:1)
+--   FrameBitsPerRow = 32
+--   NumberOfRows = 16
+--   RowSelectWidth = 5
+--   desync_flag = 20
 entity eFPGA_Config is
   generic (
     RowSelectWidth : integer := 5;
@@ -15,31 +20,34 @@ entity eFPGA_Config is
   port (
     CLK : in std_logic;
     ComActive : out std_logic;
-    ConfigWriteData : out std_logic_vector(31 downto 0);
+    ConfigWriteData : out STD_LOGIC_VECTOR(31 downto 0);
     ConfigWriteStrobe : out std_logic;
     FrameAddressRegister : out std_logic_vector(31 downto 0);
     LongFrameStrobe : out std_logic;
     ReceiveLED : out std_logic;
     RowSelect : out std_logic_vector(4 downto 0);
     Rx : in std_logic;
-    SelfWriteData : in std_logic_vector(31 downto 0);
+    SelfWriteData : in STD_LOGIC_VECTOR(31 downto 0);
     SelfWriteStrobe : in std_logic;
+    resetn : in std_logic;
     s_clk : in std_logic;
     s_data : in std_logic
   );
 end entity; 
 
--- Generated from Verilog module Config (Config_template.v:1)
+-- Generated from Verilog module eFPGA_Config (eFPGA_Config.v:1)
 --   FrameBitsPerRow = 32
+--   NumberOfRows = 16
 --   RowSelectWidth = 5
+--   desync_flag = 20
 architecture from_verilog of eFPGA_Config is
   signal BitBangActive : std_logic := '0'; 
-  signal BitBangWriteData : std_logic_vector(31 downto 0); 
+  signal BitBangWriteData : std_logic_vector(31 downto 0);
   signal BitBangWriteData_Mux : std_logic_vector(31 downto 0);  
   signal BitBangWriteStrobe : std_logic := '0';  
   signal BitBangWriteStrobe_Mux : std_logic := '0';  
   signal Command : unsigned(7 downto 0);  
-  signal Reset : std_logic := '0';  
+  signal FSM_Reset : std_logic := '0';  
   signal UART_ComActive : std_logic := '0';  
   signal UART_LED : std_logic := '0';  
   signal UART_WriteData : unsigned(31 downto 0);  
@@ -56,14 +64,15 @@ architecture from_verilog of eFPGA_Config is
     );
     port (
       CLK : in std_logic;
+      FSM_Reset : in std_logic;
       FrameAddressRegister : out std_logic_vector(31 downto 0);
       LongFrameStrobe : out std_logic;
-      Reset : in std_logic;
       RowSelect : out std_logic_vector(4 downto 0);
       WriteData : in std_logic_vector(31 downto 0);
-      WriteStrobe : in std_logic
+      WriteStrobe : in std_logic;
+      resetn : in std_logic
     );
- end component;
+  end component;
   signal FrameAddressRegister_Readable : std_logic_vector(31 downto 0);  -- Needed to connect outputs
   signal LongFrameStrobe_Readable : std_logic;  -- Needed to connect outputs
   signal RowSelect_Readable : std_logic_vector(4 downto 0);  -- Needed to connect outputs
@@ -76,7 +85,8 @@ architecture from_verilog of eFPGA_Config is
       ReceiveLED : out std_logic;
       Rx : in std_logic;
       WriteData : out unsigned(31 downto 0);
-      WriteStrobe : out std_logic
+      WriteStrobe : out std_logic;
+      resetn : in std_logic
     );
   end component;
   
@@ -85,6 +95,7 @@ architecture from_verilog of eFPGA_Config is
       active : out std_logic;
       clk : in std_logic;
       data : out std_logic_vector(31 downto 0);
+      resetn : in std_logic;
       s_clk : in std_logic;
       s_data : in std_logic;
       strobe : out std_logic
@@ -93,10 +104,10 @@ architecture from_verilog of eFPGA_Config is
 begin
   ConfigWriteData <= UART_WriteData_Mux;
   ConfigWriteStrobe <= UART_WriteStrobe_Mux;
-  Reset <= UART_ComActive or BitBangActive;
+  FSM_Reset <= UART_ComActive or BitBangActive;
   ComActive <= UART_ComActive;
   ReceiveLED <= UART_LED xor BitBangWriteStrobe;
-  BitBangWriteData_Mux <= std_logic_vector(BitBangWriteData) when BitBangActive = '1' else SelfWriteData;
+  BitBangWriteData_Mux <= BitBangWriteData when BitBangActive = '1' else SelfWriteData;
   BitBangWriteStrobe_Mux <= BitBangWriteStrobe when BitBangActive = '1' else SelfWriteStrobe;
   UART_WriteData_Mux <= std_logic_vector(UART_WriteData) when UART_ComActive = '1' else BitBangWriteData_Mux;
   UART_WriteStrobe_Mux <= UART_WriteStrobe when UART_ComActive = '1' else BitBangWriteStrobe_Mux;
@@ -104,19 +115,20 @@ begin
   LongFrameStrobe <= LongFrameStrobe_Readable;
   RowSelect <= RowSelect_Readable;
   
-  -- Generated from instantiation at Config_template.v:81
+  -- Generated from instantiation at eFPGA_Config.v:90
   ConfigFSM_inst: ConfigFSM
     port map (
       CLK => CLK,
+      FSM_Reset => FSM_Reset,
       FrameAddressRegister => FrameAddressRegister_Readable,
       LongFrameStrobe => LongFrameStrobe_Readable,
-      Reset => Reset,
       RowSelect => RowSelect_Readable,
       WriteData => UART_WriteData_Mux,
-      WriteStrobe => UART_WriteStrobe_Mux
+      WriteStrobe => UART_WriteStrobe_Mux,
+      resetn => resetn
     );
   
-  -- Generated from instantiation at Config_template.v:41
+  -- Generated from instantiation at eFPGA_Config.v:42
   INST_config_UART: config_UART
     port map (
       CLK => CLK,
@@ -125,15 +137,17 @@ begin
       ReceiveLED => UART_LED,
       Rx => Rx,
       WriteData => UART_WriteData,
-      WriteStrobe => UART_WriteStrobe
+      WriteStrobe => UART_WriteStrobe,
+      resetn => resetn
     );
   
-  -- Generated from instantiation at Config_template.v:52
+  -- Generated from instantiation at eFPGA_Config.v:54
   Inst_bitbang: bitbang
     port map (
       active => BitBangActive,
       clk => CLK,
       data => BitBangWriteData,
+      resetn => resetn,
       s_clk => s_clk,
       s_data => s_data,
       strobe => BitBangWriteStrobe

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/my_lib.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/my_lib.vhdl
@@ -15,7 +15,7 @@ architecture from_verilog of LHQD1 is
 begin
   process (E, D) is
   begin
-    if rising_edge(E) then
+    if E = '1' then
       Q <= D;
       QN <= not D;
     end if;
@@ -99,7 +99,7 @@ begin
          IN2  when "01",
          IN3  when "10",
          IN4  when "11",
-         'U'  when others ;
+         '0'  when others ;
   
 end architecture;
 
@@ -249,14 +249,45 @@ architecture from_verilog of cus_mux41 is
   signal X_reg : std_logic;
   signal LPM_d0_ivl_1 : std_logic;
   signal LPM_d1_ivl_1 : std_logic;
+
+  component my_buf is 
+  port
+  (
+    A : in std_logic;
+    X : out std_logic
+  );
+  end component;
+  signal AIN : std_logic_vector(3 downto 0);
+
 begin
   SEL <= S1 & S0;
 
+  my_buf_inst0: my_buf
+    port map (
+      A => A0,
+      X => AIN(0)
+    );
+  my_buf_inst1: my_buf
+    port map (
+      A => A1,
+      X => AIN(1)
+    );
+  my_buf_inst2: my_buf
+    port map (
+      A => A2,
+      X => AIN(2)
+    );
+  my_buf_inst3: my_buf
+    port map (
+      A => A3,
+      X => AIN(3)
+    );  
+
   with SEL select
-    X <= A0  when "00",
-         A1  when "01",
-         A2  when "10",
-         A3  when "11",
+    X <= AIN(0)  when "00",
+         AIN(1)  when "01",
+         AIN(2)  when "10",
+         AIN(3)  when "11",
          'U'  when others;
 
 end architecture;
@@ -406,15 +437,46 @@ architecture from_verilog of cus_mux41_buf is
   signal SEL : unsigned(1 downto 0); 
   signal LPM_d0_ivl_1 : std_logic;
   signal LPM_d1_ivl_1 : std_logic;
+
+  component my_buf is
+  port
+  (
+    A : in std_logic;
+    X : out std_logic
+  );
+  end component;
+  signal AIN : std_logic_vector(3 downto 0);
+
 begin
   SEL <= S1 & S0;
-  with SEL select
-    X <= A0  when "00",
-         A1  when "01",
-         A2  when "10",
-         A3  when "11",
-        'U'  when others;
 
+  my_buf_inst0: my_buf
+    port map (
+      A => A0,
+      X => AIN(0)
+    );
+  my_buf_inst1: my_buf  
+    port map (
+      A => A1,
+      X => AIN(1)
+    );
+  my_buf_inst2: my_buf
+    port map (
+      A => A2,
+      X => AIN(2)
+    );
+  my_buf_inst3: my_buf
+   port map (
+      A => A3,
+      X => AIN(3)
+    );
+
+  with SEL select
+    X <= AIN(0)  when "00",
+         AIN(1)  when "01",
+         AIN(2)  when "10",
+         AIN(3)  when "11",
+        'U'  when others;
 end architecture;
 
 library ieee;
@@ -521,12 +583,33 @@ end entity;
 
 architecture from_verilog of my_mux2 is
   signal SEL : std_logic;
+  
+  component my_buf is
+  port
+  (
+    A : in std_logic;
+    X : out std_logic
+  );
+  end component;
+  signal AIN : std_logic_vector(1 downto 0);
+
 begin
   SEL <= S;
 
+  my_buf_inst0: my_buf
+    port map (
+      A => A0,
+      X => AIN(0)
+    );
+  my_buf_inst1: my_buf
+    port map (
+      A => A1,
+      X => AIN(1)
+    );
+
   with SEL select
-    X <= A0  when '0',
-         A1  when '1',
+    X <= AIN(0)  when '0',
+         AIN(1)  when '1',
         'U'  when others;
   
 end architecture;

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Test/build_test_design.sh
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Test/build_test_design.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-
-SYNTH_TCL=../../nextpnr/fabulous/synth/synth_fabulous.tcl
-BIT_GEN=../../nextpnr/fabulous/fab_arch/bit_gen.py
-
+SYNTH_TCL=./synth/synth_fabulous.tcl
+BIT_GEN=bit_gen
 
 DESIGN=counter
 
 set -ex
-yosys -qp "tcl $SYNTH_TCL 4 top_wrapper test_design/${DESIGN}.json" test_design/${DESIGN}.v test_design/top_wrapper.v
-# yosys -qp "tcl $SYNTH_TCL 4 top_wrapper test_design/${DESIGN}.json" ../generic/IO_1_bidirectional_frame_config_pass.v test_design/${DESIGN}.v test_design/top_wrapper.v
+yosys -m ghdl -p "ghdl test_design/${DESIGN}.vhdl -e top; read_verilog test_design/top_wrapper.v; tcl $SYNTH_TCL 4 top_wrapper test_design/${DESIGN}.json;"
 
 FAB_ROOT=.. nextpnr-generic --uarch fabulous --json test_design/${DESIGN}.json -o fasm=test_design/${DESIGN}_des.fasm
-python3 ${BIT_GEN} -genBitstream test_design/${DESIGN}_des.fasm ../.FABulous/bitStreamSpec.bin test_design/${DESIGN}.bin
+${BIT_GEN} -genBitstream test_design/${DESIGN}_des.fasm ../.FABulous/bitStreamSpec.bin test_design/${DESIGN}.bin

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Test/sequential_16bit_en_tb.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Test/sequential_16bit_en_tb.vhdl
@@ -1,0 +1,170 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use std.textio.all;
+use std.env.finish;
+
+entity sequential_16bit_en_tb is
+end sequential_16bit_en_tb; 
+
+architecture Behavior of sequential_16bit_en_tb is
+  component top is 
+    port (
+      clk : in std_logic;
+      io_out: out std_logic_vector(27 downto 0);
+      io_oeb: out std_logic_vector(27 downto 0);
+      io_in: in std_logic_vector(27 downto 0)
+    );
+  end component;
+
+  constant MAX_BITBYTES:integer := 16384;
+
+  
+  signal I_top : std_logic_vector( 27 downto 0) := X"0000000";
+  signal T_top : std_logic_vector(27 downto 0) := X"0000000";
+  signal O_top : std_logic_vector( 27 downto 0) := X"0000001";
+  signal A_cfg: std_logic_vector(55 downto 0) :=  X"00000000000000";
+  signal B_cfg: std_logic_vector(55 downto 0) :=  X"00000000000000";
+  signal C_cfg: std_logic_vector(55 downto 0) :=  X"00000000000000";
+  signal I_top_gold : std_logic_vector(27 downto 0) := X"0000000";  
+  signal T_top_gold : std_logic_vector(27 downto 0) := X"0000000";  
+  signal resetn : std_logic := '1';
+  signal CLK : std_logic := '0';  
+  signal SelfWriteStrobe : std_logic := '0'; 
+  signal SelfWriteData : std_logic_vector(31 downto 0) := X"00000000";  
+  signal ComActive : std_logic;  
+  signal Rx : std_logic := '1'; 
+  signal s_clk : std_logic := '0'; 
+  signal s_data : std_logic := '0';  
+  signal ReceiveLED : std_logic := '0';  
+  
+  type bitstream_Type is array (MAX_BITBYTES-1 downto 0) of std_logic_vector(7 downto 0);
+  signal bitstream : bitstream_Type;
+
+  signal O_top_unsigned : unsigned(27 downto 0) :=X"0000000";
+
+  impure function readmemh(filename : string) return bitstream_Type is
+    variable bs : bitstream_Type;
+    file read_file: text open READ_MODE is "../user_design/sequential_16bit_en.hex";
+    variable counter : integer := 0;
+    variable L: LINE;
+    variable temp: std_logic_vector(7 downto 0);
+    variable good_v : boolean := true;
+    begin
+      while not endfile(read_file) loop
+        readline (read_file, L);
+        hread (L, temp, good_v);
+        bs(counter) := temp;
+        counter := counter + 1;
+      end loop;
+    return bs;
+  end function;
+
+begin
+  O_top_unsigned <= unsigned(O_top);
+  init_eFPGA : entity work.eFPGA_top port map (
+        I_top => I_top,
+        T_top => T_top,
+        O_top => O_top,
+        A_config_C => A_cfg, 
+        B_config_C => B_cfg,
+        Config_accessC => C_cfg,
+        CLK => CLK, 
+        resetn => resetn,
+        SelfWriteStrobe => SelfWriteStrobe, 
+        SelfWriteData => SelfWriteData,
+        Rx => Rx,
+        ComActive => ComActive,
+        ReceiveLED => ReceiveLED,
+        s_clk => s_clk,
+        s_data => s_data
+    );
+
+    init_top: top 
+      port map (
+        clk => CLK,
+        io_out => I_top_gold,
+        io_oeb => T_top_gold,
+        io_in => O_top--_unsigned
+      );
+  
+
+  clock:  process is
+          begin
+            wait for 5000 ps;
+            CLK <= not CLK;
+          end process clock;
+
+  final:process is
+    variable i : integer := 0;
+    variable j : integer := 0; 
+  begin
+    while i < MAX_BITBYTES loop
+      bitstream(i) <= X"00";
+      i := i + 1;
+    end loop;
+
+    j := 0;
+    bitstream <= readmemh("../user_design/sequential_16bit_en.hex");
+    report "Bitstream loaded into memory array";
+    wait for 100 ps;
+    resetn <= '0';
+    wait for 10000 ps;
+    resetn <= '1';
+    wait for 10000 ps;
+    for Verilog_Repeat in 1 to 20 loop
+      wait until rising_edge(CLK);
+    end loop;
+    
+    wait for 2500 ps;
+      
+    while j <= MAX_BITBYTES - 4 loop
+      SelfWriteData <= bitstream(j) & bitstream(j+1) &  bitstream(j+2) & bitstream(j+3);
+      -- wait 2 clock cycles
+      wait until rising_edge(CLK);
+      wait until rising_edge(CLK);
+
+      -- report integer'image(i) & " " & to_hstring(SelfWriteData); 
+      SelfWriteStrobe <= '1';
+      wait until rising_edge(CLK);
+      SelfWriteStrobe <= '0';
+
+      -- wait another 2 clock cycles
+      wait until rising_edge(CLK);
+      wait until rising_edge(CLK);
+
+      j := j + 4;
+    end loop;
+
+    -- wait 100 clock cycles
+    for Verilog_Repeat in 1 to 100 loop
+      wait until rising_edge(CLK);
+    end loop;
+    report "Configuration completed";
+
+    O_top <= X"0000001";
+    wait until rising_edge(CLK);
+
+    -- wait 5 clock cycles
+    for Verilog_Repeat in 1 to 5 loop
+      wait until rising_edge(CLK);
+    end loop;
+
+    O_top <= X"0000000";
+    for Verilog_Repeat in 1 to 1000 loop
+      wait until rising_edge(CLK);
+    end loop;
+
+    for Verilog_Repeat in 0 to 100 loop
+      wait until falling_edge(CLK);
+      report "fabric(I_top) = 0x" & to_hstring(I_top) & " gold = 0x" & to_hstring(I_top_gold) & " fabric(T_top) = 0x" & to_hstring(T_top) & " gold = 0x" & to_hstring(T_top_gold);
+      if To_integer(unsigned(I_top)) /= To_integer(unsigned(I_top_gold)) then
+        report "Error: Miss match between fabric output and golden " severity error; 
+      end if;
+    end loop;
+    report "SIMULATION FINISHED";
+    report "Calling finish";
+    finish;
+  end process final;
+end architecture;
+

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Test/vhdl_simulation.sh
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Test/vhdl_simulation.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+DEFINED_OPTION=$1
+DESIGN=$2
+PROJECT=$3
+mkdir -p $PROJECT/ghdl_simul_files
+OUTPUTdir=$PROJECT/ghdl_simul_files
+FLAG="--std=08 -O2 --workdir=$OUTPUTdir -fexplicit"
+eFLAG="--std=08 -O2"
+GHDL=ghdl
+VHDL=$PROJECT/Tile
+FABRIC=$PROJECT/Fabric
+ulimit -s unlimited
+
+echo "Crrent working directory: $(pwd)"
+echo "Script is located at: $(dirname "$(readlink -f "$0")")"
+
+$GHDL -a $FLAG $FABRIC/my_lib.vhdl
+cd $PROJECT/ghdl_simul_files
+echo "Current working directory: $(pwd)"
+$GHDL -e $eFLAG LHQD1 
+$GHDL -e $eFLAG MUX4PTv4 
+$GHDL -e $eFLAG MUX16PTv2
+$GHDL -e $eFLAG cus_mux161
+$GHDL -e $eFLAG cus_mux41
+$GHDL -e $eFLAG cus_mux161_buf
+$GHDL -e $eFLAG cus_mux41_buf
+$GHDL -e $eFLAG cus_mux81
+$GHDL -e $eFLAG my_mux2
+$GHDL -e $eFLAG cus_mux81_buf
+$GHDL -e $eFLAG my_buf
+$GHDL -e $eFLAG clk_buf
+cd ../../
+echo "Current working directory: $(pwd)"
+
+$GHDL -a $FLAG $VHDL/LUT4AB/LUT4AB_switch_matrix.vhdl \
+              $VHDL/LUT4AB/LUT4AB_ConfigMem.vhdl \
+              $VHDL/LUT4AB/LUT4c_frame_config.vhdl \
+              $VHDL/LUT4AB/MUX8LUT_frame_config.vhdl \
+              $VHDL/LUT4AB/LUT4AB.vhdl
+
+$GHDL -a $FLAG $VHDL/RAM_IO/RAM_IO_switch_matrix.vhdl \
+              $VHDL/RAM_IO/RAM_IO_ConfigMem.vhdl \
+              $VHDL/RAM_IO/InPass4_frame_config.vhdl \
+              $VHDL/RAM_IO/OutPass4_frame_config.vhdl \
+              $VHDL/RAM_IO/RAM_IO.vhdl
+
+$GHDL -a $FLAG $VHDL/RegFile/RegFile_switch_matrix.vhdl \
+              $VHDL/RegFile/RegFile_ConfigMem.vhdl \
+              $VHDL/RegFile/RegFile_32x4.vhdl \
+              $VHDL/RegFile/RegFile.vhdl
+
+
+$GHDL -a $FLAG $VHDL/W_IO/W_IO_switch_matrix.vhdl \
+              $VHDL/W_IO/W_IO_ConfigMem.vhdl \
+              $VHDL/W_IO/IO_1_bidirectional_frame_config_pass.vhdl \
+              $VHDL/W_IO/Config_access.vhdl \
+              $VHDL/W_IO/W_IO.vhdl
+
+
+$GHDL -a $FLAG $VHDL/DSP/DSP_top/DSP_top_switch_matrix.vhdl \
+              $VHDL/DSP/DSP_top/DSP_top_ConfigMem.vhdl \
+              $VHDL/DSP/DSP_top/DSP_top.vhdl
+
+
+$GHDL -a $FLAG $VHDL/DSP/DSP_bot/DSP_bot_switch_matrix.vhdl \
+              $VHDL/DSP/DSP_bot/DSP_bot_ConfigMem.vhdl \
+              $VHDL/DSP/DSP_bot/MULADD.vhdl \
+              $VHDL/DSP/DSP_bot/DSP_bot.vhdl
+
+
+$GHDL -a $FLAG $VHDL/DSP/DSP_top/DSP_top.vhdl \
+                $VHDL/DSP/DSP_bot/DSP_bot.vhdl \
+                $VHDL/DSP/DSP.vhdl
+
+
+$GHDL -a $FLAG $VHDL/N_term_DSP/N_term_DSP_switch_matrix.vhdl \
+              $VHDL/N_term_DSP/N_term_DSP_ConfigMem.vhdl \
+              $VHDL/N_term_DSP/N_term_DSP.vhdl
+
+
+$GHDL -a $FLAG $VHDL/S_term_DSP/S_term_DSP_switch_matrix.vhdl \
+              $VHDL/S_term_DSP/S_term_DSP_ConfigMem.vhdl \
+              $VHDL/S_term_DSP/S_term_DSP.vhdl
+
+
+$GHDL -a $FLAG $VHDL/N_term_RAM_IO/N_term_RAM_IO_switch_matrix.vhdl \
+              $VHDL/N_term_RAM_IO/N_term_RAM_IO_ConfigMem.vhdl \
+              $VHDL/N_term_RAM_IO/N_term_RAM_IO.vhdl
+
+
+$GHDL -a $FLAG $VHDL/S_term_RAM_IO/S_term_RAM_IO_switch_matrix.vhdl \
+              $VHDL/S_term_RAM_IO/S_term_RAM_IO_ConfigMem.vhdl \
+              $VHDL/S_term_RAM_IO/S_term_RAM_IO.vhdl
+
+
+$GHDL -a $FLAG $VHDL/N_term_single/N_term_single_switch_matrix.vhdl \
+              $VHDL/N_term_single/N_term_single_ConfigMem.vhdl \
+              $VHDL/N_term_single/N_term_single.vhdl
+
+
+$GHDL -a $FLAG $VHDL/S_term_single/S_term_single_switch_matrix.vhdl \
+              $VHDL/S_term_single/S_term_single_ConfigMem.vhdl \
+              $VHDL/S_term_single/S_term_single.vhdl
+
+
+$GHDL -a $FLAG $VHDL/N_term_single2/N_term_single2_switch_matrix.vhdl \
+              $VHDL/N_term_single2/N_term_single2_ConfigMem.vhdl \
+              $VHDL/N_term_single2/N_term_single2.vhdl
+
+
+$GHDL -a $FLAG $VHDL/S_term_single2/S_term_single2_switch_matrix.vhdl \
+              $VHDL/S_term_single2/S_term_single2_ConfigMem.vhdl \
+              $VHDL/S_term_single2/S_term_single2.vhdl
+
+
+$GHDL -a $FLAG $FABRIC/config_UART.vhdl 
+$GHDL -a $FLAG $FABRIC/bitbang.vhdl
+$GHDL -a $FLAG $FABRIC/ConfigFSM.vhdl 
+$GHDL -a $FLAG $FABRIC/eFPGA_Config.vhdl 
+$GHDL -a $FLAG $FABRIC/Frame_Data_Reg.vhdl 
+$GHDL -a $FLAG $FABRIC/Frame_Select.vhdl 
+$GHDL -a $FLAG $FABRIC/BlockRAM_1KB.vhdl
+$GHDL -a $FLAG $FABRIC/eFPGA.vhdl
+$GHDL -a $FLAG $FABRIC/eFPGA_top.vhdl 
+
+$GHDL -a $FLAG $PROJECT/user_design/${DESIGN}.vhdl 
+$GHDL -a $FLAG $PROJECT/Test/${DESIGN}_tb.vhdl
+
+cd $PROJECT/ghdl_simul_files
+$GHDL -e $eFLAG "-fexplicit" ${DESIGN}_tb 
+$GHDL -r $eFLAG ${DESIGN}_tb --stats --ieee-asserts=disable --${DEFINED_OPTION}=../Test/${DESIGN}_tb.${DEFINED_OPTION}
+cd ../../
+rm -rf $PROJECT/ghdl_simul_files

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/sequential_16bit_en.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/sequential_16bit_en.vhdl
@@ -5,15 +5,15 @@ use ieee.numeric_std.all;
 entity top is
     port (
         clk    : in  std_logic;
-        io_in  : in  std_logic_vector(30 downto 0);
-        io_out : out std_logic_vector(30 downto 0);
+        io_in  : in  std_logic_vector(27 downto 0);
+        io_out : out std_logic_vector(27 downto 0);
         io_oeb : out std_logic_vector(27 downto 0)
     );
 end top;
 
 architecture Behavioral of top is
     signal rst      : std_logic;
-    signal ctr      : unsigned(23 downto 0) := (others => '0');
+    signal ctr      : unsigned(26 downto 0) := (others => '0');
     
 begin
     rst <= io_in(0);
@@ -29,7 +29,7 @@ begin
         end if;
     end process;
 
-    io_out(30 downto 1) <= "111111" & std_logic_vector(ctr(23 downto 0));
+    io_out(27 downto 1) <= std_logic_vector(ctr(26 downto 0));
     io_out(0) <= '0';
     io_oeb(27 downto 1)<= (others => '1');
     io_oeb(0) <= '0';

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/sequential_16bit_en.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/sequential_16bit_en.vhdl
@@ -1,0 +1,36 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity top is
+    port (
+        clk    : in  std_logic;
+        io_in  : in  std_logic_vector(30 downto 0);
+        io_out : out std_logic_vector(30 downto 0);
+        io_oeb : out std_logic_vector(27 downto 0)
+    );
+end top;
+
+architecture Behavioral of top is
+    signal rst      : std_logic;
+    signal ctr      : unsigned(23 downto 0) := (others => '0');
+    
+begin
+    rst <= io_in(0);
+
+    process(clk)
+    begin
+        if rising_edge(clk) then
+            if rst = '1' then
+                ctr <= (others => '0');
+            else
+                ctr <= ctr + 1;
+            end if;
+        end if;
+    end process;
+
+    io_out(30 downto 1) <= "111111" & std_logic_vector(ctr(23 downto 0));
+    io_out(0) <= '0';
+    io_oeb(27 downto 1)<= (others => '1');
+    io_oeb(0) <= '0';
+end Behavioral;

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/top_wrapper.v
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/user_design/top_wrapper.v
@@ -1,0 +1,41 @@
+// TODO: find a more fun test design
+
+module top_wrapper;
+
+wire [27:0] io_in, io_out, io_oeb;
+(* keep, BEL="X0Y1.A" *) IO_1_bidirectional_frame_config_pass io27_i (.O(io_in[27]), .I(io_out[27]), .T(io_oeb[27]));
+(* keep, BEL="X0Y1.B" *) IO_1_bidirectional_frame_config_pass io26_i (.O(io_in[26]), .I(io_out[26]), .T(io_oeb[26]));
+(* keep, BEL="X0Y2.A" *) IO_1_bidirectional_frame_config_pass io25_i (.O(io_in[25]), .I(io_out[25]), .T(io_oeb[25]));
+(* keep, BEL="X0Y2.B" *) IO_1_bidirectional_frame_config_pass io24_i (.O(io_in[24]), .I(io_out[24]), .T(io_oeb[24]));
+(* keep, BEL="X0Y3.A" *) IO_1_bidirectional_frame_config_pass io23_i (.O(io_in[23]), .I(io_out[23]), .T(io_oeb[23]));
+(* keep, BEL="X0Y3.B" *) IO_1_bidirectional_frame_config_pass io22_i (.O(io_in[22]), .I(io_out[22]), .T(io_oeb[22]));
+(* keep, BEL="X0Y4.A" *) IO_1_bidirectional_frame_config_pass io21_i (.O(io_in[21]), .I(io_out[21]), .T(io_oeb[21]));
+(* keep, BEL="X0Y4.B" *) IO_1_bidirectional_frame_config_pass io20_i (.O(io_in[20]), .I(io_out[20]), .T(io_oeb[20]));
+(* keep, BEL="X0Y5.A" *) IO_1_bidirectional_frame_config_pass io19_i (.O(io_in[19]), .I(io_out[19]), .T(io_oeb[19]));
+(* keep, BEL="X0Y5.B" *) IO_1_bidirectional_frame_config_pass io18_i (.O(io_in[18]), .I(io_out[18]), .T(io_oeb[18]));
+(* keep, BEL="X0Y6.A" *) IO_1_bidirectional_frame_config_pass io17_i (.O(io_in[17]), .I(io_out[17]), .T(io_oeb[17]));
+(* keep, BEL="X0Y6.B" *) IO_1_bidirectional_frame_config_pass io16_i (.O(io_in[16]), .I(io_out[16]), .T(io_oeb[16]));
+(* keep, BEL="X0Y7.A" *) IO_1_bidirectional_frame_config_pass io15_i (.O(io_in[15]), .I(io_out[15]), .T(io_oeb[15]));
+(* keep, BEL="X0Y7.B" *) IO_1_bidirectional_frame_config_pass io14_i (.O(io_in[14]), .I(io_out[14]), .T(io_oeb[14]));
+(* keep, BEL="X0Y8.A" *) IO_1_bidirectional_frame_config_pass io13_i (.O(io_in[13]), .I(io_out[13]), .T(io_oeb[13]));
+(* keep, BEL="X0Y8.B" *) IO_1_bidirectional_frame_config_pass io12_i (.O(io_in[12]), .I(io_out[12]), .T(io_oeb[12]));
+(* keep, BEL="X0Y9.A" *) IO_1_bidirectional_frame_config_pass io11_i (.O(io_in[11]), .I(io_out[11]), .T(io_oeb[11]));
+(* keep, BEL="X0Y9.B" *) IO_1_bidirectional_frame_config_pass io10_i (.O(io_in[10]), .I(io_out[10]), .T(io_oeb[10]));
+(* keep, BEL="X0Y10.A" *) IO_1_bidirectional_frame_config_pass io9_i (.O(io_in[9]), .I(io_out[9]), .T(io_oeb[9]));
+(* keep, BEL="X0Y10.B" *) IO_1_bidirectional_frame_config_pass io8_i (.O(io_in[8]), .I(io_out[8]), .T(io_oeb[8]));
+(* keep, BEL="X0Y11.A" *) IO_1_bidirectional_frame_config_pass io7_i (.O(io_in[7]), .I(io_out[7]), .T(io_oeb[7]));
+(* keep, BEL="X0Y11.B" *) IO_1_bidirectional_frame_config_pass io6_i (.O(io_in[6]), .I(io_out[6]), .T(io_oeb[6]));
+(* keep, BEL="X0Y12.A" *) IO_1_bidirectional_frame_config_pass io5_i (.O(io_in[5]), .I(io_out[5]), .T(io_oeb[5]));
+(* keep, BEL="X0Y12.B" *) IO_1_bidirectional_frame_config_pass io4_i (.O(io_in[4]), .I(io_out[4]), .T(io_oeb[4]));
+(* keep, BEL="X0Y13.A" *) IO_1_bidirectional_frame_config_pass io3_i (.O(io_in[3]), .I(io_out[3]), .T(io_oeb[3]));
+(* keep, BEL="X0Y13.B" *) IO_1_bidirectional_frame_config_pass io2_i (.O(io_in[2]), .I(io_out[2]), .T(io_oeb[2]));
+(* keep, BEL="X0Y14.A" *) IO_1_bidirectional_frame_config_pass io1_i (.O(io_in[1]), .I(io_out[1]), .T(io_oeb[1]));
+(* keep, BEL="X0Y14.B" *) IO_1_bidirectional_frame_config_pass io0_i (.O(io_in[0]), .I(io_out[0]), .T(io_oeb[0]));
+
+wire clk;
+(* keep *) Global_Clock clk_i (.CLK(clk));
+
+top top_i(.clk(clk), .io_in(io_in), .io_out(io_out), .io_oeb(io_oeb));
+
+endmodule
+

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -877,15 +877,6 @@ class FabricGenerator:
                     f"Could not find {tile.name}_ConfigMem.vhdl in {basePath} config_mem generation first"
                 )
 
-            if (
-                self.fabric.configBitMode == ConfigBitMode.FRAME_BASED
-                and tile.globalConfigBits > 0
-            ):
-                if os.path.exists(f"{basePath}/{tile.name}_ConfigMem.vhdl"):
-                    self.writer.addComponentDeclarationForFile(
-                        f"{basePath}/{tile.name}_ConfigMem.vhdl"
-                    )
-
         # VHDL signal declarations
         self.writer.addComment("signal declarations", onNewLine=True)
         # BEL port wires

--- a/docs/source/FPGA-to-bitstream/Yosys compilation.rst
+++ b/docs/source/FPGA-to-bitstream/Yosys compilation.rst
@@ -40,9 +40,17 @@ file is located at ``user_design/sequential_16bit_en.v`` then the result of the 
 
 Manual Synthesis
 ^^^^^^^^^^^^^^^^
-FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell. If synthesizing for the nextpnr flow, run this command: ``yosys -p "synth_fabulous -top <toplevel> -json <out.json>" <files.v>``.
+FABulous is supported by upstream Yosys, using the ``synth_fabulous`` pass. First, run ``yosys``, which will open up an interactive Yosys shell.  
 
-If you are synthesizing for use in the VPR flow, then run this command: ``yosys -p "synth_fabulous -top <toplevel> -blif <out.blif> -vpr" <files.v>``.
+For Verilog projects:
+ If synthesizing for the nextpnr flow, run this command: ``yosys -p "synth_fabulous -top <toplevel> -json <out.json>" <files.v>``.
+
+ If you are synthesizing for the VPR flow, then run this command: ``yosys -p "synth_fabulous -top <toplevel> -blif <out.blif> -vpr" <files.v>``.
+
+For  VHDL projects:
+ If synthesizing for the nextpnr flow, run this command: ``yosys -m ghdl -p ghdl <files.vhdl> -e <top-entity>;read_verilog <top_wrapper(verilog constraint)>;synth_fabulous -top <top_wrapper> -json <out.json>``.
+ 
+ `Note:` For VHDL projects we used the top_wrapper as verilog because ghdl doesn't interpret the attributes(`*BEL*`);
 
 * For any clocked benchmark, a clock tile blackbox module must be instantiated in the top module for clock generation.
 

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -49,7 +49,14 @@ with ``source venv/bin/activate`` to use FABulous.
     (venv)$ pip install -r requirements.txt
 
 
+Install FABulous with "editable" option:
+.. code-block:: console
+
+    (venv)$ pip install -e .
+
 The following packages need to be installed for the CAD toolchain
+
+If you are using yosys oss-cad-suite, no need to install the following packages.
 
 :`Yosys <https://github.com/YosysHQ/yosys>`_:
  version > 0.26+0
@@ -57,10 +64,7 @@ The following packages need to be installed for the CAD toolchain
 :`Nextpnr-generic <https://github.com/YosysHQ/nextpnr#nextpnr-generic>`_:
  version > 0.4-28-gac17c36b
 
-Install FABulous with "editable" option:
-.. code-block:: console
-
-    (venv)$ pip install -e .
+`Yosys ghdl plugin <https://github.com/ghdl/ghdl-yosys-plugin>`_
 
 Building Fabric and Bitstream
 -----------------------------


### PR DESCRIPTION
While working on the simulation of a VHDL design, I encountered an error related to the resetn signal. I realized that the VHDL fabric files were not updated to match the current Verilog files, so I updated them accordingly. However, when I attempted to run the simulation, it quit before executing the run simulation command of ghdl.

To diagnose the problem, I used GDB (GNU Project Debugger) and discovered that the issue was related to the system's stack size. The default stack size on Linux is 8192 kB. By increasing the stack size to unlimited, the simulation was able to run, but it took approximately 2 hours and 30 minutes to complete.

I'm looking for ways to reduce the simulation time. I used the optimization flags of ghdl but they didn't help much. Any ideas or suggestions would be greatly appreciated.