### PR TITLE
fix: validate tile name matches folder name and guard empty tile list

### DIFF
--- a/fabulous/fabric_generator/parser/parse_csv.py
+++ b/fabulous/fabric_generator/parser/parse_csv.py
@@ -88,6 +88,11 @@ def parseTilesCSV(fileName: Path) -> tuple[list[Tile], list[tuple[str, str]]]:
     for t in tilesData:
         t = t.split("\n")
         tileName = t[0].split(",")[1].strip()
+        if filePathParent.name != tileName:
+            logger.warning(
+                f"Tile name '{tileName}' does not match folder name "
+                f"'{filePathParent.name}' in {fileName}."
+            )
         ports: list[Port] = []
         bels: list[Bel] = []
         matrixDir: Path | None = None

--- a/fabulous/fabulous_cli/fabulous_cli.py
+++ b/fabulous/fabulous_cli/fabulous_cli.py
@@ -460,6 +460,13 @@ class FABulous_CLI(Cmd):
         superTileByFabric = list(self.fabulousAPI.fabric.superTileDic.keys())
         self.allTile = list(set(tileByPath) & set(tileByFabric + superTileByFabric))
 
+        if not self.allTile:
+            logger.error(
+                "No tiles found in the project tiles directory that match the tiles "
+                "defined in the fabric.csv"
+            )
+            raise ValueError
+
         proj_dir = get_context().proj_dir
         if (proj_dir / "eFPGA_geometry.csv").exists():
             self.enable_category(CMD_GUI)


### PR DESCRIPTION
parseTilesCSV now warns when the parsed tile name does not match the parent directory name.

FABulous_CLI raises an error when no intersecting tiles found on disk with those defined in fabric.csv, since this crashed previously with a unrelated message.