### PR TITLE
Vector Support for User BEL in Verilog.

### DIFF
--- a/FABulous/fabric_definition/Bel.py
+++ b/FABulous/fabric_definition/Bel.py
@@ -39,6 +39,8 @@ class Bel:
         The feature map of the BEL.
     withUserCLK : bool
         Whether the BEL has userCLK port. Default is False.
+    individually_declared : bool
+        Indicates if ports are individually declared. Default is False.
     """
 
     src: str
@@ -53,6 +55,7 @@ class Bel:
     configBit: int
     belFeatureMap: dict[str, dict] = field(default_factory=dict)
     withUserCLK: bool = False
+    individually_declared: bool = False
 
     def __init__(
         self,
@@ -65,6 +68,7 @@ class Bel:
         configBit: int,
         belMap: dict[str, dict],
         userCLK: bool,
+        individually_declared: bool,
     ) -> None:
         self.src = src
         self.prefix = prefix
@@ -78,3 +82,4 @@ class Bel:
         self.configBit = configBit
         self.belFeatureMap = belMap
         self.withUserCLK = userCLK
+        self.individually_declared = individually_declared

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/DSP/DSP_bot/MULADD.v
@@ -20,74 +20,17 @@ ACC=3,
 signExtension=4,
 ACCout=5
 *)
-module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C19, C18, C17, C16, C15, C14, C13, C12, C11, C10, C9, C8, C7, C6, C5, C4, C3, C2, C1, C0, Q19, Q18, Q17, Q16, Q15, Q14, Q13, Q12, Q11, Q10, Q9, Q8, Q7, Q6, Q5, Q4, Q3, Q2, Q1, Q0, clr, UserCLK, ConfigBits);
-	parameter NoConfigBits = 6;// has to be adjusted manually (we don't use an arithmetic parser for the value)
-	// IMPORTANT: this has to be in a dedicated line
-	input A7;// operand A
-	input A6;
-	input A5;
-	input A4;
-	input A3;
-	input A2;
-	input A1;
-	input A0;
-	input B7;// operand B
-	input B6;
-	input B5;
-	input B4;
-	input B3;
-	input B2;
-	input B1;
-	input B0;
-	input C19;// operand C
-	input C18;
-	input C17;
-	input C16;
-	input C15;
-	input C14;
-	input C13;
-	input C12;
-	input C11;
-	input C10;
-	input C9;
-	input C8;
-	input C7;
-	input C6;
-	input C5;
-	input C4;
-	input C3;
-	input C2;
-	input C1;
-	input C0;
-	output Q19;// result
-	output Q18;
-	output Q17;
-	output Q16;
-	output Q15;
-	output Q14;
-	output Q13;
-	output Q12;
-	output Q11;
-	output Q10;
-	output Q9;
-	output Q8;
-	output Q7;
-	output Q6;
-	output Q5;
-	output Q4;
-	output Q3;
-	output Q2;
-	output Q1;
-	output Q0;
-
-	input clr;
-	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK; // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+module MULADD #(parameter NoConfigBits = 6)(
+	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
+	input [7:0] A, // operand A
+	input [7:0] B, // operand B
+	input [19:0] C, // operand C
+	output [19:0] Q,// result
+	input clr,
+	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK, // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits;
-
-	wire [7:0] A;		// port A read data 
-	wire [7:0] B;		// port B read data 
-	wire [19:0] C;		// port B read data 
+	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+);
 	reg [7:0] A_reg;		// port A read data register
 	reg [7:0] B_reg;		// port B read data register
 	reg [19:0] C_reg;		// port B read data register
@@ -99,10 +42,6 @@ module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C
 	wire [19:0] sum_in;// port B read data register
 	wire [15:0] product;
 	wire [19:0] product_extended;
-
-	assign A = {A7,A6,A5,A4,A3,A2,A1,A0};
-	assign B = {B7,B6,B5,B4,B3,B2,B1,B0};
-	assign C = {C19,C18,C17,C16,C15,C14,C13,C12,C11,C10,C9,C8,C7,C6,C5,C4,C3,C2,C1,C0};
 
 	assign OPA = ConfigBits[0] ? A_reg : A;
 	assign OPB = ConfigBits[1] ? B_reg : B;
@@ -117,26 +56,7 @@ module MULADD (A7, A6, A5, A4, A3, A2, A1, A0, B7, B6, B5, B4, B3, B2, B1, B0, C
 
 	assign sum = product_extended + sum_in;
 
-	assign Q19	= ConfigBits[5] ? ACC[19] : sum[19];
-	assign Q18	= ConfigBits[5] ? ACC[18] : sum[18];
-	assign Q17	= ConfigBits[5] ? ACC[17] : sum[17];
-	assign Q16	= ConfigBits[5] ? ACC[16] : sum[16];
-	assign Q15	= ConfigBits[5] ? ACC[15] : sum[15];
-	assign Q14	= ConfigBits[5] ? ACC[14] : sum[14];
-	assign Q13	= ConfigBits[5] ? ACC[13] : sum[13];
-	assign Q12	= ConfigBits[5] ? ACC[12] : sum[12];
-	assign Q11	= ConfigBits[5] ? ACC[11] : sum[11];
-	assign Q10	= ConfigBits[5] ? ACC[10] : sum[10];
-	assign Q9	= ConfigBits[5] ? ACC[9] : sum[9];
-	assign Q8	= ConfigBits[5] ? ACC[8] : sum[8];
-	assign Q7	= ConfigBits[5] ? ACC[7] : sum[7];
-	assign Q6	= ConfigBits[5] ? ACC[6] : sum[6];
-	assign Q5	= ConfigBits[5] ? ACC[5] : sum[5];
-	assign Q4	= ConfigBits[5] ? ACC[4] : sum[4];
-	assign Q3	= ConfigBits[5] ? ACC[3] : sum[3];
-	assign Q2	= ConfigBits[5] ? ACC[2] : sum[2];
-	assign Q1	= ConfigBits[5] ? ACC[1] : sum[1];
-	assign Q0	= ConfigBits[5] ? ACC[0] : sum[0];
+	assign Q = ConfigBits[5] ? ACC : sum;
 
 	always @ (posedge UserCLK)
 	begin

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
@@ -17,27 +17,24 @@
 c0=0,
 c1=1
 *)
-module MUX8LUT_frame_config_mux (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD, M_AH, M_EF, ConfigBits);
-	parameter NoConfigBits = 2;// has to be adjusted manually (we don't use an arithmetic parser for the value)
-	// IMPORTANT: this has to be in a dedicated line
-	input A; // MUX inputs
-	input B;
-	input C;
-	input D;
-	input E; 
-	input F;
-	input G;
-	input H;
-	input S0;
-	input S1;
-	input S2;
-	input S3;
-	output M_AB;
-	output M_AD;
-	output M_AH;
-	output M_EF;
+module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
+    // ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
+	input A, // MUX inputs
+	input B,
+	input C,
+	input D,
+	input E, 
+	input F,
+	input G,
+	input H,
+	input [3:0] S,
+	output M_AB,
+	output M_AD,
+	output M_AH,
+	output M_EF,
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits;
+	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+);
 
 	wire AB, CD, EF, GH;
 	wire sCD, sEF, sGH, sEH;
@@ -50,11 +47,11 @@ module MUX8LUT_frame_config_mux (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M
 	assign c1 = ConfigBits[1];
 
 // see figure (column-wise left-to-right)
-	//assign AB = S0 ? B : A;
+	//assign AB = S[0] ? B : A;
     my_mux2 my_mux2_AB(
     .A0(A),
     .A1(B),
-    .S(S0),
+    .S(S[0]),
     .X(AB)
     );
 	//assign CD = sCD ? D : C;
@@ -79,17 +76,17 @@ module MUX8LUT_frame_config_mux (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M
     .X(GH)
     );
 
-	//assign sCD = c0 ? S0 : S1;
+	//assign sCD = c0 ? S[0] : S[1];
     my_mux2 my_mux2_sCD(
-    .A0(S1),
-    .A1(S0),
+    .A0(S[1]),
+    .A1(S[0]),
     .S(c0),
     .X(sCD)
     );
-	//assign sEF = c1 ? S0 : S2;
+	//assign sEF = c1 ? S[0] : S[2];
     my_mux2 my_mux2_sEF(
-    .A0(S2),
-    .A1(S0),
+    .A0(S[2]),
+    .A1(S[0]),
     .S(c1),
     .X(sEF)
     );
@@ -100,19 +97,19 @@ module MUX8LUT_frame_config_mux (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M
     .S(c0),
     .X(sGH)
     );
-	//assign sEH = c1 ? S1 : S3;
+	//assign sEH = c1 ? S[1] : S[3];
     my_mux2 my_mux2_sEH(
-    .A0(S3),
-    .A1(S1),
+    .A0(S[3]),
+    .A1(S[1]),
     .S(c1),
     .X(sEH)
     );
 
-	//assign AD = S1 ? CD : AB;
+	//assign AD = S[1] ? CD : AB;
     my_mux2 my_mux2_AD(
     .A0(AB),
     .A1(CD),
-    .S(S1),
+    .S(S[1]),
     .X(AD)
     );
 	//assign EH = sEH ? GH : EF;
@@ -123,11 +120,11 @@ module MUX8LUT_frame_config_mux (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M
     .X(EH)
     );
 
-	//assign AH = S3 ? EH : AD;
+	//assign AH = S[3] ? EH : AD;
     my_mux2 my_mux2_AH(
     .A0(AD),
     .A1(EH),
-    .S(S3),
+    .S(S[3]),
     .X(AH)
     );
 

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
@@ -7,14 +7,11 @@ C_bit3=3
 module Config_access #(parameter NoConfigBits = 4)(
 	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
 	// Pin0
-	(* FABulous, EXTERNAL *)output [3:0] C, // EXTERNAL
+	(* FABulous, EXTERNAL *)output [3:0] C_bit, // EXTERNAL
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
 	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits
 );
 	// we just wire configuration bits to fabric top
-	assign C[0] = ConfigBits[0];
-    assign C[1] = ConfigBits[1];
-    assign C[2] = ConfigBits[2];
-    assign C[3] = ConfigBits[3];
+	assign C_bit = ConfigBits;
 
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/Config_access.v
@@ -4,20 +4,17 @@ C_bit1=1,
 C_bit2=2,
 C_bit3=3
 *)
-module Config_access (C_bit0, C_bit1, C_bit2, C_bit3, ConfigBits);
-	parameter NoConfigBits = 4;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+module Config_access #(parameter NoConfigBits = 4)(
+	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
 	// Pin0
-	(* FABulous, EXTERNAL *)output C_bit0; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit1; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit2; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit3; // EXTERNAL
+	(* FABulous, EXTERNAL *)output [3:0] C, // EXTERNAL
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits;
-
+	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits
+);
 	// we just wire configuration bits to fabric top
-	assign C_bit0 = ConfigBits[0];
-	assign C_bit1 = ConfigBits[1];
-	assign C_bit2 = ConfigBits[2];
-	assign C_bit3 = ConfigBits[3];
+	assign C[0] = ConfigBits[0];
+    assign C[1] = ConfigBits[1];
+    assign C[2] = ConfigBits[2];
+    assign C[3] = ConfigBits[3];
 
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
@@ -19,67 +19,58 @@ I1_reg=1,
 I2_reg=2,
 I3_reg=3
 *)
-module InPass4_frame_config_mux (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, ConfigBits);
-	parameter NoConfigBits = 4;
+module InPass4_frame_config_mux #(parameter NoConfigBits = 4)(
 	// Pin0
-	(* FABulous, EXTERNAL *) input I0; //EXTERNAL
-	(* FABulous, EXTERNAL *) input I1; //EXTERNAL
-	(* FABulous, EXTERNAL *) input I2; //EXTERNAL
-	(* FABulous, EXTERNAL *) input I3; //EXTERNAL
-	output O0; //EXTERNAL
-	output O1; //EXTERNAL
-	output O2; //EXTERNAL
-	output O3; //EXTERNAL
+	(* FABulous, EXTERNAL *) input [3:0] I, //EXTERNAL
+	output [3:0] O, //EXTERNAL
 	// Tile IO ports from BELs
-	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK; //EXTERNAL -- SHARED_PORT -- ## the EXTERNAL keyword will send this signal all the way to top and the --SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK, //EXTERNAL -- SHARED_PORT -- ## the EXTERNAL keyword will send this signal all the way to top and the --SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *) input [NoConfigBits - 1 : 0] ConfigBits;
+	(* FABulous, GLOBAL *) input [NoConfigBits - 1 : 0] ConfigBits
 	//_____   ______
 	//    I----+--->|FLOP|-Q-|1 M |
 	//         |             |  U |-------> O
 	//         +-------------|0 X |               
 	// I am instantiating an IOBUF primitive.
 	// However, it is possible to connect corresponding pins all the way to top, just by adding an "-- EXTERNAL" comment (see PAD in the entity)
-	reg Q0, Q1, Q2, Q3; // FLOPs
+);
+	reg [3:0] Q; // FLOPs
 	
 	always @ (posedge UserCLK)
 	begin
-		Q0 <= I0;
-		Q1 <= I1;
-		Q2 <= I2;
-		Q3 <= I3;
+		Q <= I;
 	end
 	// ConfigBits ( '0' combinatorial; '1' registered )
-	//assign O0 = ConfigBits[0] ? Q0 : I0;
-	//assign O1 = ConfigBits[1] ? Q1 : I1;
-	//assign O2 = ConfigBits[2] ? Q2 : I2;
-	//assign O3 = ConfigBits[3] ? Q3 : I3;
+	//assign O[0] = ConfigBits[0] ? Q[0] : I[0];
+	//assign O[1] = ConfigBits[1] ? Q[1] : I[1];
+	//assign O[2] = ConfigBits[2] ? Q[2] : I[2];
+	//assign O[3] = ConfigBits[3] ? Q[3] : I[3];
 
     my_mux2 my_mux2_inst0(
-    .A0(I0),
-    .A1(Q0),
+    .A0(I[0]),
+    .A1(Q[0]),
     .S(ConfigBits[0]),
-    .X(O0)
+    .X(O[0])
     );
 
     my_mux2 my_mux2_inst1(
-    .A0(I1),
-    .A1(Q1),
+    .A0(I[1]),
+    .A1(Q[1]),
     .S(ConfigBits[1]),
-    .X(O1)
+    .X(O[1])
     );
 
     my_mux2 my_mux2_inst2(
-    .A0(I2),
-    .A1(Q2),
+    .A0(I[2]),
+    .A1(Q[2]),
     .S(ConfigBits[2]),
-    .X(O2)
+    .X(O[2])
     );
 
     my_mux2 my_mux2_inst3(
-    .A0(I3),
-    .A1(Q3),
+    .A0(I[3]),
+    .A1(Q[3]),
     .S(ConfigBits[3]),
-    .X(O3)
+    .X(O[3])
     );	
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
@@ -20,21 +20,16 @@ I2_reg=2,
 I3_reg=3
 *)
 // InPassFlop2 and OutPassFlop2 are the same except for changing which side I0,I1 or O0,O1 gets connected to the top entity
-module OutPass4_frame_config_mux (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, ConfigBits);
-	parameter NoConfigBits = 4;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+module OutPass4_frame_config_mux #(parameter NoConfigBits = 4)(
+	// NoConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
 	// Pin0
-	input I0;
-	input I1;
-	input I2;
-	input I3;
-	(* FABulous, EXTERNAL *) output O0;// EXTERNAL
-	(* FABulous, EXTERNAL *) output O1;// EXTERNAL
-	(* FABulous, EXTERNAL *) output O2;// EXTERNAL
-	(* FABulous, EXTERNAL *) output O3;// EXTERNAL
+	input [3:0] I,
+	(* FABulous, EXTERNAL *) output [3:0] O, // EXTERNAL
 	// Tile IO ports from BELs
-	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK;// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this signal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK,// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this signal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits;
+	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+);
 
 //              ______   ______
 //    I////+//->|FLOP|-Q-|1 M |
@@ -44,14 +39,11 @@ module OutPass4_frame_config_mux (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, Confi
 // I am instantiating an IOBUF primitive.
 // However, it is possible to connect corresponding pins all the way to top, just by adding an "// EXTERNAL" comment (see PAD in the entity)
 
-	reg Q0, Q1, Q2, Q3;   // FLOPs
+	reg [3:0] Q;   // FLOPs
 
 	always @ (posedge UserCLK)
 	begin
-		Q0 <= I0;
-		Q1 <= I1;
-		Q2 <= I2;
-		Q3 <= I3;
+		Q <= I;
 	end
 
 	//assign O0 = ConfigBits[0] ? Q0 : I0;
@@ -60,31 +52,31 @@ module OutPass4_frame_config_mux (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, Confi
 	//assign O3 = ConfigBits[3] ? Q3 : I3;
 
     my_mux2 my_mux2_inst0(
-    .A0(I0),
-    .A1(Q0),
+    .A0(I[0]),
+    .A1(Q[0]),
     .S(ConfigBits[0]),
-    .X(O0)
+    .X(O[0])
     );
 
     my_mux2 my_mux2_inst1(
-    .A0(I1),
-    .A1(Q1),
+    .A0(I[1]),
+    .A1(Q[1]),
     .S(ConfigBits[1]),
-    .X(O1)
+    .X(O[1])
     );
 
     my_mux2 my_mux2_inst2(
-    .A0(I2),
-    .A1(Q2),
+    .A0(I[2]),
+    .A1(Q[2]),
     .S(ConfigBits[2]),
-    .X(O2)
+    .X(O[2])
     );
 
     my_mux2 my_mux2_inst3(
-    .A0(I3),
-    .A1(Q3),
+    .A0(I[3]),
+    .A1(Q[3]),
     .S(ConfigBits[3]),
-    .X(O3)
+    .X(O[3])
     );
 
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -17,66 +17,31 @@
 AD_reg=0,
 BD_reg=1
 *)
-module RegFile_32x4 (D0, D1, D2, D3, W_ADR0, W_ADR1, W_ADR2, W_ADR3, W_ADR4, W_en, AD0, AD1, AD2, AD3, A_ADR0, A_ADR1, A_ADR2, A_ADR3, A_ADR4, BD0, BD1, BD2, BD3, B_ADR0, B_ADR1, B_ADR2, B_ADR3, B_ADR4, UserCLK, ConfigBits);
-	parameter NoConfigBits = 2;// has to be adjusted manually (we don't use an arithmetic parser for the value)
-	// IMPORTANT: this has to be in a dedicated line
-	input D0; // Register File write port
-	input D1;
-	input D2;
-	input D3;
-	input W_ADR0;
-	input W_ADR1;
-	input W_ADR2;
-	input W_ADR3;
-	input W_ADR4;
-	input W_en;
+module RegFile_32x4 #(parameter NoConfigBits = 2)(
+	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
+	input [3:0] D, // Register File write port
+	input [4:0] W_ADR,
+	input W_en,
 	
-	output AD0;// Register File read port A
-	output AD1;
-	output AD2;
-	output AD3;
-	input A_ADR0;
-	input A_ADR1;
-	input A_ADR2;
-	input A_ADR3;
-	input A_ADR4;
+	output [3:0] AD, // Register File read port A
+	input [4:0] A_ADR,
 
-	output BD0;//Register File read port B
-	output BD1;
-	output BD2;
-	output BD3;
-	input B_ADR0;
-	input B_ADR1;
-	input B_ADR2;
-	input B_ADR3;
-	input B_ADR4;
+	output [3:0] BD, //Register File read port B
+	input [4:0] B_ADR,
 
-	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK;// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
+	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK, // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits;
+	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
+);
 
 	//type memtype is array (31 downto 0) of std_logic_vector(3 downto 0); // 32 entries of 4 bit
 	//signal mem : memtype := (others => (others => '0'));
 	reg [3:0] mem [31:0];
 
-	wire [4:0] W_ADR;// write address
-	wire [4:0] A_ADR;// port A read address
-	wire [4:0] B_ADR;// port B read address
-
-	wire [3:0] D;		// write data
-	wire [3:0] AD;		// port A read data
-	wire [3:0] BD;		// port B read data
-
 	reg [3:0] AD_reg;		// port A read data register
 	reg [3:0] BD_reg;		// port B read data register
 	
 	integer i;
-
-	assign W_ADR = {W_ADR4,W_ADR3,W_ADR2,W_ADR1,W_ADR0};
-	assign A_ADR = {A_ADR4,A_ADR3,A_ADR2,A_ADR1,A_ADR0};
-	assign B_ADR = {B_ADR4,B_ADR3,B_ADR2,B_ADR1,B_ADR0};
-
-	assign D = {D3,D2,D1,D0};
 	
 	initial begin
 		for (i=0; i<32; i=i+1) begin
@@ -91,22 +56,12 @@ module RegFile_32x4 (D0, D1, D2, D3, W_ADR0, W_ADR1, W_ADR2, W_ADR3, W_ADR4, W_e
 		end
 	end
 
-	assign AD = mem[A_ADR];
-	assign BD = mem[B_ADR];
-
     always @ (posedge UserCLK) begin
         AD_reg <= AD;
-		BD_reg <= BD;
+        BD_reg <= BD;
     end
 
-	assign AD0 = ConfigBits[0] ? AD_reg[0] : AD[0];
-	assign AD1 = ConfigBits[0] ? AD_reg[1] : AD[1];
-	assign AD2 = ConfigBits[0] ? AD_reg[2] : AD[2];
-	assign AD3 = ConfigBits[0] ? AD_reg[3] : AD[3];
-
-	assign BD0 = ConfigBits[1] ? BD_reg[0] : BD[0];
-	assign BD1 = ConfigBits[1] ? BD_reg[1] : BD[1];
-	assign BD2 = ConfigBits[1] ? BD_reg[2] : BD[2];
-	assign BD3 = ConfigBits[1] ? BD_reg[3] : BD[3];
+	assign AD = ConfigBits[0] ? AD_reg : AD;
+	assign BD = ConfigBits[1] ? BD_reg : BD;
 
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RegFile/RegFile_32x4.v
@@ -56,6 +56,9 @@ module RegFile_32x4 #(parameter NoConfigBits = 2)(
 		end
 	end
 
+	assign AD = mem[A_ADR];	
+	assign BD = mem[B_ADR];
+
     always @ (posedge UserCLK) begin
         AD_reg <= AD;
         BD_reg <= BD;

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
@@ -7,14 +7,11 @@ C_bit3=3
 module Config_access #(parameter NoConfigBits = 4)(
 	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
 	// Pin0
-	(* FABulous, EXTERNAL *)output [3:0] C, // EXTERNAL
+	(* FABulous, EXTERNAL *)output [3:0] C_bit, // EXTERNAL
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
 	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits
 );
 	// we just wire configuration bits to fabric top
-	assign C[0] = ConfigBits[0];
-    assign C[1] = ConfigBits[1];
-    assign C[2] = ConfigBits[2];
-    assign C[3] = ConfigBits[3];
+	assign C_bit = ConfigBits;
 
 endmodule

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/W_IO/Config_access.v
@@ -4,20 +4,17 @@ C_bit1=1,
 C_bit2=2,
 C_bit3=3
 *)
-module Config_access (C_bit0, C_bit1, C_bit2, C_bit3, ConfigBits);
-	parameter NoConfigBits = 4;// has to be adjusted manually (we don't use an arithmetic parser for the value)
+module Config_access #(parameter NoConfigBits = 4)(
+	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
 	// Pin0
-	(* FABulous, EXTERNAL *)output C_bit0; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit1; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit2; // EXTERNAL
-	(* FABulous, EXTERNAL *)output C_bit3; // EXTERNAL
+	(* FABulous, EXTERNAL *)output [3:0] C, // EXTERNAL
 	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
-	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits;
-
+	(* FABulous, GLOBAL *)input [NoConfigBits-1:0] ConfigBits
+);
 	// we just wire configuration bits to fabric top
-	assign C_bit0 = ConfigBits[0];
-	assign C_bit1 = ConfigBits[1];
-	assign C_bit2 = ConfigBits[2];
-	assign C_bit3 = ConfigBits[3];
+	assign C[0] = ConfigBits[0];
+    assign C[1] = ConfigBits[1];
+    assign C[2] = ConfigBits[2];
+    assign C[3] = ConfigBits[3];
 
 endmodule

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -1117,18 +1117,28 @@ class FabricGenerator:
                 else:
                     portsPairs.append((port[0], port[0]))
 
-            for portname, ports in port_dict.items():
-                if len(ports) > 1:
-                    # Sort ports based on bit significance
-                    ports.sort(key=lambda x: int(x[1]) if x[1].isdigit() else -1)
-                    # Concatenate the ports in the correct order
-                    concatenated_ports = ", ".join(port for port, _ in ports[::-1])
-                    portsPairs.append((portname, f"{{{concatenated_ports}}}"))
-                else:
-                    # Single port, no need for concatenation
-                    single_port = ports[0][0]
-                    portsPairs.append((portname, single_port))
-            # makes sure UserCLK is after ports
+            if bel.individually_declared:
+                for portname, ports in port_dict.items():
+                    for port, number in ports:
+                        # If there's a number, include it in the port name.
+                        if number:
+                            portsPairs.append((f"{portname}{number}", port))
+                        else:
+                            portsPairs.append((portname, port))
+            else:
+                for portname, ports in port_dict.items():
+                    if len(ports) > 1:
+                        # Sort ports based on bit significance.
+                        ports.sort(key=lambda x: int(x[1]) if x[1].isdigit() else -1)
+                        # Concatenate the ports in the correct order.
+                        concatenated_ports = ", ".join(port for port, _ in ports[::-1])
+                        portsPairs.append((portname, f"{{{concatenated_ports}}}"))
+                    else:
+                        # Single port, no need for concatenation.
+                        single_port = ports[0][0]
+                        portsPairs.append((portname, single_port))
+
+            # Makes sure UserCLK is after ports.
             if userclk_pair is not None:
                 portsPairs.append(userclk_pair)
 

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -568,6 +568,7 @@ def parseFile(filename: str, belPrefix: str = "", filetype: str = "") -> Bel:
     isConfig = False
     isShared = False
     userClk = False
+    individually_declared = False
     noConfigBits = 0
 
     try:
@@ -680,6 +681,8 @@ def parseFile(filename: str, belPrefix: str = "", filetype: str = "") -> Bel:
                     continue
                 if "UserCLK" in port_name:
                     userClk = True
+                if port_name[-1].isdigit():
+                    individually_declared = True
                 direction = IO[details["direction"].upper()]
                 bits = details.get("bits", [])
                 filtered_ports[port_name] = (direction, bits)
@@ -725,6 +728,7 @@ def parseFile(filename: str, belPrefix: str = "", filetype: str = "") -> Bel:
             raise ValueError(
                 f"NoConfigBits does not match with the BEL map in file {filename}, length of BelMap is {len(belMapDic)}, but with {noConfigBits} config bits"
             )
+
     return Bel(
         filename,
         belPrefix,
@@ -735,6 +739,7 @@ def parseFile(filename: str, belPrefix: str = "", filetype: str = "") -> Bel:
         noConfigBits,
         belMapDic,
         userClk,
+        individually_declared,
     )
 
 


### PR DESCRIPTION
Currently in the verilog files containing user BEL, ports must be declared individually, an example of this would be as follows: 
```
module RegFile_32x4 (D0, D1, D2, D3, W_ADR0, W_ADR1, W_ADR2, W_ADR3, W_ADR4, W_en, AD0, AD1, AD2, AD3, A_ADR0, A_ADR1, A_ADR2, A_ADR3, A_ADR4, BD0, BD1, BD2, BD3, B_ADR0, B_ADR1, B_ADR2, B_ADR3, B_ADR4, UserCLK, ConfigBits);
	parameter NoConfigBits = 2;// has to be adjusted manually (we don't use an arithmetic parser for the value)
	// IMPORTANT: this has to be in a dedicated line
	input D0; // Register File write port
	input D1;
	input D2;
	input D3;
	input W_ADR0;
	input W_ADR1;
	input W_ADR2;
	input W_ADR3;
	input W_ADR4;
	input W_en;
	
	output AD0;// Register File read port A
	output AD1;
	output AD2;
	output AD3;
	input A_ADR0;
	input A_ADR1;
	input A_ADR2;
	input A_ADR3;
	input A_ADR4;

	output BD0;//Register File read port B
	output BD1;
	output BD2;
	output BD3;
	input B_ADR0;
	input B_ADR1;
	input B_ADR2;
	input B_ADR3;
	input B_ADR4;

	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK;// EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits;
```

With these modifications  input can now be as follows:

```
module RegFile_32x4 #(parameter NoConfigBits = 2)(
	// ConfigBits has to be adjusted manually (we don't use an arithmetic parser for the value)
	input [3:0] D, // Register File write port
	input [4:0] W_ADR,
	input W_en,
	
	output [3:0] AD, // Register File read port A
	input [4:0] A_ADR,

	output [3:0] BD, //Register File read port B
	input [4:0] B_ADR,

	(* FABulous, EXTERNAL, SHARED_PORT *) input UserCLK, // EXTERNAL // SHARED_PORT // ## the EXTERNAL keyword will send this sisgnal all the way to top and the //SHARED Allows multiple BELs using the same port (e.g. for exporting a clock to the top)
	// GLOBAL all primitive pins that are connected to the switch matrix have to go before the GLOBAL label
	(* FABulous, GLOBAL *) input [NoConfigBits-1:0] ConfigBits
);
```

This is primarily done by using yosys to convert the verilog into a JSON netlist and parsing the JSON instead. This also has the added benefits of passing off some of the error handling to yosys and potentially being able to process VHDL files using the same logic in the future.

Backwards compatibility has been added for the individual deceleration of ports and as long as files that rely on each other have the same format, all should be well. However this does not include mixing styles within the same file.

Current Verilog template tiles have been changed to vector to reflect these changes.

### Testing

The following scenarios were tested using the demo tiles:

- All tiles kept as original. | **Passed**
- All tiles converted to use vectors. | **Passed**
- Mixed formats (MULADD.v & LUT4c_frame_config_dffesr.v were kept original, rest vector). | **Passed**
- Mixed formats (RAM_IO/config_access.v & W_IO/config_access.v had different formats). | **Failed**

Please review the changes and let me know if there are any questions or further modifications needed. Thank you!



