### PR TITLE
Fix .fst generation in run_simulation and correct signal generation for the demo design in the test bench

### DIFF
--- a/FABulous.py
+++ b/FABulous.py
@@ -1079,7 +1079,10 @@ To run the complete FABulous flow with the default project, run the following co
         make_hex(f"{self.projectDir}/{path}/{bitstream}", f"{self.projectDir}/{path}/{bitstream_hex}")
 
         try:
-            runCmd = ["vvp", f"{self.projectDir}/{path}/{vvp_file}"]
+            if optional_arg  == "fst":
+                runCmd = ["vvp", f"{self.projectDir}/{path}/{vvp_file}", "-fst"]
+            else:
+                runCmd = ["vvp", f"{self.projectDir}/{path}/{vvp_file}"]
             sp.run(runCmd, check=True)
         except sp.CalledProcessError:
             logger.error("Simulation failed")

--- a/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
+++ b/fabric_files/FABulous_project_template_verilog/Test/sequential_16bit_en_tb.v
@@ -88,9 +88,9 @@ module sequential_16bit_en_tb;
         end
 `endif
         repeat (100) @(posedge CLK);
-        O_top = 28'b1; // reset
+        O_top = 28'b11; // enable and reset
         repeat (5) @(posedge CLK);
-        O_top = 28'b0;
+        O_top = 28'b10;
         for (i = 0; i < 100; i = i + 1) begin
             @(negedge CLK);
             $display("fabric(I_top) = 0x%X gold = 0x%X, fabric(T_top) = 0x%X gold = 0x%X", I_top, I_top_gold, T_top, T_top_gold);


### PR DESCRIPTION
As mentioned in #213, the generation of `.fst` files is currently broken, since the `-fst` flag is missing when calling `vvp`. 
This is fixed here. The second fix concerns the test bench `sequential_16bit_en_tb.v`, where the enable bit was not set for the user design, resulting in undefined signals. Since the simulation is meant for the fabric, it did still not fail, but the output values of the DUT were useless. 

The fix for the `.fst` file was not applied to `run_simulation.sh` since no waveform will be generated by default in this file.
In the future `sequential_16bit_en_tb.v` could be made more generic, but for now this is just a quick fix with the minimum required changes, so that at least the demo design is correctly simulated.