### PR TITLE
ci: Add workflow to publish FABulous to PyPI and cleanup pyproject.toml 

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -15,9 +15,9 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7.2.1
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - name: Build a binary wheel and a source tarball

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "FABulous FPGA Fabric generator"
 readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["version"]
-license = {text = "Apache-2.0"}
+license = { text = "Apache-2.0" }
 
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -57,7 +57,6 @@ local_scheme = "node-and-date"
 [tool.setuptools.packages.find]
 exclude = [
   "docs",
-  "demo",
   "tests",
   "scripts",
   "nix",


### PR DESCRIPTION
[ci: add publish to PyPI workflow](https://github.com/FPGA-Research/FABulous/commit/bc874a0fc0bb0ef06e70f43f76e2369864ef9c62)

[chore(pyproject.toml): Cleanup and prepare for release](https://github.com/FPGA-Research/FABulous/commit/3d0f337e1e2e1b9b1fe50f50d98610ebc8d92286)