### PR TITLE
Add start_FABulator command to be able to run FABulator from the FABulous shell

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -1579,7 +1579,7 @@ def main():
         default=False,
         action="count",
         help="Show detailed log information including function and line number. For -vv additionally output from "
-             "FABulator is logged to the shell for the start_FABulator command",
+        "FABulator is logged to the shell for the start_FABulator command",
     )
 
     args = parser.parse_args()

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -893,7 +893,8 @@ To run the complete FABulous flow with the default project, run the following co
         if fabulatorRoot is None:
             logger.warning("FABULATOR_ROOT environment variable not set.")
             logger.warning(
-                "Install FABulator and set the FABULATOR_ROOT environment variable to use this feature."
+                "Install FABulator (https://github.com/FPGA-Research-Manchester/FABulator) "
+                "and set the FABULATOR_ROOT environment variable to the root directory to use this feature."
             )
             return
 

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -1578,7 +1578,8 @@ def main():
         "--verbose",
         default=False,
         action="count",
-        help="Show detailed log information including function and line number. For -vv additionally output from FABulator is logged to the shell for the start_FABulator command",
+        help="Show detailed log information including function and line number. For -vv additionally output from "
+             "FABulator is logged to the shell for the start_FABulator command",
     )
 
     args = parser.parse_args()

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -823,7 +823,7 @@ To run the complete FABulous flow with the default project, run the following co
         logger.info("Fabric generation complete")
 
     def do_gen_geometry(self, *vargs):
-        """Generates geometry of fabric for the FABulous editor by checking if fabric
+        """Generates geometry of fabric for FABulator by checking if fabric
         is loaded, and calling 'genGeometry' and passing on padding value. Default
         padding is '8'.
 
@@ -869,9 +869,43 @@ To run the complete FABulous flow with the default project, run the following co
         if 4 <= padding <= 32:
             self.fabricGen.genGeometry(padding)
             logger.info("Geometry generation complete")
-            logger.info(f"{geomFile} can now be imported into the FABulous Editor")
+            logger.info(f"{geomFile} can now be imported into FABulator")
         else:
             logger.error("padding has to be between 4 and 32 inclusively!")
+
+    def do_start_FABulator(self, *ignored):
+        """Starts FABulator if an installation can be found.
+        If no installation can be found, a warning is produced.
+
+        Usage:
+            start_FABulator
+
+        Parameters
+        ----------
+        *ignored : tuple
+            Ignores additional arguments.
+
+        """
+        logger.info("Checking for FABulator installation")
+        fabulatorRoot = os.getenv("FABULATOR_ROOT")
+        if fabulatorRoot is None:
+            logger.warning("FABULATOR_ROOT environment variable not set.")
+            logger.warning(
+                "Install FABulator and set the FABULATOR_ROOT environment variable to use this feature."
+            )
+        elif not os.path.exists(fabulatorRoot):
+            logger.warning(
+                f"FABULATOR_ROOT environment variable set to {fabulatorRoot} but the directory does not exist."
+            )
+        else:
+            logger.info(f"Found FABulator installation at {fabulatorRoot}")
+            logger.info(f"Trying to start FABulator...")
+
+            startupCmd = ["mvn", "-f", f"{fabulatorRoot}/pom.xml", "javafx:run"]
+            try:
+                sp.Popen(startupCmd)
+            except sp.SubprocessError:
+                logger.error("Startup of FABulator failed.")
 
     def do_gen_bitStream_spec(self, *ignored):
         """Generates bitstream specification of the fabric by calling

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -889,30 +889,34 @@ To run the complete FABulous flow with the default project, run the following co
         """
         logger.info("Checking for FABulator installation")
         fabulatorRoot = os.getenv("FABULATOR_ROOT")
+
         if fabulatorRoot is None:
             logger.warning("FABULATOR_ROOT environment variable not set.")
             logger.warning(
                 "Install FABulator and set the FABULATOR_ROOT environment variable to use this feature."
             )
-        elif not os.path.exists(fabulatorRoot):
-            logger.warning(
+            return
+
+        if not os.path.exists(fabulatorRoot):
+            logger.error(
                 f"FABULATOR_ROOT environment variable set to {fabulatorRoot} but the directory does not exist."
             )
-        else:
-            logger.info(f"Found FABulator installation at {fabulatorRoot}")
-            logger.info(f"Trying to start FABulator...")
+            return
 
-            startupCmd = ["mvn", "-f", f"{fabulatorRoot}/pom.xml", "javafx:run"]
-            try:
-                if self.verbose:
-                    # log FABulator output to the FABulous shell
-                    sp.Popen(startupCmd)
-                else:
-                    # discard FABulator output
-                    sp.Popen(startupCmd, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+        logger.info(f"Found FABulator installation at {fabulatorRoot}")
+        logger.info(f"Trying to start FABulator...")
 
-            except sp.SubprocessError:
-                logger.error("Startup of FABulator failed.")
+        startupCmd = ["mvn", "-f", f"{fabulatorRoot}/pom.xml", "javafx:run"]
+        try:
+            if self.verbose:
+                # log FABulator output to the FABulous shell
+                sp.Popen(startupCmd)
+            else:
+                # discard FABulator output
+                sp.Popen(startupCmd, stdout=sp.DEVNULL, stderr=sp.DEVNULL)
+
+        except sp.SubprocessError:
+            logger.error("Startup of FABulator failed.")
 
     def do_gen_bitStream_spec(self, *ignored):
         """Generates bitstream specification of the fabric by calling

--- a/FABulous/geometry_generator/geometry_gen.py
+++ b/FABulous/geometry_generator/geometry_gen.py
@@ -40,6 +40,6 @@ class GeometryGenerator:
 
     def saveToCSV(self, fileName: str) -> None:
         """Saves the generated geometry into a file specified by the given file name.
-        This file can then be imported into the FABulous Editor.
+        This file can then be imported into FABulator.
         """
         self.fabricGeometry.saveToCSV(fileName)


### PR DESCRIPTION
The title pretty much sais it all... 
I added the command in the FABulous2.0-development branch, is that correct?
Let me know if anything here should be changed.
The command basically just runs FABulator in a new process.

***Before this is merged***, I want to add an option to enable/disable logging to the start_FABulator command, as right now the output of FABulator is logged to the FABulous shell (Which can be very annoying if not intended).
I've pretty much got it all running locally already, but I'm not quite happy with how logging it enabled/disabled.
Ideally, you'd simpy be able to pass an additional flag such as -enable_logging, but I'm not sure how to do this in a clean way. Any suggestions are greatly appreciated!
In my quick and dirty solution, I basically just passed an optional argument to  start_FABulator and checked if that argument (if it exists) == "-enable_logging". 
