### PR TITLE
chore(ci): Deactivate no-commit-to-branch pre-commit-hook for CI

### DIFF
--- a/.github/workflows/pre-commit-hooks.yml
+++ b/.github/workflows/pre-commit-hooks.yml
@@ -17,4 +17,4 @@ jobs:
     - name: run pre-commit
       run: |
         uv run pre-commit install
-        uv run pre-commit run --show-diff-on-failure --color=always --all-files
+        SKIP=no-commit-to-branch uv run pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
no-commit-to-branch not needed in CI runs.