### PR TITLE
fix!: Leave the lowest bit of a belMap vector untouched

### DIFF
--- a/FABulous/fabric_generator/parser/parse_hdl.py
+++ b/FABulous/fabric_generator/parser/parse_hdl.py
@@ -53,17 +53,6 @@ def belMapProcessing(module_info: YosysModule) -> dict:
         "top",
     }
 
-    # Convert attributes ending with _<digits> to vector notation
-    # First pass: identify which base names have indexed variants
-    indexed_bases = set()
-    for key in module_info.attributes:
-        if key.casefold() in (item.casefold() for item in exclude_attributes):
-            continue
-        if "_" in key:
-            parts = key.rsplit("_", 1)
-            if len(parts) == 2 and parts[1].isdigit():
-                indexed_bases.add(parts[0])
-
     # Second pass: convert keys to appropriate format
     atters = {}
     for key, value in module_info.attributes.items():
@@ -79,20 +68,15 @@ def belMapProcessing(module_info: YosysModule) -> dict:
             )
 
         # Check if key contains underscore and last part after underscore is all digits
-        if "_" in key:
-            parts = key.rsplit("_", 1)  # Split from the right, only once
-            if len(parts) == 2 and parts[1].isdigit():
-                # Convert to vector notation: SOME_KEY_NAME_123 -> SOME_KEY_NAME[123]
-                base_name = parts[0]
-                index = parts[1]
-                new_key = f"{base_name}[{index}]"
-            else:
-                new_key = key
+        parts = key.rsplit("_", 1)  # Split from the right, only once
+        if len(parts) == 2 and parts[1].isdigit():
+            # Convert to vector notation: SOME_KEY_NAME_123 -> SOME_KEY_NAME[123]
+            base_name = parts[0]
+            index = parts[1]
+            new_key = f"{base_name}[{index}]"
         else:
-            # Check if this key has indexed variants
-            # (e.g., INIT exists and INIT_1, INIT_2 exist)
-            # and Convert to vector notation with index 0
-            new_key = f"{key}[0]" if key in indexed_bases else key
+            # Leave key unchanged
+            new_key = key
 
         atters[new_key] = int(value)
 


### PR DESCRIPTION
Commit 483b3e6ca6fabfce9fa3fe1def9fe3611d6444dd
introduced a change in the belMap processing, which changed the lowest value of a belMap vector from <parameter> to <parameter>[0]. Sadly, nextpnr has for some cases still the <parameter> notation hardcoded, and ignores the names given in the bel.v2.txt.

This patch rolls back to the initial notation, jut <parameter> for the lowest bit of a belMap vector.