### PR TITLE
chore: make typer help as default

### DIFF
--- a/FABulous/FABulous.py
+++ b/FABulous/FABulous.py
@@ -399,7 +399,7 @@ def main() -> None:
             app()
 
         for i in sys.argv[1:]:
-            if i in [i.name for i in app.registered_commands]:
+            if i in [i.name for i in app.registered_commands] or i == "--help":
                 app()
                 break
         else:


### PR DESCRIPTION
Making typer help as default