### PR TITLE
fix: Add check if models_pack path is absolute path

### DIFF
--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -84,17 +84,17 @@ class FABulousSettings(BaseSettings):
                 mp = p / "Fabric" / "my_lib.vhdl"
                 if mp.exists():
                     logger.warning(
-                        f"Model pack path is not set. Guessing model pack as: {mp}"
+                        f"Models pack path is not set. Guessing models pack as: {mp}"
                     )
                     return mp
                 mp = p / "Fabric" / "models_pack.vhdl"
                 if mp.exists():
                     logger.warning(
-                        f"Model pack path is not set. Guessing model pack as: {mp}"
+                        f"Models pack path is not set. Guessing models pack as: {mp}"
                     )
                     return mp
                 logger.warning(
-                    "Cannot find a suitable model pack. "
+                    "Cannot find a suitable models pack. "
                     "This might lead to error if not set."
                 )
 
@@ -102,11 +102,11 @@ class FABulousSettings(BaseSettings):
                 mp = p / "Fabric" / "models_pack.v"
                 if mp.exists():
                     logger.warning(
-                        f"Model pack path is not set. Guessing model pack as: {mp}"
+                        f"Models pack path is not set. Guessing models pack as: {mp}"
                     )
                     return mp
                 logger.warning(
-                    "Cannot find a suitable model pack. "
+                    "Cannot find a suitable models pack. "
                     "This might lead to error if not set."
                 )
 
@@ -123,21 +123,21 @@ class FABulousSettings(BaseSettings):
             else:
                 raise ValueError("Project directory is not set.")
 
-            # check if project dir is  not absolute and
-            # in model pack path, since in the default it is
-            # put there as folder
+            # Check if `project_dir` is not an absolute path and
+            # in the models_pack path, since in the default it is
+            # put there as folder.
             if not value.is_absolute() and proj_dir.name in value.parts:
                 parts = list(value.parts)
                 index = parts.index(proj_dir.name)
                 value = proj_dir.joinpath(*parts[index + 1 :])
                 if not value.is_file():
                     raise ValueError(
-                        f"Model pack file does not exist: {value}"
+                        f"Models pack file does not exist: {value}"
                         " Check your FAB_MODELS_PACK env var setting."
                     )
             else:
                 raise ValueError(
-                    f"Model pack file does not exist: {value}"
+                    f"Models pack file does not exist: {value}"
                     " Check your FAB_MODELS_PACK env var setting."
                 )
 
@@ -156,10 +156,10 @@ class FABulousSettings(BaseSettings):
             HDLType.SYSTEM_VERILOG,
         } and value.suffix not in {".v", ".sv"}:
             raise ValueError(
-                "Model pack for Verilog/System Verilog must be a .v or .sv file"
+                "Models pack for Verilog/System Verilog must be a .v or .sv file"
             )
         if proj_lang == HDLType.VHDL and value.suffix not in {".vhdl", ".vhd"}:
-            raise ValueError("Model pack for VHDL must be a .vhdl or .vhd file")
+            raise ValueError("Models pack for VHDL must be a .vhdl or .vhd file")
         return value.absolute()
 
     @field_validator("user_config_dir", mode="after")

--- a/docs/source/Usage.rst
+++ b/docs/source/Usage.rst
@@ -239,7 +239,7 @@ FAB_IVERILOG_PATH         Path to Icarus Verilog binary                       iv
 FAB_VVP_PATH              Path to Verilog VVP binary                          vvp  (Uses global Verilog VVP installation)
 FAB_GHDL_PATH             Path to GHDL binary                                 ghdl  (Uses global GHDL installation)
 FAB_PROJ_DIR              The root directory of the FABulous project          The directory where the FABulous project is located, given by command line
-FAB_MODELS_PACK           The model pack for the project                      Pointing to <project_dir>/Fabric/models_pack.<project_lang>
+FAB_MODELS_PACK           The models pack for the project                      Pointing to <project_dir>/Fabric/models_pack.<project_lang>
 FAB_OSS_CAD_SUITE         Path to the oss-cad-suite installation              <None>
 FAB_DEBUG                 Enable debug mode                                   False
 FAB_VERBOSE               Enable verbose mode                                 0

--- a/tests/utils_test/test_yosys_obj.py
+++ b/tests/utils_test/test_yosys_obj.py
@@ -38,14 +38,14 @@ def setup_mocks(monkeypatch: pytest.MonkeyPatch, json_data: dict) -> None:
 
     monkeypatch.setattr("builtins.open", mock_open_func)
 
-    # Ensure FABulousSettings validation passes by providing a model pack
+    # Ensure FABulousSettings validation passes by providing a models pack
     tmp_mp = Path(tempfile.gettempdir()) / "models_pack.v"
     try:
-        tmp_mp.write_text("// test model pack\n")
+        tmp_mp.write_text("// test models pack\n")
     except OSError:
         # In rare cases temp dir may be read-only; fallback to current working dir
         tmp_mp = Path.cwd() / "models_pack.v"
-        tmp_mp.write_text("// test model pack\n")
+        tmp_mp.write_text("// test models pack\n")
     monkeypatch.setenv("FAB_MODELS_PACK", str(tmp_mp))
 
 
@@ -109,14 +109,14 @@ def test_yosys_json_initialization_parametric(
     for k, v in (set_env or {}).items():
         monkeypatch.setenv(k, v)
 
-    # Provide a valid model pack path to satisfy FABulousSettings validation
+    # Provide a valid models pack path to satisfy FABulousSettings validation
     if suffix in {".vhd", ".vhdl"}:
         mp = tmp_path / "models_pack.vhdl"
     elif suffix == ".sv":
         mp = tmp_path / "models_pack.v"  # .v is acceptable for SystemVerilog projects
     else:
         mp = tmp_path / "models_pack.v"
-    mp.write_text("// dummy model pack\n")
+    mp.write_text("// dummy models pack\n")
     monkeypatch.setenv("FAB_MODELS_PACK", str(mp))
 
     # Prepare files


### PR DESCRIPTION
If its an absolute path, we should not touche it and directly throw an error if its not a file.