### PR TITLE
fix(geometry_generator): broken geometry in FABulator

### DIFF
--- a/FABulous/geometry_generator/sm_geometry.py
+++ b/FABulous/geometry_generator/sm_geometry.py
@@ -8,7 +8,7 @@ from FABulous.fabric_definition.define import IO, Direction, Side
 from FABulous.fabric_definition.Port import Port
 from FABulous.fabric_definition.Tile import Tile
 from FABulous.geometry_generator.bel_geometry import BelGeometry
-from FABulous.geometry_generator.geometry_obj import Border
+from FABulous.geometry_generator.geometry_obj import Border, oppositeIO
 from FABulous.geometry_generator.port_geometry import PortGeometry, PortType
 
 
@@ -495,7 +495,7 @@ class SmGeometry:
                     belPortGeom.sourceName,
                     belPortGeom.destName,
                     PortType.SWITCH_MATRIX,
-                    belPortGeom.ioDirection,
+                    oppositeIO(belPortGeom.ioDirection),
                     portX,
                     portY,
                 )

--- a/FABulous/geometry_generator/tile_geometry.py
+++ b/FABulous/geometry_generator/tile_geometry.py
@@ -76,7 +76,7 @@ class TileGeometry:
     width: int = 0
     height: int = 0
     border: Border = Border.NONE
-    wireConstraints: WireConstraints = WireConstraints()
+    wireConstraints: WireConstraints = field(default_factory=WireConstraints)
     neighbourConstraints: WireConstraints | None = None
     smGeometry: SmGeometry = field(default_factory=SmGeometry)
     belGeomList: list[BelGeometry] = field(default_factory=list)


### PR DESCRIPTION
The TileGeometry class had a missing default_factory call for the WireConstrains, which caused that all TileGeometry objects referenced the same WireConstrain object. This lead to wrong geometry generation.

For the generateBelPorts method of the SmGeometry class, was a oppositeIO call missing.