### PR TITLE
Update Dependencies

### DIFF
--- a/FABulous/fabric_cad/bit_gen.py
+++ b/FABulous/fabric_cad/bit_gen.py
@@ -4,8 +4,17 @@ import pickle
 import re
 import sys
 
-from fasm import *  # Remove this line if you do not have the fasm library installed and will not be generating a bitstream
 from loguru import logger
+
+try:
+    from fasm import (
+        parse_fasm_filename,
+        fasm_tuple_to_string,
+        parse_fasm_string,
+        set_feature_to_str,
+    )
+except:
+    logger.critical("Could not import fasm. Bitstream generation not supported.")
 
 
 def replace(string, substitutions):

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -43,7 +43,6 @@ from FABulous.fabric_definition.define import (
 )
 
 from FABulous.fabric_generator.file_parser import parseConfigMem, parseList, parseMatrix
-from fasm import *  # Remove this line if you do not have the fasm library installed and will not be generating a bitstream
 
 SWITCH_MATRIX_DEBUG_SIGNAL = True
 

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -97,7 +97,7 @@ Building Fabric and Bitstream
    # inside the FABulous shell
    FABulous> load_fabric
    FABulous> run_FABulous_fabric
-   FABulous> run_FABulous_bitstream npnr user_design/sequential_16bit_en.v
+   FABulous> run_FABulous_bitstream user_design/sequential_16bit_en.v
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
 
 
 dependencies = [
-    'numpy',
-    'fasm',
-    'docker',
+    'python-dotenv>=1.0.0',
+    'loguru>=0.7.0',
+    'fasm>=0.0.2',
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-numpy
-fasm
-docker
-python-dotenv
-loguru
+python-dotenv>=1.0.0
+loguru>=0.7.0
+fasm>=0.0.2


### PR DESCRIPTION
Update the dependencies as discussed in #236.

`numpy` and `docker` have been removed and for the others the minimum required versions have been set.
If `fasm` cannot be imported, a warning is issued that bitstream generation is not supported in that case. 