### PR TITLE
chore: Write models_pack path as relative in .env

### DIFF
--- a/FABulous/FABulous_CLI/helper.py
+++ b/FABulous/FABulous_CLI/helper.py
@@ -216,7 +216,7 @@ def create_project(project_dir: Path, lang: HDLType = HDLType.VERILOG) -> None:
     set_key(
         env_file,
         "FAB_MODELS_PACK",
-        str(project_dir.absolute() / "Fabric" / f"models_pack.{new_suffix}"),
+        str(Path(project_dir.name) / "Fabric" / f"models_pack.{new_suffix}"),
     )
 
     logger.info(

--- a/FABulous/FABulous_settings.py
+++ b/FABulous/FABulous_settings.py
@@ -165,6 +165,8 @@ class FABulousSettings(BaseSettings):
             )
         if proj_lang == HDLType.VHDL and value.suffix not in {".vhdl", ".vhd"}:
             raise ValueError("Models pack for VHDL must be a .vhdl or .vhd file")
+
+        logger.info(f"Using models pack at: {value.absolute()}")
         return value.absolute()
 
     @field_validator("user_config_dir", mode="after")


### PR DESCRIPTION
Write the models_pack path als relative path in the project .env to allow the FABuluos project to be moved, without an error of models_pack not found. This is already supported in the models_pack field validator and need no further changes. The field validator still publishes the path as absolute path for internal usage.

Add a log message with the models pack path.