### PR TITLE
workflows: Update workflows for ubuntu 24

### DIFF
--- a/.github/workflows/fabric_gen.yml
+++ b/.github/workflows/fabric_gen.yml
@@ -20,10 +20,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip3 install flake8 pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          if [ -f requirements.txt ]; then python3.10 -m pip install -r requirements.txt; fi
-          sudo apt update
-          sudo apt install python-tk -y
+          if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/README.md
+++ b/README.md
@@ -43,17 +43,17 @@ The following packages need to be installed for generating fabric HDL models and
 Install python dependencies
 
 ```
-sudo apt-get install python3-tk python3-virtualenv
+sudo apt-get install python3-virtualenv
 ```
 
 > [!NOTE]
 >
->If you get the warning `ModuleNotFoundError: No module named 'tkinter'` or
+>If you get the warning `ModuleNotFoundError: No module named virtualenv` or
 >errors when installing the requirements, you have to install the dependencies
 >for your specific python version. For Python 3.12 use
 >
 >```
->sudo apt-get install python3.12-tk python3.12-virtualenv
+>sudo apt-get install python3.12-virtualenv
 >```
 
 

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -17,17 +17,17 @@ Version >= 3.12
 
 .. code-block:: console
 
-    $ sudo apt-get install python3-tk python3-virtualenv
+    $ sudo apt-get install python3-virtualenv
 
 .. note::
 
-    If you get the warning ``ModuleNotFoundError: No module named 'tkinter'``
+    If you get the warning ``ModuleNotFoundError: No module named 'virtualenv'``
     or errors when installing the requirements, you have to install the
     dependencies for your specific python version. For Python 3.12 use
 
     .. code-block:: console
 
-       $ sudo apt-get install python3.12-tk python3.12-virtualenv
+       $ sudo apt-get install python3.12-virtualenv
 
 :FABulous repository:
 


### PR DESCRIPTION
Remove legacy python3.10 call.
Remove installation of python-tk since it is already included in the default binares since Python3.7.
Update docs and README.


Since we are using 'ubunut-latest' for the workflows, the workflows failed since python-tk was removed from the Ubunut PPA. 