### PR TITLE
Fix backward compatibility to old project structure and some housekeeping 

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -1509,11 +1509,26 @@ To run the complete FABulous flow with the default project, run the following co
             run_FABulous_bitstream <top_module_file>
 
         """
-        if len(args) != 1:
+        if len(args) == 1:
+            verilog_file_path = get_path(args[0])
+        elif len(args) == 2:
+            # Backwards compatibility to older scripts
+            if "npnr" in args[0]:
+                verilog_file_path = get_path(args[1])
+            elif "vpr" in args[0]:
+                logger.error(
+                    "run_FABulous_bitstream does not support vpr anymore, please use npnr or try a older FABulous version."
+                )
+                return
+
+            else:
+                logger.error(f"run_FABulous_bitstream does not support {args[0]}")
+                return
+
+        else:
             logger.error("Usage: run_FABulous_bitstream <top_module_file>")
             return
 
-        verilog_file_path = get_path(args[0])
         file_path_no_suffix = verilog_file_path.parent / verilog_file_path.stem
 
         if verilog_file_path.suffix != ".v":

--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -31,7 +31,7 @@ import tkinter as tk
 import traceback
 from contextlib import redirect_stdout
 from glob import glob
-from pathlib import PurePosixPath, PureWindowsPath, Path
+from pathlib import PurePath, Path
 from typing import List, Literal
 from dotenv import load_dotenv
 
@@ -269,35 +269,6 @@ def adjust_directory_in_verilog_tb(project_dir):
         with open(f"{project_dir}/Test/sequential_16bit_en_tb.v", "wt") as fout:
             for line in fin:
                 fout.write(line.replace("PROJECT_DIR", f"{project_dir}"))
-
-
-def get_path(path):
-    """Returns system-specific path object.
-
-    Parameters
-    ----------
-    path : str
-        File system path.
-
-    Returns
-    -------
-    PurePath
-        System-specific path object (PurePosixPath or PureWindowsPath)
-
-    Raises
-    ------
-    NotImplementedError
-        If the operating system is not supported.
-    """
-    system = platform.system()
-    # Darwin corresponds to MacOS, which also uses POSIX-style paths
-    if system == "Linux" or system == "Darwin":
-        return PurePosixPath(path)
-    elif system == "Windows":
-        return PureWindowsPath(path)
-    else:
-        logger.error(f"Unsupported operating system: {system}")
-        raise NotImplementedError
 
 
 class PlaceAndRouteError(Exception):
@@ -1168,7 +1139,7 @@ To run the complete FABulous flow with the default project, run the following co
                 f"do_synthesis takes exactly one argument ({len(args)} given)"
             )
         logger.info(f"Running synthesis that targeting Nextpnr with design {args[0]}")
-        path = get_path(args[0])
+        path = PurePath(args[0])
         parent = path.parent
         verilog_file = path.name
         top_module_name = path.stem
@@ -1231,7 +1202,7 @@ To run the complete FABulous flow with the default project, run the following co
                 f"do_place_and_route takes exactly one argument ({len(args)} given)"
             )
         logger.info(f"Running Placement and Routing with Nextpnr for design {args[0]}")
-        path = get_path(args[0])
+        path = PurePath(args[0])
         parent = path.parent
         json_file = path.name
         top_module_name = path.stem
@@ -1321,7 +1292,7 @@ To run the complete FABulous flow with the default project, run the following co
         if len(args) != 1:
             logger.error("Usage: gen_bitStream_binary <fasm_file>")
             return
-        path = get_path(args[0])
+        path = PurePath(args[0])
         parent = path.parent
         fasm_file = path.name
         top_module_name = path.stem
@@ -1510,11 +1481,11 @@ To run the complete FABulous flow with the default project, run the following co
 
         """
         if len(args) == 1:
-            verilog_file_path = get_path(args[0])
+            verilog_file_path = PurePath(args[0])
         elif len(args) == 2:
             # Backwards compatibility to older scripts
             if "npnr" in args[0]:
-                verilog_file_path = get_path(args[1])
+                verilog_file_path = PurePath(args[1])
             elif "vpr" in args[0]:
                 logger.error(
                     "run_FABulous_bitstream does not support vpr anymore, please use npnr or try a older FABulous version."
@@ -1569,7 +1540,7 @@ To run the complete FABulous flow with the default project, run the following co
             logger.error("Usage: tcl <tcl_script>")
             return
         path_str = args[0]
-        path = get_path(path_str)
+        path = PurePath(path_str)
         name = path.stem
         if not os.path.exists(path_str):
             logger.error(f"Cannot find {path_str}")

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -19,7 +19,6 @@
 import csv
 import math
 import os
-import pathlib
 import re
 import string
 from sys import prefix
@@ -69,7 +68,7 @@ class FabricGenerator:
         self.writer = writer
 
     @staticmethod
-    def bootstrapSwitchMatrix(tile: Tile, outputDir: pathlib.Path) -> None:
+    def bootstrapSwitchMatrix(tile: Tile, outputDir: Path) -> None:
         """Generates a blank switch matrix CSV file for the given tile. The top left corner will
         contain the name of the tile. Columns are the source signals and rows are the destination signals.
 
@@ -117,7 +116,7 @@ class FabricGenerator:
                 writer.writerow([p] + [0] * len(destName))
 
     @staticmethod
-    def list2CSV(InFileName: pathlib.Path, OutFileName: pathlib.Path) -> None:
+    def list2CSV(InFileName: Path, OutFileName: Path) -> None:
         """This function is used to export a given list description into its equivalent CSV switch matrix description.
         A comment will be appended to the end of the column and row of the matrix, which will indicate the number
         of signals in a given row.

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -2425,10 +2425,21 @@ class FabricGenerator:
             for x, tile in enumerate(row):
                 if tile == None:
                     continue
-                configMemPath = tile.tileDir.parent.joinpath(
-                    f"{tile.name}_ConfigMem.csv"
-                )
-                if configMemPath.exists():
+                if "fabric.csv" in str(tile.tileDir):
+                    # backward compatibility for old project structure
+                    configMemPath = (
+                        Path(os.getenv("FAB_PROJ_DIR"))
+                        / "Tile"
+                        / tile.name
+                        / f"{tile.name}_ConfigMem.csv"
+                    )
+                else:
+                    configMemPath = tile.tileDir.parent.joinpath(
+                        f"{tile.name}_ConfigMem.csv"
+                    )
+                logger.info(f"ConfigMemPath: {configMemPath}")
+
+                if configMemPath.exists() and configMemPath.is_file():
                     configMemList = parseConfigMem(
                         configMemPath,
                         self.fabric.maxFramesPerCol,
@@ -2439,6 +2450,10 @@ class FabricGenerator:
                     logger.critical(
                         f"No ConfigMem csv file found for {tile.name} which have config bits"
                     )
+                    configMemList = []
+                else:
+                    logger.info(f"No config memory for {tile.name}.")
+                    configMemList = []
 
                 encodeDict = [-1] * (
                     self.fabric.maxFramesPerCol * self.fabric.frameBitsPerRow

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -1,5 +1,4 @@
 import csv
-import pathlib
 import re
 import subprocess
 import json
@@ -7,6 +6,7 @@ from loguru import logger
 from copy import deepcopy
 
 from typing import Literal, overload
+from pathlib import Path
 from FABulous.fabric_generator.utilities import expandListPorts
 from FABulous.fabric_definition.Bel import Bel
 from FABulous.fabric_definition.Port import Port
@@ -56,7 +56,7 @@ def parseFabricCSV(fileName: str) -> Fabric:
         The fabric object.
     """
 
-    fName = pathlib.Path(fileName)
+    fName = Path(fileName)
     if fName.suffix != ".csv":
         logger.error("File must be a csv file")
         raise ValueError
@@ -236,12 +236,12 @@ def parseFabricCSV(fileName: str) -> Fabric:
     )
 
 
-def parseMatrix(fileName: pathlib.Path, tileName: str) -> dict[str, list[str]]:
+def parseMatrix(fileName: Path, tileName: str) -> dict[str, list[str]]:
     """Parse the matrix CSV into a dictionary from destination to source.
 
     Parameters
     ----------
-    fileName : pathlib.Path
+    fileName : Path
         Directory of the matrix CSV file.
     tileName : str
         Name of the tile needed to be parsed.
@@ -283,20 +283,20 @@ def parseMatrix(fileName: pathlib.Path, tileName: str) -> dict[str, list[str]]:
 
 @overload
 def parseList(
-    filePath: pathlib.Path, collect: Literal["pair"] = "pair", prefix: str = ""
+    filePath: Path, collect: Literal["pair"] = "pair", prefix: str = ""
 ) -> list[tuple[str, str]]:
     pass
 
 
 @overload
 def parseList(
-    filePath: pathlib.Path, collect: Literal["source", "sink"], prefix: str = ""
+    filePath: Path, collect: Literal["source", "sink"], prefix: str = ""
 ) -> dict[str, list[str]]:
     pass
 
 
 def parseList(
-    filePath: pathlib.Path,
+    filePath: Path,
     collect: Literal["pair", "source", "sink"] = "pair",
     prefix: str = "",
 ) -> list[tuple[str, str]] | dict[str, list[str]]:
@@ -304,7 +304,7 @@ def parseList(
 
     Parameters
     ----------
-    fileName : pathlib.Path
+    fileName : Path
         ""
     collect : (Literal["", "source", "sink"], optional)
         Collect value by source, sink or just as pair. Defaults to "pair".
@@ -439,7 +439,7 @@ def parsePortLine(line: str) -> tuple[list[Port], tuple[str, str] | None]:
     return (ports, commonWirePair)
 
 
-def parseTiles(fileName: pathlib.Path) -> tuple[list[Tile], list[tuple[str, str]]]:
+def parseTiles(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
     """Parses a CSV tile configuration file and returns all tile objects.
 
     Parameters
@@ -479,7 +479,7 @@ def parseTiles(fileName: pathlib.Path) -> tuple[list[Tile], list[tuple[str, str]
         tileName = t[0].split(",")[1]
         ports: list[Port] = []
         bels: list[Bel] = []
-        matrixDir: pathlib.Path | None = None
+        matrixDir: Path | None = None
         withUserCLK = False
         configBit = 0
         for item in t:
@@ -567,9 +567,7 @@ def parseTiles(fileName: pathlib.Path) -> tuple[list[Tile], list[tuple[str, str]
     return (new_tiles, commonWirePairs)
 
 
-def parseSupertiles(
-    fileName: pathlib.Path, tileDic: dict[str, Tile]
-) -> list[SuperTile]:
+def parseSupertiles(fileName: Path, tileDic: dict[str, Tile]) -> list[SuperTile]:
     """Parses a CSV supertile configuration file and returns all SuperTile objects.
 
     Parameters
@@ -655,7 +653,7 @@ def parseSupertiles(
 
 
 def parseBelFile(
-    filename: pathlib.Path,
+    filename: Path,
     belPrefix: str = "",
     filetype: Literal["verilog", "vhdl"] = "",
 ) -> Bel:
@@ -1056,7 +1054,7 @@ def vhdl_belMapProcessing(file: str, filename: str) -> dict:
 
 
 def parseConfigMem(
-    fileName: pathlib.Path,
+    fileName: Path,
     maxFramePerCol: int,
     frameBitPerRow: int,
     globalConfigBits: int,

--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -1,10 +1,8 @@
 import csv
-import os
 import pathlib
 import re
 import subprocess
 import json
-from sys import prefix
 from loguru import logger
 from copy import deepcopy
 
@@ -12,7 +10,6 @@ from typing import Literal, overload
 from FABulous.fabric_generator.utilities import expandListPorts
 from FABulous.fabric_definition.Bel import Bel
 from FABulous.fabric_definition.Port import Port
-from FABulous.fabric_definition.Wire import Wire
 from FABulous.fabric_definition.Tile import Tile
 from FABulous.fabric_definition.SuperTile import SuperTile
 from FABulous.fabric_definition.Fabric import Fabric
@@ -455,7 +452,6 @@ def parseTiles(fileName: pathlib.Path) -> tuple[list[Tile], list[tuple[str, str]
     Tuple[List[Tile], List[Tuple[str, str]]]
         A tuple containing a list of Tile objects and a list of common wire pairs.
     """
-
     logger.info(f"Reading tile configuration: {fileName}")
 
     if fileName.suffix != ".csv":
@@ -555,7 +551,6 @@ def parseTiles(fileName: pathlib.Path) -> tuple[list[Tile], list[tuple[str, str]
             else:
                 logger.error(f"Unknown tile description {temp[0]} in tile {t}.")
                 raise ValueError
-
             withUserCLK = any(bel.withUserCLK for bel in bels)
             new_tiles.append(
                 Tile(


### PR DESCRIPTION
Fix backward compatibility to old project structure: 
- Add case for old tcl scripts in run_FABulous_bitstream.
- ConfigMemPath in fabric_gen:generateBitstreamSpec was set wrong, if a project used the old fabric.csv structure.

Remove unneeded get_path() function and use Path() instead of pathlib.Path()

Add check if external programs are installed