### PR TITLE
Fix UserCLK wire generation in SuperTiles

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -1428,7 +1428,7 @@ class FabricGenerator:
                         indentLevel=1,
                     )
                     self.writer.addConnectionScalar(
-                        f"Tile_X{x}Y{y}_userCLKo", indentLevel=1
+                        f"Tile_X{x}Y{y}_UserCLKo", indentLevel=1
                     )
                 if (
                     0 <= x - 1 < len(superTile.tileMap[y])


### PR DESCRIPTION
Fixes a typo in `fabric_gen` regarding UserClock wire generation in SuperTiles, which would otherwise break the netlist.

Verilator complains:

```
%Warning-UNUSEDSIGNAL: DSP.v:105:10: Signal is not driven, nor used: 'Tile_X0Y1_userCLKo'                                                                                                    
: ... note: In instance 'DSP'                                                                                                                                                                
105 |     wire Tile_X0Y1_userCLKo;
```

This has been tested with the default fabric.