### PR TITLE
Wip/listfile multipliers

### DIFF
--- a/FABulous/fabric_generator/file_parser.py
+++ b/FABulous/fabric_generator/file_parser.py
@@ -349,6 +349,10 @@ def parseList(
         rightList = []
         expandListPorts(left, leftList)
         expandListPorts(right, rightList)
+        if len(leftList) != len(rightList):
+            raise ValueError(
+                f"List file {filePath} does not have the same number of source and sink ports."
+            )
         resultList += list(zip(leftList, rightList))
 
     result = list(dict.fromkeys(resultList))

--- a/docs/source/fabric_definition.rst
+++ b/docs/source/fabric_definition.rst
@@ -429,6 +429,9 @@ Configurable connections are defined in either an adjacency list or an adjacency
 
 A switch matrix entry is specified by a line <output_port>,<input_port>.
 For convenience, it is possible to specify multiple ports though a list operator [item1|item2|...].
+There is also a multiplier {N}, where N is the number of times the port should be repeated.
+So a {4}N2BEG0 will be expanded to [N2BEG0|N2BEG0|N2BEG0|N2BEG0]
+
 For instance, the following line in a list file
 
 .. code-block:: python
@@ -468,7 +471,13 @@ A switch matrix multiplexer is modelled by having multiple connections for the s
 
    # the same in compact form:
    N2BEG[0|0|0|0],[N2END3|E2END2|S2END1|LB_O]
+   # or even more compact:
+   {4}N2BEG0,[N2END3|E2END2|S2END1|LB_O]
 
+For completion, the following expressions are all equivalent:
+.. code-block:: python
+
+  N2BEG[0|0|0|0] <=> {4}N2BEG0 <=> N2BEG[{4}0] <=> {2}N2BEG[0|0] <=> {2}N2BEG[{2}0] <=> [N2BEG0|N2BEG0|N2BEG0|N2BEG0]
 
 The ``INCLUDE`` keyword can also be used to include another list file in the current list file. For example:
 


### PR DESCRIPTION
fabric_gen:utils: Add multiplier support to switch matrix listfile
Add multipliers to switch matrix list files.

{<num>} defines a multipliert, wich adds the expand the port <num> times.

Add docs for multiplier.

fabric_gen: Add check if multiplexers in .list files have the same number of inputs and outputs