### PR TITLE
fix configuration bit problem after #242

### DIFF
--- a/FABulous/fabric_generator/fabric_gen.py
+++ b/FABulous/fabric_generator/fabric_gen.py
@@ -704,7 +704,7 @@ class FabricGenerator:
                     )
 
                 # update the configuration bitstream position
-                configBitstreamPosition += len(connections[portName]).bit_length() - 1
+                configBitstreamPosition += paddedMuxSize.bit_length() - 1
 
         ### SwitchMatrixDebugSignals ### SwitchMatrixDebugSignals ###
         ### SwitchMatrixDebugSignals ### SwitchMatrixDebugSignals ###


### PR DESCRIPTION
After #242 for non-power of 2 mux, it will result in the following behaviour:

```verilog
assign BEG_i_0to60_input = {J_l_AB_END0,J2END_AB_END0,J2MID_ABb_END0,J2MID_ABa_END0,END_o_6to00};
cus_mux81_buf inst_cus_mux81_buf_BEG_i_0to60 (
    .A0(BEG_i_0to60_input[0]),
    .A1(BEG_i_0to60_input[1]),
    .A2(BEG_i_0to60_input[2]),
    .A3(BEG_i_0to60_input[3]),
    .A4(BEG_i_0to60_input[4]),
    .A5(GND0),
    .A6(GND0),
    .A7(GND0),
    .S0(ConfigBits[0+0]),
    .S0N(ConfigBits_N[0+0]),
    .S1(ConfigBits[0+1]),
    .S1N(ConfigBits_N[0+1]),
    .S2(ConfigBits[0+2]),
    .S2N(ConfigBits_N[0+2]),
    .X(BEG_i_0to60)
);

 //switch matrix multiplexer BEG_i_0to61 MUX-5
assign BEG_i_0to61_input = {J_l_AB_END1,J2END_AB_END1,J2MID_ABb_END1,J2MID_ABa_END1,END_o_6to01};
cus_mux81_buf inst_cus_mux81_buf_BEG_i_0to61 (
    .A0(BEG_i_0to61_input[0]),
    .A1(BEG_i_0to61_input[1]),
    .A2(BEG_i_0to61_input[2]),
    .A3(BEG_i_0to61_input[3]),
    .A4(BEG_i_0to61_input[4]),
    .A5(GND0),
    .A6(GND0),
    .A7(GND0),
    .S0(ConfigBits[2+0]),
    .S0N(ConfigBits_N[2+0]),
    .S1(ConfigBits[2+1]),
    .S1N(ConfigBits_N[2+1]),
    .S2(ConfigBits[2+2]),
    .S2N(ConfigBits_N[2+2]),
    .X(BEG_i_0to61)
```

which the config bit is overlapping. 

This pull request corrects the behaviour to the following:

```verilog
 //switch matrix multiplexer E2BEGb7 MUX-3
assign E2BEGb7_input = {W6END0,WW4END8,WW4END0};
cus_mux41_buf inst_cus_mux41_buf_E2BEGb7 (
    .A0(E2BEGb7_input[0]),
    .A1(E2BEGb7_input[1]),
    .A2(E2BEGb7_input[2]),
    .A3(GND0),
    .S0(ConfigBits[34+0]),
    .S0N(ConfigBits_N[34+0]),
    .S1(ConfigBits[34+1]),
    .S1N(ConfigBits_N[34+1]),
    .X(E2BEGb7)
);

 //switch matrix multiplexer EE4BEG0 MUX-4
assign EE4BEG0_input = {A_O,W6END4,W6END2,W6END0};
cus_mux41_buf inst_cus_mux41_buf_EE4BEG0 (
    .A0(EE4BEG0_input[0]),
    .A1(EE4BEG0_input[1]),
    .A2(EE4BEG0_input[2]),
    .A3(EE4BEG0_input[3]),
    .S0(ConfigBits[36+0]),
    .S0N(ConfigBits_N[36+0]),
    .S1(ConfigBits[36+1]),
    .S1N(ConfigBits_N[36+1]),
    .X(EE4BEG0)
);

```