### PR TITLE
Warning For Individual Port Declaration

### DIFF
--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -667,10 +667,10 @@ def parseFile(
 
         with open(f"{json_file}", "r") as f:
             data_dict = json.load(f)
-        # Default yosys list names added.
+
         modules = data_dict.get("modules", {})
         filtered_ports: dict[str, IO] = {}
-        # Gatheres port name and direction, filters out configbits as they show in ports.
+        # Gathers port name and direction, filters out configbits as they show in ports.
         for module_name, module_info in modules.items():
             ports = module_info["ports"]
             for port_name, details in ports.items():
@@ -683,6 +683,12 @@ def parseFile(
                 direction = IO[details["direction"].upper()]
                 bits = details.get("bits", [])
                 filtered_ports[port_name] = (direction, bits)
+
+        if individually_declared:
+            logger.warning(
+                f"Ports in {filename} have been individually declared rather than as a vector."
+            )
+            logger.warning("Ports will not be concatenated during fabric generation.")
 
         param_defaults = module_info.get("parameter_default_values")
         if param_defaults and "NoConfigBits" in param_defaults:


### PR DESCRIPTION
PR adds warning for Individual Port Declaration as suggested by @KelvinChung2000.

Example:

![image](https://github.com/user-attachments/assets/bca269a0-c87c-4e4e-8a88-6fda64873cbb)

-Edit- 

Message is now `...Individually declared rather than as a vector.`