### PR TITLE
Fixing non power of 2 mux generation 

### DIFF
--- a/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -192,7 +192,7 @@ module cus_mux41_buf (A0, A1, A2, A3, S0, S0N, S1, S1N, X);
 	assign X =  S1 ? B1 : B0;
 endmodule
 
-module cus_mux21_buf (A0, A1, S, X);
+module cus_mux21 (A0, A1, S, X);
 	input A0;
 	input A1;
 	input S;

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -249,7 +249,7 @@ module cus_mux81 (A0, A1, A2, A3, A4, A5, A6, A7, S0, S0N, S1, S1N, S2, S2N, X);
 	.X  (cus_mux41_out1)
 	);
 
-	cus_mux21_buf cus_mux21_buf_inst(
+	cus_mux21 cus_mux21_inst(
 	.A0(cus_mux41_out0),
 	.A1(cus_mux41_out1),
 	.S (S2),
@@ -301,7 +301,7 @@ module cus_mux81_buf (A0, A1, A2, A3, A4, A5, A6, A7, S0, S0N, S1, S1N, S2, S2N,
 	.X  (cus_mux41_buf_out1)
 	);
 
-	cus_mux21_buf cus_mux21_buf_inst(
+	cus_mux21 cus_mux21_inst(
 	.A0(cus_mux41_buf_out0),
 	.A1(cus_mux41_buf_out1),
 	.S (S2),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Fabric/models_pack.v
@@ -192,7 +192,7 @@ module cus_mux41_buf (A0, A1, A2, A3, S0, S0N, S1, S1N, X);
 	assign X =  S1 ? B1 : B0;
 endmodule
 
-module my_mux2 (A0, A1, S, X);
+module cus_mux21_buf (A0, A1, S, X);
 	input A0;
 	input A1;
 	input S;
@@ -203,7 +203,7 @@ module my_mux2 (A0, A1, S, X);
 	break_comb_loop break_comb_loop_inst1(.A (A1), .X (AIN[1]));
 
 	assign X = S ? AIN[1] : AIN[0];
-endmodule 
+endmodule
 
 module cus_mux81 (A0, A1, A2, A3, A4, A5, A6, A7, S0, S0N, S1, S1N, S2, S2N, X);
 	input A0;
@@ -249,7 +249,7 @@ module cus_mux81 (A0, A1, A2, A3, A4, A5, A6, A7, S0, S0N, S1, S1N, S2, S2N, X);
 	.X  (cus_mux41_out1)
 	);
 
-	my_mux2 my_mux2_inst(
+	cus_mux21_buf cus_mux21_buf_inst(
 	.A0(cus_mux41_out0),
 	.A1(cus_mux41_out1),
 	.S (S2),
@@ -301,7 +301,7 @@ module cus_mux81_buf (A0, A1, A2, A3, A4, A5, A6, A7, S0, S0N, S1, S1N, S2, S2N,
 	.X  (cus_mux41_buf_out1)
 	);
 
-	my_mux2 my_mux2_inst(
+	cus_mux21_buf cus_mux21_buf_inst(
 	.A0(cus_mux41_buf_out0),
 	.A1(cus_mux41_buf_out1),
 	.S (S2),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
@@ -62,7 +62,7 @@ module LUT4c_frame_config_dffesr #(parameter NoConfigBits = 19)(
 //CONFout <= c_I0mux;
 
 	//assign I0mux = c_I0mux ? Ci : I0;
-	my_mux2 my_mux2_I0mux(
+	cus_mux21_buf cus_mux21_buf_I0mux(
 	.A0(I[0]),
 	.A1(Ci),
 	.S(c_I0mux),
@@ -126,7 +126,7 @@ module LUT4c_frame_config_dffesr #(parameter NoConfigBits = 19)(
 	);
 
 	//assign O = c_out_mux ? LUT_flop : LUT_out;
-	my_mux2 my_mux2_O(
+	cus_mux21_buf cus_mux21_buf_O(
 	.A0(LUT_out),
 	.A1(LUT_flop),
 	.S(c_out_mux),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/LUT4c_frame_config_dffesr.v
@@ -62,7 +62,7 @@ module LUT4c_frame_config_dffesr #(parameter NoConfigBits = 19)(
 //CONFout <= c_I0mux;
 
 	//assign I0mux = c_I0mux ? Ci : I0;
-	cus_mux21_buf cus_mux21_buf_I0mux(
+	cus_mux21 cus_mux21_I0mux(
 	.A0(I[0]),
 	.A1(Ci),
 	.S(c_I0mux),
@@ -126,7 +126,7 @@ module LUT4c_frame_config_dffesr #(parameter NoConfigBits = 19)(
 	);
 
 	//assign O = c_out_mux ? LUT_flop : LUT_out;
-	cus_mux21_buf cus_mux21_buf_O(
+	cus_mux21 cus_mux21_O(
 	.A0(LUT_out),
 	.A1(LUT_flop),
 	.S(c_out_mux),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
@@ -23,7 +23,7 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
 	input B,
 	input C,
 	input D,
-	input E, 
+	input E,
 	input F,
 	input G,
 	input H,
@@ -48,28 +48,28 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
 
 // see figure (column-wise left-to-right)
 	//assign AB = S[0] ? B : A;
-    my_mux2 my_mux2_AB(
+    cus_mux21_buf cus_mux21_buf_AB(
     .A0(A),
     .A1(B),
     .S(S[0]),
     .X(AB)
     );
 	//assign CD = sCD ? D : C;
-    my_mux2 my_mux2_CD(
+    cus_mux21_buf cus_mux21_buf_CD(
     .A0(C),
     .A1(D),
     .S(sCD),
     .X(CD)
     );
 	//assign EF = sEF ? F : E;
-    my_mux2 my_mux2_EF(
+    cus_mux21_buf cus_mux21_buf_EF(
     .A0(E),
     .A1(F),
     .S(sEF),
     .X(EF)
     );
 	//assign GH = sGH ? H : G;
-    my_mux2 my_mux2_GH(
+    cus_mux21_buf cus_mux21_buf_GH(
     .A0(G),
     .A1(H),
     .S(sGH),
@@ -77,28 +77,28 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign sCD = c0 ? S[0] : S[1];
-    my_mux2 my_mux2_sCD(
+    cus_mux21_buf cus_mux21_buf_sCD(
     .A0(S[1]),
     .A1(S[0]),
     .S(c0),
     .X(sCD)
     );
 	//assign sEF = c1 ? S[0] : S[2];
-    my_mux2 my_mux2_sEF(
+    cus_mux21_buf cus_mux21_buf_sEF(
     .A0(S[2]),
     .A1(S[0]),
     .S(c1),
     .X(sEF)
     );
 	//assign sGH = c0 ? sEF : sEH;
-    my_mux2 my_mux2_sGH(
+    cus_mux21_buf cus_mux21_buf_sGH(
     .A0(sEH),
     .A1(sEF),
     .S(c0),
     .X(sGH)
     );
 	//assign sEH = c1 ? S[1] : S[3];
-    my_mux2 my_mux2_sEH(
+    cus_mux21_buf cus_mux21_buf_sEH(
     .A0(S[3]),
     .A1(S[1]),
     .S(c1),
@@ -106,14 +106,14 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign AD = S[1] ? CD : AB;
-    my_mux2 my_mux2_AD(
+    cus_mux21_buf cus_mux21_buf_AD(
     .A0(AB),
     .A1(CD),
     .S(S[1]),
     .X(AD)
     );
 	//assign EH = sEH ? GH : EF;
-    my_mux2 my_mux2_EH(
+    cus_mux21_buf cus_mux21_buf_EH(
     .A0(EF),
     .A1(GH),
     .S(sEH),
@@ -121,7 +121,7 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign AH = S[3] ? EH : AD;
-    my_mux2 my_mux2_AH(
+    cus_mux21_buf cus_mux21_buf_AH(
     .A0(AD),
     .A1(EH),
     .S(S[3]),
@@ -129,7 +129,7 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign EH_GH = c0 ? EH : GH;
-    my_mux2 my_mux2_EH_GH(
+    cus_mux21_buf cus_mux21_buf_EH_GH(
     .A0(GH),
     .A1(EH),
     .S(c0),
@@ -138,14 +138,14 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
 
 	assign M_AB = AB;
 	//assign M_AD = c0 ? AD : CD;
-    my_mux2 my_mux2_M_AD(
+    cus_mux21_buf cus_mux21_buf_M_AD(
     .A0(CD),
     .A1(AD),
     .S(c0),
     .X(M_AD)
     );
 	//assign M_AH = c1 ? AH : EH_GH;
-    my_mux2 my_mux2_M_AH(
+    cus_mux21_buf cus_mux21_buf_M_AH(
     .A0(EH_GH),
     .A1(AH),
     .S(c1),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/LUT4AB/MUX8LUT_frame_config_mux.v
@@ -48,28 +48,28 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
 
 // see figure (column-wise left-to-right)
 	//assign AB = S[0] ? B : A;
-    cus_mux21_buf cus_mux21_buf_AB(
+    cus_mux21 cus_mux21_AB(
     .A0(A),
     .A1(B),
     .S(S[0]),
     .X(AB)
     );
 	//assign CD = sCD ? D : C;
-    cus_mux21_buf cus_mux21_buf_CD(
+    cus_mux21 cus_mux21_CD(
     .A0(C),
     .A1(D),
     .S(sCD),
     .X(CD)
     );
 	//assign EF = sEF ? F : E;
-    cus_mux21_buf cus_mux21_buf_EF(
+    cus_mux21 cus_mux21_EF(
     .A0(E),
     .A1(F),
     .S(sEF),
     .X(EF)
     );
 	//assign GH = sGH ? H : G;
-    cus_mux21_buf cus_mux21_buf_GH(
+    cus_mux21 cus_mux21_GH(
     .A0(G),
     .A1(H),
     .S(sGH),
@@ -77,28 +77,28 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign sCD = c0 ? S[0] : S[1];
-    cus_mux21_buf cus_mux21_buf_sCD(
+    cus_mux21 cus_mux21_sCD(
     .A0(S[1]),
     .A1(S[0]),
     .S(c0),
     .X(sCD)
     );
 	//assign sEF = c1 ? S[0] : S[2];
-    cus_mux21_buf cus_mux21_buf_sEF(
+    cus_mux21 cus_mux21_sEF(
     .A0(S[2]),
     .A1(S[0]),
     .S(c1),
     .X(sEF)
     );
 	//assign sGH = c0 ? sEF : sEH;
-    cus_mux21_buf cus_mux21_buf_sGH(
+    cus_mux21 cus_mux21_sGH(
     .A0(sEH),
     .A1(sEF),
     .S(c0),
     .X(sGH)
     );
 	//assign sEH = c1 ? S[1] : S[3];
-    cus_mux21_buf cus_mux21_buf_sEH(
+    cus_mux21 cus_mux21_sEH(
     .A0(S[3]),
     .A1(S[1]),
     .S(c1),
@@ -106,14 +106,14 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign AD = S[1] ? CD : AB;
-    cus_mux21_buf cus_mux21_buf_AD(
+    cus_mux21 cus_mux21_AD(
     .A0(AB),
     .A1(CD),
     .S(S[1]),
     .X(AD)
     );
 	//assign EH = sEH ? GH : EF;
-    cus_mux21_buf cus_mux21_buf_EH(
+    cus_mux21 cus_mux21_EH(
     .A0(EF),
     .A1(GH),
     .S(sEH),
@@ -121,7 +121,7 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign AH = S[3] ? EH : AD;
-    cus_mux21_buf cus_mux21_buf_AH(
+    cus_mux21 cus_mux21_AH(
     .A0(AD),
     .A1(EH),
     .S(S[3]),
@@ -129,7 +129,7 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
     );
 
 	//assign EH_GH = c0 ? EH : GH;
-    cus_mux21_buf cus_mux21_buf_EH_GH(
+    cus_mux21 cus_mux21_EH_GH(
     .A0(GH),
     .A1(EH),
     .S(c0),
@@ -138,14 +138,14 @@ module MUX8LUT_frame_config_mux #(parameter NoConfigBits = 2)(
 
 	assign M_AB = AB;
 	//assign M_AD = c0 ? AD : CD;
-    cus_mux21_buf cus_mux21_buf_M_AD(
+    cus_mux21 cus_mux21_M_AD(
     .A0(CD),
     .A1(AD),
     .S(c0),
     .X(M_AD)
     );
 	//assign M_AH = c1 ? AH : EH_GH;
-    cus_mux21_buf cus_mux21_buf_M_AH(
+    cus_mux21 cus_mux21_M_AH(
     .A0(EH_GH),
     .A1(AH),
     .S(c1),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
@@ -46,28 +46,28 @@ module InPass4_frame_config_mux #(parameter NoConfigBits = 4)(
 	//assign O[2] = ConfigBits[2] ? Q[2] : I[2];
 	//assign O[3] = ConfigBits[3] ? Q[3] : I[3];
 
-    cus_mux21_buf cus_mux21_buf_inst0(
+    cus_mux21 cus_mux21_inst0(
     .A0(I[0]),
     .A1(Q[0]),
     .S(ConfigBits[0]),
     .X(O[0])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst1(
+    cus_mux21 cus_mux21_inst1(
     .A0(I[1]),
     .A1(Q[1]),
     .S(ConfigBits[1]),
     .X(O[1])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst2(
+    cus_mux21 cus_mux21_inst2(
     .A0(I[2]),
     .A1(Q[2]),
     .S(ConfigBits[2]),
     .X(O[2])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst3(
+    cus_mux21 cus_mux21_inst3(
     .A0(I[3]),
     .A1(Q[3]),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/InPass4_frame_config_mux.v
@@ -46,28 +46,28 @@ module InPass4_frame_config_mux #(parameter NoConfigBits = 4)(
 	//assign O[2] = ConfigBits[2] ? Q[2] : I[2];
 	//assign O[3] = ConfigBits[3] ? Q[3] : I[3];
 
-    my_mux2 my_mux2_inst0(
+    cus_mux21_buf cus_mux21_buf_inst0(
     .A0(I[0]),
     .A1(Q[0]),
     .S(ConfigBits[0]),
     .X(O[0])
     );
 
-    my_mux2 my_mux2_inst1(
+    cus_mux21_buf cus_mux21_buf_inst1(
     .A0(I[1]),
     .A1(Q[1]),
     .S(ConfigBits[1]),
     .X(O[1])
     );
 
-    my_mux2 my_mux2_inst2(
+    cus_mux21_buf cus_mux21_buf_inst2(
     .A0(I[2]),
     .A1(Q[2]),
     .S(ConfigBits[2]),
     .X(O[2])
     );
 
-    my_mux2 my_mux2_inst3(
+    cus_mux21_buf cus_mux21_buf_inst3(
     .A0(I[3]),
     .A1(Q[3]),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
@@ -51,28 +51,28 @@ module OutPass4_frame_config_mux #(parameter NoConfigBits = 4)(
 	//assign O2 = ConfigBits[2] ? Q2 : I2;
 	//assign O3 = ConfigBits[3] ? Q3 : I3;
 
-    my_mux2 my_mux2_inst0(
+    cus_mux21_buf cus_mux21_buf_inst0(
     .A0(I[0]),
     .A1(Q[0]),
     .S(ConfigBits[0]),
     .X(O[0])
     );
 
-    my_mux2 my_mux2_inst1(
+    cus_mux21_buf cus_mux21_buf_inst1(
     .A0(I[1]),
     .A1(Q[1]),
     .S(ConfigBits[1]),
     .X(O[1])
     );
 
-    my_mux2 my_mux2_inst2(
+    cus_mux21_buf cus_mux21_buf_inst2(
     .A0(I[2]),
     .A1(Q[2]),
     .S(ConfigBits[2]),
     .X(O[2])
     );
 
-    my_mux2 my_mux2_inst3(
+    cus_mux21_buf cus_mux21_buf_inst3(
     .A0(I[3]),
     .A1(Q[3]),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/FABulous_project_template_verilog/Tile/RAM_IO/OutPass4_frame_config_mux.v
@@ -51,28 +51,28 @@ module OutPass4_frame_config_mux #(parameter NoConfigBits = 4)(
 	//assign O2 = ConfigBits[2] ? Q2 : I2;
 	//assign O3 = ConfigBits[3] ? Q3 : I3;
 
-    cus_mux21_buf cus_mux21_buf_inst0(
+    cus_mux21 cus_mux21_inst0(
     .A0(I[0]),
     .A1(Q[0]),
     .S(ConfigBits[0]),
     .X(O[0])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst1(
+    cus_mux21 cus_mux21_inst1(
     .A0(I[1]),
     .A1(Q[1]),
     .S(ConfigBits[1]),
     .X(O[1])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst2(
+    cus_mux21 cus_mux21_inst2(
     .A0(I[2]),
     .A1(Q[2]),
     .S(ConfigBits[2]),
     .X(O[2])
     );
 
-    cus_mux21_buf cus_mux21_buf_inst3(
+    cus_mux21 cus_mux21_inst3(
     .A0(I[3]),
     .A1(Q[3]),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/my_lib.vhdl
+++ b/FABulous/fabric_files/FABulous_project_template_vhdl/Fabric/my_lib.vhdl
@@ -4,19 +4,19 @@ use ieee.numeric_std.all;
 
 entity LHQD1 is
   port (
-    D : in std_logic;
-    E : in std_logic;
-    Q : out std_logic;
+    D  : in std_logic;
+    E  : in std_logic;
+    Q  : out std_logic;
     QN : out std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of LHQD1 is
 begin
   process (E, D) is
   begin
     if rising_edge(E) then
-      Q <= D;
+      Q  <= D;
       QN <= not D;
     end if;
   end process;
@@ -28,7 +28,7 @@ use ieee.numeric_std.all;
 
 entity MUX16PTv2 is
   port (
-    IN1 : in std_logic;
+    IN1  : in std_logic;
     IN10 : in std_logic;
     IN11 : in std_logic;
     IN12 : in std_logic;
@@ -36,21 +36,21 @@ entity MUX16PTv2 is
     IN14 : in std_logic;
     IN15 : in std_logic;
     IN16 : in std_logic;
-    IN2 : in std_logic;
-    IN3 : in std_logic;
-    IN4 : in std_logic;
-    IN5 : in std_logic;
-    IN6 : in std_logic;
-    IN7 : in std_logic;
-    IN8 : in std_logic;
-    IN9 : in std_logic;
-    O : out std_logic;
-    S1 : in std_logic;
-    S2 : in std_logic;
-    S3 : in std_logic;
-    S4 : in std_logic
+    IN2  : in std_logic;
+    IN3  : in std_logic;
+    IN4  : in std_logic;
+    IN5  : in std_logic;
+    IN6  : in std_logic;
+    IN7  : in std_logic;
+    IN8  : in std_logic;
+    IN9  : in std_logic;
+    O    : out std_logic;
+    S1   : in std_logic;
+    S2   : in std_logic;
+    S3   : in std_logic;
+    S4   : in std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of MUX16PTv2 is
   signal a0 : std_logic_vector(7 downto 0);
@@ -61,16 +61,16 @@ architecture from_verilog of MUX16PTv2 is
     variable r : std_logic;
   begin
     r := a when s = '0' else
-         b when s = '1' else
-         a when a = b else -- case when S is undefined, but it's don't care because a and b are the same
-         'U';
+      b when s = '1' else
+      a when a = b else -- case when S is undefined, but it's don't care because a and b are the same
+      'U';
     return r;
   end function;
 begin
   a0 <= f_mux2(IN15, IN16, S1) & f_mux2(IN13, IN14, S1) & f_mux2(IN11, IN12, S1) & f_mux2(IN9, IN10, S1) & f_mux2(IN7, IN8, S1) & f_mux2(IN5, IN6, S1) & f_mux2(IN3, IN4, S1) & f_mux2(IN1, IN2, S1);
   a1 <= f_mux2(a0(6), a0(7), S2) & f_mux2(a0(4), a0(5), S2) & f_mux2(a0(2), a0(3), S2) & f_mux2(a0(0), a0(1), S2);
   a2 <= f_mux2(a1(2), a1(3), S3) & f_mux2(a1(0), a1(1), S3);
-  O <= f_mux2(a2(0), a2(1), S4) ;
+  O  <= f_mux2(a2(0), a2(1), S4);
 end architecture;
 
 library ieee;
@@ -83,24 +83,24 @@ entity MUX4PTv4 is
     IN2 : in std_logic;
     IN3 : in std_logic;
     IN4 : in std_logic;
-    O : out std_logic;
-    S1 : in std_logic;
-    S2 : in std_logic
+    O   : out std_logic;
+    S1  : in std_logic;
+    S2  : in std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of MUX4PTv4 is
-  signal SEL : unsigned(1 downto 0); 
+  signal SEL : unsigned(1 downto 0);
 begin
   SEL <= S2 & S1;
 
   with SEL select
-    O <= IN1  when "00",
-         IN2  when "01",
-         IN3  when "10",
-         IN4  when "11",
-         'U'  when others ;
-  
+    O <= IN1 when "00",
+    IN2 when "01",
+    IN3 when "10",
+    IN4 when "11",
+    'U' when others;
+
 end architecture;
 
 library ieee;
@@ -109,121 +109,126 @@ use ieee.numeric_std.all;
 
 entity cus_mux161 is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
     A10 : in std_logic;
     A11 : in std_logic;
     A12 : in std_logic;
     A13 : in std_logic;
     A14 : in std_logic;
     A15 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    A8 : in std_logic;
-    A9 : in std_logic;
-    S0 : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    A4  : in std_logic;
+    A5  : in std_logic;
+    A6  : in std_logic;
+    A7  : in std_logic;
+    A8  : in std_logic;
+    A9  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    S2 : in std_logic;
+    S2  : in std_logic;
     S2N : in std_logic;
-    S3 : in std_logic;
+    S3  : in std_logic;
     S3N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of cus_mux161 is
   signal cus_mux41_out0 : std_logic;
   signal cus_mux41_out1 : std_logic;
   signal cus_mux41_out2 : std_logic;
   signal cus_mux41_out3 : std_logic;
-  
+
   component cus_mux41 is
     port (
-      A0 : in std_logic;
-      A1 : in std_logic;
-      A2 : in std_logic;
-      A3 : in std_logic;
-      S0 : in std_logic;
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
       S0N : in std_logic;
-      S1 : in std_logic;
+      S1  : in std_logic;
       S1N : in std_logic;
-      X : out std_logic
+      X   : out std_logic
     );
   end component;
   signal X_Readable : std_logic;
 begin
-  
-  cus_mux41_inst0: cus_mux41
-    port map (
-      A0 => A0,
-      A1 => A1,
-      A2 => A2,
-      A3 => A3,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out0
-    );
-  
-  cus_mux41_inst1: cus_mux41
-    port map (
-      A0 => A4,
-      A1 => A5,
-      A2 => A6,
-      A3 => A7,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out1
-    );
-  
-  cus_mux41_inst2: cus_mux41
-    port map (
-      A0 => A8,
-      A1 => A9,
-      A2 => A10,
-      A3 => A11,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out2
-    );
-  
-  cus_mux41_inst3: cus_mux41
-    port map (
-      A0 => A12,
-      A1 => A13,
-      A2 => A14,
-      A3 => A15,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out3
-    );
+
+  cus_mux41_inst0 : cus_mux41
+  port map
+  (
+    A0  => A0,
+    A1  => A1,
+    A2  => A2,
+    A3  => A3,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out0
+  );
+
+  cus_mux41_inst1 : cus_mux41
+  port map
+  (
+    A0  => A4,
+    A1  => A5,
+    A2  => A6,
+    A3  => A7,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out1
+  );
+
+  cus_mux41_inst2 : cus_mux41
+  port map
+  (
+    A0  => A8,
+    A1  => A9,
+    A2  => A10,
+    A3  => A11,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out2
+  );
+
+  cus_mux41_inst3 : cus_mux41
+  port map
+  (
+    A0  => A12,
+    A1  => A13,
+    A2  => A14,
+    A3  => A15,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out3
+  );
   X <= X_Readable;
-  
-  cus_mux41_inst4: cus_mux41
-    port map (
-      A0 => cus_mux41_out0,
-      A1 => cus_mux41_out1,
-      A2 => cus_mux41_out2,
-      A3 => cus_mux41_out3,
-      S0 => S2,
-      S0N => S2N,
-      S1 => S3,
-      S1N => S3N,
-      X => X_Readable
-    );
+
+  cus_mux41_inst4 : cus_mux41
+  port map
+  (
+    A0  => cus_mux41_out0,
+    A1  => cus_mux41_out1,
+    A2  => cus_mux41_out2,
+    A3  => cus_mux41_out3,
+    S0  => S2,
+    S0N => S2N,
+    S1  => S3,
+    S1N => S3N,
+    X   => X_Readable
+  );
 end architecture;
 
 library ieee;
@@ -232,32 +237,32 @@ use ieee.numeric_std.all;
 
 entity cus_mux41 is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    S0 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of cus_mux41 is
-  signal SEL : unsigned(1 downto 0);
-  signal X_reg : std_logic;
+  signal SEL          : unsigned(1 downto 0);
+  signal X_reg        : std_logic;
   signal LPM_d0_ivl_1 : std_logic;
   signal LPM_d1_ivl_1 : std_logic;
 begin
   SEL <= S1 & S0;
 
   with SEL select
-    X <= A0  when "00",
-         A1  when "01",
-         A2  when "10",
-         A3  when "11",
-         'U'  when others;
+    X <= A0 when "00",
+    A1 when "01",
+    A2 when "10",
+    A3 when "11",
+    'U' when others;
 
 end architecture;
 
@@ -267,121 +272,126 @@ use ieee.numeric_std.all;
 
 entity cus_mux161_buf is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
     A10 : in std_logic;
     A11 : in std_logic;
     A12 : in std_logic;
     A13 : in std_logic;
     A14 : in std_logic;
     A15 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    A8 : in std_logic;
-    A9 : in std_logic;
-    S0 : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    A4  : in std_logic;
+    A5  : in std_logic;
+    A6  : in std_logic;
+    A7  : in std_logic;
+    A8  : in std_logic;
+    A9  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    S2 : in std_logic;
+    S2  : in std_logic;
     S2N : in std_logic;
-    S3 : in std_logic;
+    S3  : in std_logic;
     S3N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 -- Generated from Verilog module cus_mux161_buf (./models_pack.v:418)
 architecture from_verilog of cus_mux161_buf is
   signal cus_mux41_buf_out0 : std_logic;
-  signal cus_mux41_buf_out1 : std_logic; 
-  signal cus_mux41_buf_out2 : std_logic; 
-  signal cus_mux41_buf_out3 : std_logic; 
-  
+  signal cus_mux41_buf_out1 : std_logic;
+  signal cus_mux41_buf_out2 : std_logic;
+  signal cus_mux41_buf_out3 : std_logic;
+
   component cus_mux41_buf is
     port (
-      A0 : in std_logic;
-      A1 : in std_logic;
-      A2 : in std_logic;
-      A3 : in std_logic;
-      S0 : in std_logic;
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
       S0N : in std_logic;
-      S1 : in std_logic;
+      S1  : in std_logic;
       S1N : in std_logic;
-      X : out std_logic
+      X   : out std_logic
     );
   end component;
-  signal X_Readable : std_logic; 
+  signal X_Readable : std_logic;
 begin
-  cus_mux41_buf_inst0: cus_mux41_buf
-    port map (
-      A0 => A0,
-      A1 => A1,
-      A2 => A2,
-      A3 => A3,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out0
-    );
-  
-  cus_mux41_buf_inst1: cus_mux41_buf
-    port map (
-      A0 => A4,
-      A1 => A5,
-      A2 => A6,
-      A3 => A7,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out1
-    );
+  cus_mux41_buf_inst0 : cus_mux41_buf
+  port map
+  (
+    A0  => A0,
+    A1  => A1,
+    A2  => A2,
+    A3  => A3,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out0
+  );
 
-  cus_mux41_buf_inst2: cus_mux41_buf
-    port map (
-      A0 => A8,
-      A1 => A9,
-      A2 => A10,
-      A3 => A11,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out2
-    );
-  
-  cus_mux41_buf_inst3: cus_mux41_buf
-    port map (
-      A0 => A12,
-      A1 => A13,
-      A2 => A14,
-      A3 => A15,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out3
-    );
+  cus_mux41_buf_inst1 : cus_mux41_buf
+  port map
+  (
+    A0  => A4,
+    A1  => A5,
+    A2  => A6,
+    A3  => A7,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out1
+  );
+
+  cus_mux41_buf_inst2 : cus_mux41_buf
+  port map
+  (
+    A0  => A8,
+    A1  => A9,
+    A2  => A10,
+    A3  => A11,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out2
+  );
+
+  cus_mux41_buf_inst3 : cus_mux41_buf
+  port map
+  (
+    A0  => A12,
+    A1  => A13,
+    A2  => A14,
+    A3  => A15,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out3
+  );
   X <= X_Readable;
 
-  cus_mux41_buf_inst4: cus_mux41_buf
-    port map (
-      A0 => cus_mux41_buf_out0,
-      A1 => cus_mux41_buf_out1,
-      A2 => cus_mux41_buf_out2,
-      A3 => cus_mux41_buf_out3,
-      S0 => S2,
-      S0N => S2N,
-      S1 => S3,
-      S1N => S3N,
-      X => X_Readable
-    );
+  cus_mux41_buf_inst4 : cus_mux41_buf
+  port map
+  (
+    A0  => cus_mux41_buf_out0,
+    A1  => cus_mux41_buf_out1,
+    A2  => cus_mux41_buf_out2,
+    A3  => cus_mux41_buf_out3,
+    S0  => S2,
+    S0N => S2N,
+    S1  => S3,
+    S1N => S3N,
+    X   => X_Readable
+  );
 end architecture;
 
 library ieee;
@@ -390,30 +400,30 @@ use ieee.numeric_std.all;
 
 entity cus_mux41_buf is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    S0 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of cus_mux41_buf is
-  signal SEL : unsigned(1 downto 0); 
+  signal SEL          : unsigned(1 downto 0);
   signal LPM_d0_ivl_1 : std_logic;
   signal LPM_d1_ivl_1 : std_logic;
 begin
   SEL <= S1 & S0;
   with SEL select
-    X <= A0  when "00",
-         A1  when "01",
-         A2  when "10",
-         A3  when "11",
-        'U'  when others;
+    X <= A0 when "00",
+    A1 when "01",
+    A2 when "10",
+    A3 when "11",
+    'U' when others;
 
 end architecture;
 
@@ -423,112 +433,115 @@ use ieee.numeric_std.all;
 
 entity cus_mux81 is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    S0 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    A4  : in std_logic;
+    A5  : in std_logic;
+    A6  : in std_logic;
+    A7  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    S2 : in std_logic;
+    S2  : in std_logic;
     S2N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 architecture from_verilog of cus_mux81 is
-  signal cus_mux41_out0 : std_logic;  
-  signal cus_mux41_out1 : std_logic; 
-  
+  signal cus_mux41_out0 : std_logic;
+  signal cus_mux41_out1 : std_logic;
+
   component cus_mux41 is
     port (
-      A0 : in std_logic;
-      A1 : in std_logic;
-      A2 : in std_logic;
-      A3 : in std_logic;
-      S0 : in std_logic;
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
       S0N : in std_logic;
-      S1 : in std_logic;
+      S1  : in std_logic;
       S1N : in std_logic;
-      X : out std_logic
+      X   : out std_logic
     );
   end component;
-  
-  component my_mux2 is
+
+  component cus_mux21 is
     port (
       A0 : in std_logic;
       A1 : in std_logic;
-      S : in std_logic;
-      X : out std_logic
+      S  : in std_logic;
+      X  : out std_logic
     );
   end component;
-  signal X_Readable : std_logic; 
+  signal X_Readable : std_logic;
 begin
-  
-  cus_mux41_inst0: cus_mux41
-    port map (
-      A0 => A0,
-      A1 => A1,
-      A2 => A2,
-      A3 => A3,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out0
-    );
-  
-  cus_mux41_inst1: cus_mux41
-    port map (
-      A0 => A4,
-      A1 => A5,
-      A2 => A6,
-      A3 => A7,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_out1
-    );
+
+  cus_mux41_inst0 : cus_mux41
+  port map
+  (
+    A0  => A0,
+    A1  => A1,
+    A2  => A2,
+    A3  => A3,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out0
+  );
+
+  cus_mux41_inst1 : cus_mux41
+  port map
+  (
+    A0  => A4,
+    A1  => A5,
+    A2  => A6,
+    A3  => A7,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_out1
+  );
   X <= X_Readable;
-  
-  my_mux2_inst: my_mux2
-    port map (
-      A0 => cus_mux41_out0,
-      A1 => cus_mux41_out1,
-      S => S2,
-      X => X_Readable
-    );
+
+  cus_mux21_inst : cus_mux21
+  port map
+  (
+    A0 => cus_mux41_out0,
+    A1 => cus_mux41_out1,
+    S  => S2,
+    X  => X_Readable
+  );
 end architecture;
 
 library ieee;
 use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
-entity my_mux2 is
+entity cus_mux21 is
   port (
     A0 : in std_logic;
     A1 : in std_logic;
-    S : in std_logic;
-    X : out std_logic
+    S  : in std_logic;
+    X  : out std_logic
   );
-end entity; 
+end entity;
 
-architecture from_verilog of my_mux2 is
+architecture from_verilog of cus_mux21 is
   signal SEL : std_logic;
 begin
   SEL <= S;
 
   with SEL select
-    X <= A0  when '0',
-         A1  when '1',
-        'U'  when others;
-  
+    X <= A0 when '0',
+    A1 when '1',
+    'U' when others;
+
 end architecture;
 
 library ieee;
@@ -538,91 +551,94 @@ use ieee.numeric_std.all;
 -- Generated from Verilog module cus_mux81_buf (./models_pack.v:273)
 entity cus_mux81_buf is
   port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    S0 : in std_logic;
+    A0  : in std_logic;
+    A1  : in std_logic;
+    A2  : in std_logic;
+    A3  : in std_logic;
+    A4  : in std_logic;
+    A5  : in std_logic;
+    A6  : in std_logic;
+    A7  : in std_logic;
+    S0  : in std_logic;
     S0N : in std_logic;
-    S1 : in std_logic;
+    S1  : in std_logic;
     S1N : in std_logic;
-    S2 : in std_logic;
+    S2  : in std_logic;
     S2N : in std_logic;
-    X : out std_logic
+    X   : out std_logic
   );
-end entity; 
+end entity;
 
 -- Generated from Verilog module cus_mux81_buf (./models_pack.v:273)
 architecture from_verilog of cus_mux81_buf is
-  signal cus_mux41_buf_out0 : std_logic;  -- Declared at ./models_pack.v:290
-  signal cus_mux41_buf_out1 : std_logic;  -- Declared at ./models_pack.v:291
-  
+  signal cus_mux41_buf_out0 : std_logic; -- Declared at ./models_pack.v:290
+  signal cus_mux41_buf_out1 : std_logic; -- Declared at ./models_pack.v:291
+
   component cus_mux41_buf is
     port (
-      A0 : in std_logic;
-      A1 : in std_logic;
-      A2 : in std_logic;
-      A3 : in std_logic;
-      S0 : in std_logic;
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
       S0N : in std_logic;
-      S1 : in std_logic;
+      S1  : in std_logic;
       S1N : in std_logic;
-      X : out std_logic
+      X   : out std_logic
     );
   end component;
-  
-  component my_mux2 is
+
+  component cus_mux21 is
     port (
       A0 : in std_logic;
       A1 : in std_logic;
-      S : in std_logic;
-      X : out std_logic
+      S  : in std_logic;
+      X  : out std_logic
     );
   end component;
-  signal X_Readable : std_logic;  -- Needed to connect outputs
+  signal X_Readable : std_logic; -- Needed to connect outputs
 begin
-  
+
   -- Generated from instantiation at ./models_pack.v:293
-  cus_mux41_buf_inst0: cus_mux41_buf
-    port map (
-      A0 => A0,
-      A1 => A1,
-      A2 => A2,
-      A3 => A3,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out0
-    );
-  
+  cus_mux41_buf_inst0 : cus_mux41_buf
+  port map
+  (
+    A0  => A0,
+    A1  => A1,
+    A2  => A2,
+    A3  => A3,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out0
+  );
+
   -- Generated from instantiation at ./models_pack.v:305
-  cus_mux41_buf_inst1: cus_mux41_buf
-    port map (
-      A0 => A4,
-      A1 => A5,
-      A2 => A6,
-      A3 => A7,
-      S0 => S0,
-      S0N => S0N,
-      S1 => S1,
-      S1N => S1N,
-      X => cus_mux41_buf_out1
-    );
+  cus_mux41_buf_inst1 : cus_mux41_buf
+  port map
+  (
+    A0  => A4,
+    A1  => A5,
+    A2  => A6,
+    A3  => A7,
+    S0  => S0,
+    S0N => S0N,
+    S1  => S1,
+    S1N => S1N,
+    X   => cus_mux41_buf_out1
+  );
   X <= X_Readable;
-  
+
   -- Generated from instantiation at ./models_pack.v:317
-  my_mux2_inst: my_mux2
-    port map (
-      A0 => cus_mux41_buf_out0,
-      A1 => cus_mux41_buf_out1,
-      S => S2,
-      X => X_Readable
-    );
+  cus_mux21_inst : cus_mux21
+  port map
+  (
+    A0 => cus_mux41_buf_out0,
+    A1 => cus_mux41_buf_out1,
+    S  => S2,
+    X  => X_Readable
+  );
 end architecture;
 
 library ieee;
@@ -635,7 +651,7 @@ entity my_buf is
     A : in std_logic;
     X : out std_logic
   );
-end entity; 
+end entity;
 
 -- Generated from Verilog module my_buf (./models_pack.v:144)
 architecture from_verilog of my_buf is
@@ -653,7 +669,7 @@ entity clk_buf is
     A : in std_logic;
     X : out std_logic
   );
-end entity; 
+end entity;
 
 -- Generated from Verilog module clk_buf (fabulous_tb.v:83)
 architecture Behavior of clk_buf is
@@ -664,204 +680,204 @@ end architecture;
 library ieee;
 use ieee.std_logic_1164.all;
 
-package my_package is 
+package my_package is
 
-component LHQD1 is
-  port (
-    D : in std_logic;
-    E : in std_logic;
-    Q : out std_logic;
-    QN : out std_logic
-  );
-end component;
+  component LHQD1 is
+    port (
+      D  : in std_logic;
+      E  : in std_logic;
+      Q  : out std_logic;
+      QN : out std_logic
+    );
+  end component;
 
-component MUX16PTv2 is
-  port (
-    IN1 : in std_logic;
-    IN10 : in std_logic;
-    IN11 : in std_logic;
-    IN12 : in std_logic;
-    IN13 : in std_logic;
-    IN14 : in std_logic;
-    IN15 : in std_logic;
-    IN16 : in std_logic;
-    IN2 : in std_logic;
-    IN3 : in std_logic;
-    IN4 : in std_logic;
-    IN5 : in std_logic;
-    IN6 : in std_logic;
-    IN7 : in std_logic;
-    IN8 : in std_logic;
-    IN9 : in std_logic;
-    O : out std_logic;
-    S1 : in std_logic;
-    S2 : in std_logic;
-    S3 : in std_logic;
-    S4 : in std_logic
-  );
-end component;
+  component MUX16PTv2 is
+    port (
+      IN1  : in std_logic;
+      IN10 : in std_logic;
+      IN11 : in std_logic;
+      IN12 : in std_logic;
+      IN13 : in std_logic;
+      IN14 : in std_logic;
+      IN15 : in std_logic;
+      IN16 : in std_logic;
+      IN2  : in std_logic;
+      IN3  : in std_logic;
+      IN4  : in std_logic;
+      IN5  : in std_logic;
+      IN6  : in std_logic;
+      IN7  : in std_logic;
+      IN8  : in std_logic;
+      IN9  : in std_logic;
+      O    : out std_logic;
+      S1   : in std_logic;
+      S2   : in std_logic;
+      S3   : in std_logic;
+      S4   : in std_logic
+    );
+  end component;
 
-component MUX4PTv4 is
-  port (
-    IN1 : in std_logic;
-    IN2 : in std_logic;
-    IN3 : in std_logic;
-    IN4 : in std_logic;
-    O : out std_logic;
-    S1 : in std_logic;
-    S2 : in std_logic
-  );
-end component; 
+  component MUX4PTv4 is
+    port (
+      IN1 : in std_logic;
+      IN2 : in std_logic;
+      IN3 : in std_logic;
+      IN4 : in std_logic;
+      O   : out std_logic;
+      S1  : in std_logic;
+      S2  : in std_logic
+    );
+  end component;
 
-component cus_mux161 is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A10 : in std_logic;
-    A11 : in std_logic;
-    A12 : in std_logic;
-    A13 : in std_logic;
-    A14 : in std_logic;
-    A15 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    A8 : in std_logic;
-    A9 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    S2 : in std_logic;
-    S2N : in std_logic;
-    S3 : in std_logic;
-    S3N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux161 is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A10 : in std_logic;
+      A11 : in std_logic;
+      A12 : in std_logic;
+      A13 : in std_logic;
+      A14 : in std_logic;
+      A15 : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      A4  : in std_logic;
+      A5  : in std_logic;
+      A6  : in std_logic;
+      A7  : in std_logic;
+      A8  : in std_logic;
+      A9  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      S2  : in std_logic;
+      S2N : in std_logic;
+      S3  : in std_logic;
+      S3N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component cus_mux41 is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux41 is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component cus_mux161_buf is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A10 : in std_logic;
-    A11 : in std_logic;
-    A12 : in std_logic;
-    A13 : in std_logic;
-    A14 : in std_logic;
-    A15 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    A8 : in std_logic;
-    A9 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    S2 : in std_logic;
-    S2N : in std_logic;
-    S3 : in std_logic;
-    S3N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux161_buf is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A10 : in std_logic;
+      A11 : in std_logic;
+      A12 : in std_logic;
+      A13 : in std_logic;
+      A14 : in std_logic;
+      A15 : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      A4  : in std_logic;
+      A5  : in std_logic;
+      A6  : in std_logic;
+      A7  : in std_logic;
+      A8  : in std_logic;
+      A9  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      S2  : in std_logic;
+      S2N : in std_logic;
+      S3  : in std_logic;
+      S3N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component cus_mux41_buf is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux41_buf is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component cus_mux81 is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    S2 : in std_logic;
-    S2N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux81 is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      A4  : in std_logic;
+      A5  : in std_logic;
+      A6  : in std_logic;
+      A7  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      S2  : in std_logic;
+      S2N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component my_mux2 is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    S : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux21 is
+    port (
+      A0 : in std_logic;
+      A1 : in std_logic;
+      S  : in std_logic;
+      X  : out std_logic
+    );
+  end component;
 
-component cus_mux81_buf is
-  port (
-    A0 : in std_logic;
-    A1 : in std_logic;
-    A2 : in std_logic;
-    A3 : in std_logic;
-    A4 : in std_logic;
-    A5 : in std_logic;
-    A6 : in std_logic;
-    A7 : in std_logic;
-    S0 : in std_logic;
-    S0N : in std_logic;
-    S1 : in std_logic;
-    S1N : in std_logic;
-    S2 : in std_logic;
-    S2N : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component cus_mux81_buf is
+    port (
+      A0  : in std_logic;
+      A1  : in std_logic;
+      A2  : in std_logic;
+      A3  : in std_logic;
+      A4  : in std_logic;
+      A5  : in std_logic;
+      A6  : in std_logic;
+      A7  : in std_logic;
+      S0  : in std_logic;
+      S0N : in std_logic;
+      S1  : in std_logic;
+      S1N : in std_logic;
+      S2  : in std_logic;
+      S2N : in std_logic;
+      X   : out std_logic
+    );
+  end component;
 
-component my_buf is
-  port (
-    A : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component my_buf is
+    port (
+      A : in std_logic;
+      X : out std_logic
+    );
+  end component;
 
-component clk_buf is
-  port (
-    A : in std_logic;
-    X : out std_logic
-  );
-end component; 
+  component clk_buf is
+    port (
+      A : in std_logic;
+      X : out std_logic
+    );
+  end component;
 
 end package my_package;

--- a/FABulous/fabric_files/generic/InPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/generic/InPass4_frame_config_mux.v
@@ -55,28 +55,28 @@ module InPass4_frame_config (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, ConfigBits
 	//assign O2 = ConfigBits[2] ? Q2 : I2;
 	//assign O3 = ConfigBits[3] ? Q3 : I3;
 
-    cus_mux21_buf cus_mux21_buf_inst0(
+    cus_mux21 cus_mux21_inst0(
     .A0(I0),
     .A1(Q0),
     .S(ConfigBits[0]),
     .X(O0)
     );
 
-    cus_mux21_buf cus_mux21_buf_inst1(
+    cus_mux21 cus_mux21_inst1(
     .A0(I1),
     .A1(Q1),
     .S(ConfigBits[1]),
     .X(O1)
     );
 
-    cus_mux21_buf cus_mux21_buf_inst2(
+    cus_mux21 cus_mux21_inst2(
     .A0(I2),
     .A1(Q2),
     .S(ConfigBits[2]),
     .X(O2)
     );
 
-    cus_mux21_buf cus_mux21_buf_inst3(
+    cus_mux21 cus_mux21_inst3(
     .A0(I3),
     .A1(Q3),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/generic/InPass4_frame_config_mux.v
+++ b/FABulous/fabric_files/generic/InPass4_frame_config_mux.v
@@ -55,28 +55,28 @@ module InPass4_frame_config (I0, I1, I2, I3, O0, O1, O2, O3, UserCLK, ConfigBits
 	//assign O2 = ConfigBits[2] ? Q2 : I2;
 	//assign O3 = ConfigBits[3] ? Q3 : I3;
 
-    my_mux2 my_mux2_inst0(
+    cus_mux21_buf cus_mux21_buf_inst0(
     .A0(I0),
     .A1(Q0),
     .S(ConfigBits[0]),
     .X(O0)
     );
 
-    my_mux2 my_mux2_inst1(
+    cus_mux21_buf cus_mux21_buf_inst1(
     .A0(I1),
     .A1(Q1),
     .S(ConfigBits[1]),
     .X(O1)
     );
 
-    my_mux2 my_mux2_inst2(
+    cus_mux21_buf cus_mux21_buf_inst2(
     .A0(I2),
     .A1(Q2),
     .S(ConfigBits[2]),
     .X(O2)
     );
 
-    my_mux2 my_mux2_inst3(
+    cus_mux21_buf cus_mux21_buf_inst3(
     .A0(I3),
     .A1(Q3),
     .S(ConfigBits[3]),

--- a/FABulous/fabric_files/generic/MUX8LUT_frame_config_mux.v
+++ b/FABulous/fabric_files/generic/MUX8LUT_frame_config_mux.v
@@ -51,28 +51,28 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
 
 // see figure (column-wise left-to-right)
 	//assign AB = S0 ? B : A;
-    my_mux2 my_mux2_AB(
+    cus_mux21_buf cus_mux21_buf_AB(
     .A0(A),
     .A1(B),
     .S(S0),
     .X(AB)
     );
 	//assign CD = sCD ? D : C;
-    my_mux2 my_mux2_CD(
+    cus_mux21_buf cus_mux21_buf_CD(
     .A0(C),
     .A1(D),
     .S(sCD),
     .X(CD)
     );
 	//assign EF = sEF ? F : E;
-    my_mux2 my_mux2_EF(
+    cus_mux21_buf cus_mux21_buf_EF(
     .A0(E),
     .A1(F),
     .S(sEF),
     .X(EF)
     );
 	//assign GH = sGH ? H : G;
-    my_mux2 my_mux2_GH(
+    cus_mux21_buf cus_mux21_buf_GH(
     .A0(G),
     .A1(H),
     .S(sGH),
@@ -80,28 +80,28 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign sCD = c0 ? S0 : S1;
-    my_mux2 my_mux2_sCD(
+    cus_mux21_buf cus_mux21_buf_sCD(
     .A0(S1),
     .A1(S0),
     .S(c0),
     .X(sCD)
     );
 	//assign sEF = c1 ? S0 : S2;
-    my_mux2 my_mux2_sEF(
+    cus_mux21_buf cus_mux21_buf_sEF(
     .A0(S2),
     .A1(S0),
     .S(c1),
     .X(sEF)
     );
 	//assign sGH = c0 ? sEF : sEH;
-    my_mux2 my_mux2_sGH(
+    cus_mux21_buf cus_mux21_buf_sGH(
     .A0(sEH),
     .A1(sEF),
     .S(c0),
     .X(sGH)
     );
 	//assign sEH = c1 ? S1 : S3;
-    my_mux2 my_mux2_sEH(
+    cus_mux21_buf cus_mux21_buf_sEH(
     .A0(S3),
     .A1(S1),
     .S(c1),
@@ -109,14 +109,14 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign AD = S1 ? CD : AB;
-    my_mux2 my_mux2_AD(
+    cus_mux21_buf cus_mux21_buf_AD(
     .A0(AB),
     .A1(CD),
     .S(S1),
     .X(AD)
     );
 	//assign EH = sEH ? GH : EF;
-    my_mux2 my_mux2_EH(
+    cus_mux21_buf cus_mux21_buf_EH(
     .A0(EF),
     .A1(GH),
     .S(sEH),
@@ -124,7 +124,7 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign AH = S3 ? EH : AD;
-    my_mux2 my_mux2_AH(
+    cus_mux21_buf cus_mux21_buf_AH(
     .A0(AD),
     .A1(EH),
     .S(S3),
@@ -132,7 +132,7 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign EH_GH = c0 ? EH : GH;
-    my_mux2 my_mux2_EH_GH(
+    cus_mux21_buf cus_mux21_buf_EH_GH(
     .A0(GH),
     .A1(EH),
     .S(c0),
@@ -141,14 +141,14 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
 
 	assign M_AB = AB;
 	//assign M_AD = c0 ? AD : CD;
-    my_mux2 my_mux2_M_AD(
+    cus_mux21_buf cus_mux21_buf_M_AD(
     .A0(CD),
     .A1(AD),
     .S(c0),
     .X(M_AD)
     );
 	//assign M_AH = c1 ? AH : EH_GH;
-    my_mux2 my_mux2_M_AH(
+    cus_mux21_buf cus_mux21_buf_M_AH(
     .A0(EH_GH),
     .A1(AH),
     .S(c1),

--- a/FABulous/fabric_files/generic/MUX8LUT_frame_config_mux.v
+++ b/FABulous/fabric_files/generic/MUX8LUT_frame_config_mux.v
@@ -51,28 +51,28 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
 
 // see figure (column-wise left-to-right)
 	//assign AB = S0 ? B : A;
-    cus_mux21_buf cus_mux21_buf_AB(
+    cus_mux21 cus_mux21_AB(
     .A0(A),
     .A1(B),
     .S(S0),
     .X(AB)
     );
 	//assign CD = sCD ? D : C;
-    cus_mux21_buf cus_mux21_buf_CD(
+    cus_mux21 cus_mux21_CD(
     .A0(C),
     .A1(D),
     .S(sCD),
     .X(CD)
     );
 	//assign EF = sEF ? F : E;
-    cus_mux21_buf cus_mux21_buf_EF(
+    cus_mux21 cus_mux21_EF(
     .A0(E),
     .A1(F),
     .S(sEF),
     .X(EF)
     );
 	//assign GH = sGH ? H : G;
-    cus_mux21_buf cus_mux21_buf_GH(
+    cus_mux21 cus_mux21_GH(
     .A0(G),
     .A1(H),
     .S(sGH),
@@ -80,28 +80,28 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign sCD = c0 ? S0 : S1;
-    cus_mux21_buf cus_mux21_buf_sCD(
+    cus_mux21 cus_mux21_sCD(
     .A0(S1),
     .A1(S0),
     .S(c0),
     .X(sCD)
     );
 	//assign sEF = c1 ? S0 : S2;
-    cus_mux21_buf cus_mux21_buf_sEF(
+    cus_mux21 cus_mux21_sEF(
     .A0(S2),
     .A1(S0),
     .S(c1),
     .X(sEF)
     );
 	//assign sGH = c0 ? sEF : sEH;
-    cus_mux21_buf cus_mux21_buf_sGH(
+    cus_mux21 cus_mux21_sGH(
     .A0(sEH),
     .A1(sEF),
     .S(c0),
     .X(sGH)
     );
 	//assign sEH = c1 ? S1 : S3;
-    cus_mux21_buf cus_mux21_buf_sEH(
+    cus_mux21 cus_mux21_sEH(
     .A0(S3),
     .A1(S1),
     .S(c1),
@@ -109,14 +109,14 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign AD = S1 ? CD : AB;
-    cus_mux21_buf cus_mux21_buf_AD(
+    cus_mux21 cus_mux21_AD(
     .A0(AB),
     .A1(CD),
     .S(S1),
     .X(AD)
     );
 	//assign EH = sEH ? GH : EF;
-    cus_mux21_buf cus_mux21_buf_EH(
+    cus_mux21 cus_mux21_EH(
     .A0(EF),
     .A1(GH),
     .S(sEH),
@@ -124,7 +124,7 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign AH = S3 ? EH : AD;
-    cus_mux21_buf cus_mux21_buf_AH(
+    cus_mux21 cus_mux21_AH(
     .A0(AD),
     .A1(EH),
     .S(S3),
@@ -132,7 +132,7 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
     );
 
 	//assign EH_GH = c0 ? EH : GH;
-    cus_mux21_buf cus_mux21_buf_EH_GH(
+    cus_mux21 cus_mux21_EH_GH(
     .A0(GH),
     .A1(EH),
     .S(c0),
@@ -141,14 +141,14 @@ module MUX8LUT_frame_config (A, B, C, D, E, F, G, H, S0, S1, S2, S3, M_AB, M_AD,
 
 	assign M_AB = AB;
 	//assign M_AD = c0 ? AD : CD;
-    cus_mux21_buf cus_mux21_buf_M_AD(
+    cus_mux21 cus_mux21_M_AD(
     .A0(CD),
     .A1(AD),
     .S(c0),
     .X(M_AD)
     );
 	//assign M_AH = c1 ? AH : EH_GH;
-    cus_mux21_buf cus_mux21_buf_M_AH(
+    cus_mux21 cus_mux21_M_AH(
     .A0(EH_GH),
     .A1(AH),
     .S(c1),

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -645,7 +645,11 @@ class FabricGenerator:
 
                 # Pad mux size to the next power of 2
                 paddedMuxSize = 2 ** (muxSize - 1).bit_length()
-                muxComponentName = f"cus_mux{paddedMuxSize}1_buf"
+
+                if paddedMuxSize == 2:
+                    muxComponentName = f"cus_mux{paddedMuxSize}1"
+                else:
+                    muxComponentName = f"cus_mux{paddedMuxSize}1_buf"
 
                 portsPairs = []
                 start = 0

--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -20,27 +20,26 @@ import math
 import os
 import re
 import string
-from sys import prefix
-from loguru import logger
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Tuple
-from collections import defaultdict
 
+from loguru import logger
+
+from FABulous.fabric_definition.ConfigMem import ConfigMem
+from FABulous.fabric_definition.define import (
+    IO,
+    ConfigBitMode,
+    Direction,
+    MultiplexerStyle,
+)
+from FABulous.fabric_definition.Fabric import Fabric
+from FABulous.fabric_definition.Port import Port
+from FABulous.fabric_definition.SuperTile import SuperTile
+from FABulous.fabric_definition.Tile import Tile
 from FABulous.fabric_generator.code_generation_Verilog import VerilogWriter
 from FABulous.fabric_generator.code_generation_VHDL import VHDLWriter
 from FABulous.fabric_generator.code_generator import codeGenerator
-from FABulous.fabric_definition.Fabric import Fabric
-from FABulous.fabric_definition.Tile import Tile
-from FABulous.fabric_definition.Port import Port
-from FABulous.fabric_definition.SuperTile import SuperTile
-from FABulous.fabric_definition.ConfigMem import ConfigMem
-from FABulous.fabric_definition.define import (
-    Direction,
-    IO,
-    MultiplexerStyle,
-    ConfigBitMode,
-)
-
 from FABulous.fabric_generator.file_parser import parseConfigMem, parseList, parseMatrix
 
 SWITCH_MATRIX_DEBUG_SIGNAL = True
@@ -673,7 +672,7 @@ class FabricGenerator:
                                 )
                             )
 
-                portsPairs.append((f"X", f"{portName}"))
+                portsPairs.append(("X", f"{portName}"))
 
                 if self.fabric.multiplexerStyle == MultiplexerStyle.CUSTOM:
                     # we add the input signal in reversed order
@@ -1027,8 +1026,8 @@ class FabricGenerator:
 
         self.writer.addInstantiation(
             "clk_buf",
-            f"inst_clk_buf",
-            portsPairs=[("A", f"UserCLK"), ("X", f"UserCLKo")],
+            "inst_clk_buf",
+            portsPairs=[("A", "UserCLK"), ("X", "UserCLKo")],
         )
 
         self.writer.addNewLine()
@@ -1932,13 +1931,13 @@ class FabricGenerator:
                             pre = ""
                         # UserCLK signal
                         if y + 1 >= self.fabric.numberOfRows:
-                            portsPairs.append((f"{pre}UserCLK", f"UserCLK"))
+                            portsPairs.append((f"{pre}UserCLK", "UserCLK"))
 
                         elif (
                             y + 1 < self.fabric.numberOfRows
                             and self.fabric.tile[y + 1][x] == None
                         ):
-                            portsPairs.append((f"{pre}UserCLK", f"UserCLK"))
+                            portsPairs.append((f"{pre}UserCLK", "UserCLK"))
 
                         elif (x + i, y + j + 1) not in superTileLoc:
                             portsPairs.append(
@@ -2040,7 +2039,7 @@ class FabricGenerator:
                     name = tile.name
                     if y not in (0, self.fabric.numberOfRows - 1):
                         emulateParamPairs.append(
-                            (f"Emulate_Bitstream", f"`Tile_X{x}Y{y}_Emulate_Bitstream")
+                            ("Emulate_Bitstream", f"`Tile_X{x}Y{y}_Emulate_Bitstream")
                         )
 
                 self.writer.addInstantiation(
@@ -2258,7 +2257,7 @@ class FabricGenerator:
         # the frame data reg module
         for row in range(numberOfRows):
             self.writer.addInstantiation(
-                compName=f"Frame_Data_Reg",
+                compName="Frame_Data_Reg",
                 compInsName=f"inst_Frame_Data_Reg_{row}",
                 portsPairs=[
                     ("FrameData_I", "LocalWriteData"),
@@ -2280,7 +2279,7 @@ class FabricGenerator:
         # the frame select module
         for col in range(numberOfColumns):
             self.writer.addInstantiation(
-                compName=f"Frame_Select",
+                compName="Frame_Select",
                 compInsName=f"inst_Frame_Select_{col}",
                 portsPairs=[
                     ("FrameStrobe_I", "FrameAddressRegister[MaxFramesPerCol-1:0]"),
@@ -2501,9 +2500,9 @@ class FabricGenerator:
                                 curTileMapNoMask[pip] = {}
 
                             curTileMap[pip][encodeDict[curBitOffset + c]] = curChar
-                            curTileMapNoMask[pip][encodeDict[curBitOffset + c]] = (
-                                curChar
-                            )
+                            curTileMapNoMask[pip][
+                                encodeDict[curBitOffset + c]
+                            ] = curChar
 
                     curBitOffset += controlWidth
 


### PR DESCRIPTION
Now can correctly generate non power of 2 mux.

```verilog
 //switch matrix multiplexer E6BEG4 MUX-5
assign E6BEG4_input = {A_O,W6END3,WW4END3,W1END2,W1END0};
cus_mux81_buf inst_cus_mux81_buf_E6BEG4 (
    .A0(E6BEG4_input[0]),
    .A1(E6BEG4_input[1]),
    .A2(E6BEG4_input[2]),
    .A3(E6BEG4_input[3]),
    .A4(E6BEG4_input[4]),
    .A5(GND0),
    .A6(GND0),
    .A7(GND0),
    .S0(ConfigBits[76+0]),
    .S0N(ConfigBits_N[76+0]),
    .S1(ConfigBits[76+1]),
    .S1N(ConfigBits_N[76+1]),
    .S2(ConfigBits[76+2]),
    .S2N(ConfigBits_N[76+2]),
    .X(E6BEG4)
);
```

I have also updated the name of the my_mux2 to cus_mux21, to make them follow the same naming conversion for the other muxes. 