### PR TITLE
fabric_files:verilog_template:FABulous.tcl: Remove npnr parameter

### DIFF
--- a/FABulous/fabric_files/FABulous_project_template_verilog/FABulous.tcl
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/FABulous.tcl
@@ -1,5 +1,5 @@
 # all Directory with in the script will be relative to the project folder
 load_fabric
 run_FABulous_fabric
-run_FABulous_bitstream npnr ./user_design/sequential_16bit_en.v
+run_FABulous_bitstream ./user_design/sequential_16bit_en.v
 exit


### PR DESCRIPTION
Remove npnr parameter from FABulous.tcl, since it is not needed anymore, and throws an error.