### PR TITLE
docs: Fix build_docs workflow and add docs dependency versions

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@master
+    - uses: ammaraskar/sphinx-action@8.0.0
       with:
+        pre-build-command: "apt-get update -y && apt-get install tk git -y && pip install -r requirements.txt && pip install -e ."
         docs-folder: "docs/"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
-sphinx
-pydata_sphinx_theme
-sphinxcontrib-bibtex
-sphinx-copybutton
-sphinx-prompt
-fasm
+Sphinx>=8.0.0
+pydata-sphinx-theme>=0.15.0
+sphinxcontrib-bibtex>=2.6.0
+sphinx-copybutton>=0.5.0
+sphinx-prompt>=1.9.0


### PR DESCRIPTION
Add minimum required dependency versions to docs/requirements.txt

Add version to sphinx action in 'build_docs' workflow, since default sphinx version of the action is 2.44. Install dependencies and FABulous first before building docs.
