### PR TITLE
fix: fix when ciel is never used before

### DIFF
--- a/docs/source/user_guide/building_doc/fabric_gds.md
+++ b/docs/source/user_guide/building_doc/fabric_gds.md
@@ -28,23 +28,20 @@ As of writing, we are using custom build of librelane, as a result, the upstream
 
 ### Install PDK
 
-To compile the design, we will also need to install the PDK. FABulous automatically resolves the recommended PDK version from LibreLane and installs it via [ciel](https://github.com/fossi-foundation/ciel) on first use. By default, we have set up the project to target the `ihp-sg13g2` process (130nm).
+To compile the design, we will also need to install the PDK. For ciel-supported PDKs (e.g. `ihp-sg13g2`, `sky130A`, `gf180mcu`), FABulous automatically resolves the recommended PDK version from LibreLane and installs it via [ciel](https://github.com/fossi-foundation/ciel) on first use. No manual installation is required. By default, we have set up the project to target the `ihp-sg13g2` process (130nm).
 
-If you need to manually install a specific PDK version, you can use:
-
-```bash
-ciel enable --pdk-family ihp-sg13g2 <commit_hash>
-```
+For details on how the PDK is resolved and when manual configuration is needed, see the [PDK Resolution Logic](#pdk-resolution-logic) section.
 
 ## Changing PDK
 
-We support all PDKs that are supported by librelane. As a result you can switch to targeting other process nodes such as the Sky130A and gf180mcu. To switch to those PDKs, you will need to modify the `FAB_PDK_ROOT` and `FAB_PDK`, in `./<project>/.FABulous/.env` or set them in the shell as an environment variable. `FAB_PDK` is the PDK you are using, and `FAB_PDK_ROOT` is where the PDK is located. If you are installing the PDK from `ciel`, it will be located at `~/.ciel/`. An example of the `.env` file will be:
+We support all PDKs that are supported by librelane. As a result you can switch to targeting other process nodes such as the Sky130A and gf180mcu. For ciel-supported PDKs, you only need to set `FAB_PDK` in `./<project>/.FABulous/.env` or as a shell environment variable. FABulous will automatically resolve `FAB_PDK_ROOT` and install the correct version. For example:
 
 ```bash
 #... existing content
 FAB_PDK='sky130A'
-FAB_PDK_ROOT='/home/<user>/.ciel/sky130A'
 ```
+
+For non-ciel PDKs, you will also need to set `FAB_PDK_ROOT` to point to your PDK installation directory. See the [PDK Resolution Logic](#pdk-resolution-logic) for the full set of rules on how these variables are resolved.
 
 For any other PDK, you will need to bring up the PDK to be supported by librelane. You can follow this [guide](https://openroad-flow-scripts.readthedocs.io/en/latest/contrib/PlatformBringUp.html) for more details. For more advanced nodes, it is likely that you will need to further modify and add steps to the flow for getting a working and manufacturable design.
 
@@ -190,6 +187,7 @@ This command performs the following steps automatically:
 4. **Fabric Stitching**: Assembles all tiles into the final fabric layout.
 
 (tile-size-optimization)=
+
 ## Tile Size Optimization
 
 The GDS flow includes an iterative optimization process to find the minimum viable tile dimensions. This is controlled by the `FABULOUS_OPT_MODE` variable.

--- a/docs/source/user_guide/cli_doc/fabulous_variable.md
+++ b/docs/source/user_guide/cli_doc/fabulous_variable.md
@@ -1,4 +1,5 @@
 (fabulous-variables)=
+
 # FABulous Configuration Variables
 
 FABulous can use environment variables to configure options, paths and projects. We distinguish between two types of environment variables: **global** and **project specific** environment variables.
@@ -21,5 +22,32 @@ All environment variables can be set in the shell before running FABulous or can
 Environment variables set in the **shell** always have the **highest priority**, followed by project-specific `.env` files, then global `.env` files.
 :::
 
+## PDK Resolution Logic
+
+FABulous uses three environment variables to locate and manage a Process Design Kit (PDK) for back-end GDS generation.
+
+| Variable | Purpose |
+|----------|---------|
+| `FAB_PDK` | Name of the PDK (e.g. `ihp-sg13g2`) |
+| `FAB_PDK_ROOT` | File-system path to the PDK installation directory |
+| `FAB_PDK_HASH` | Version hash identifying a specific PDK snapshot |
+
+### Default value of `FAB_PDK`
+
+When a new project is created with `create_project`, `FAB_PDK` is set to `ihp-sg13g2` in the project `.env` file by default. This value can be overridden afterward.
+
+### Resolution at startup
+
+When FABulous loads its settings, the following rules determine how the PDK is resolved.
+
+1. **Neither `FAB_PDK` nor `FAB_PDK_ROOT` is set.** A warning is logged and GDS features are unavailable.
+2. **`FAB_PDK_ROOT` is set but `FAB_PDK` is missing.** An error is raised asking the user to set `FAB_PDK`.
+3. **`FAB_PDK` is set without `FAB_PDK_ROOT`, and the PDK belongs to a ciel-supported family.** `FAB_PDK_ROOT` is automatically resolved from the ciel home directory.
+4. **`FAB_PDK` is set without `FAB_PDK_ROOT`, and the PDK is not ciel-supported.** An error is raised asking the user to set `FAB_PDK_ROOT` manually.
+5. **Both are set, but the PDK is not a ciel family.** FABulous assumes a custom PDK with manual setup. The path must exist on disk.
+6. **Both are set and the PDK is a ciel family.** The recommended `FAB_PDK_HASH` is resolved from librelane. If the user did not provide `FAB_PDK_HASH`, it is filled in automatically; if the user-provided value differs from the recommended one, a mismatch warning is logged. The PDK is then enabled via ciel.
+
 ```{include} /generated_doc/fabulous_variable.md
+```
+
 ```

--- a/docs/source/user_guide/cli_doc/fabulous_variable.md
+++ b/docs/source/user_guide/cli_doc/fabulous_variable.md
@@ -49,5 +49,3 @@ When FABulous loads its settings, the following rules determine how the PDK is r
 
 ```{include} /generated_doc/fabulous_variable.md
 ```
-
-```

--- a/docs/source/user_guide/cli_doc/fabulous_variable.md
+++ b/docs/source/user_guide/cli_doc/fabulous_variable.md
@@ -22,6 +22,7 @@ All environment variables can be set in the shell before running FABulous or can
 Environment variables set in the **shell** always have the **highest priority**, followed by project-specific `.env` files, then global `.env` files.
 :::
 
+(pdk-resolution-logic)=
 ## PDK Resolution Logic
 
 FABulous uses three environment variables to locate and manage a Process Design Kit (PDK) for back-end GDS generation.
@@ -38,14 +39,14 @@ When a new project is created with `create_project`, `FAB_PDK` is set to `ihp-sg
 
 ### Resolution at startup
 
-When FABulous loads its settings, the following rules determine how the PDK is resolved.
+When FABulous loads its settings, the following rules determine how the PDK is resolved. For ciel-supported PDKs, FABulous handles installation and activation automatically, so there is no need to manually run `ciel enable`.
 
 1. **Neither `FAB_PDK` nor `FAB_PDK_ROOT` is set.** A warning is logged and GDS features are unavailable.
 2. **`FAB_PDK_ROOT` is set but `FAB_PDK` is missing.** An error is raised asking the user to set `FAB_PDK`.
-3. **`FAB_PDK` is set without `FAB_PDK_ROOT`, and the PDK belongs to a ciel-supported family.** `FAB_PDK_ROOT` is automatically resolved from the ciel home directory.
+3. **`FAB_PDK` is set without `FAB_PDK_ROOT`, and the PDK belongs to a ciel-supported family.** `FAB_PDK_ROOT` is automatically resolved from the ciel home directory and the PDK is installed and activated via ciel.
 4. **`FAB_PDK` is set without `FAB_PDK_ROOT`, and the PDK is not ciel-supported.** An error is raised asking the user to set `FAB_PDK_ROOT` manually.
 5. **Both are set, but the PDK is not a ciel family.** FABulous assumes a custom PDK with manual setup. The path must exist on disk.
-6. **Both are set and the PDK is a ciel family.** The recommended `FAB_PDK_HASH` is resolved from librelane. If the user did not provide `FAB_PDK_HASH`, it is filled in automatically; if the user-provided value differs from the recommended one, a mismatch warning is logged. The PDK is then enabled via ciel.
+6. **Both are set and the PDK is a ciel family.** The recommended `FAB_PDK_HASH` is resolved from librelane. If the user did not provide `FAB_PDK_HASH`, it is filled in automatically; if the user-provided value differs from the recommended one, a mismatch warning is logged. The PDK is then installed and activated via ciel.
 
 ```{include} /generated_doc/fabulous_variable.md
 ```

--- a/fabulous/fabulous_cli/helper.py
+++ b/fabulous/fabulous_cli/helper.py
@@ -25,9 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import requests
-from ciel.common import get_ciel_home
 from dotenv import get_key, set_key
-from librelane.common.misc import get_pdk_hash
 from loguru import logger
 from packaging.version import Version
 from pick import pick
@@ -223,28 +221,8 @@ def create_project(project_dir: Path, lang: HDLType = HDLType.VERILOG) -> None:
         "FAB_MODELS_PACK",
         str(Path(project_dir.name) / "Fabric" / f"models_pack.{new_suffix}"),
     )
-    ciel_home = Path(get_ciel_home())
 
-    if ciel_home.exists():
-        if (ciel_home / "ihp-sg13g2").exists():
-            set_key(env_file, "FAB_PDK", "ihp-sg13g2")
-            set_key(env_file, "FAB_PDK_ROOT", str(ciel_home / "ihp-sg13g2"))
-
-            try:
-                pdk_hash = get_pdk_hash("ihp-sg13g2")
-            except SystemExit:
-                pdk_hash = None
-            if pdk_hash:
-                set_key(env_file, "FAB_PDK_HASH", pdk_hash)
-        else:
-            logger.warning(
-                "IHP SG13G2 PDK not found in ciel home. "
-                "Please ensure it is installed correctly.",
-            )
-    else:
-        logger.warning(
-            "Cannot find ciel home directory. Please set FAB_PDK_ROOT in .env file."
-        )
+    set_key(env_file, "FAB_PDK", "ihp-sg13g2")
 
     logger.info(
         f"New FABulous project created in {project_dir} with {lang!s} language."

--- a/fabulous/fabulous_settings.py
+++ b/fabulous/fabulous_settings.py
@@ -69,9 +69,20 @@ class FABulousSettings(BaseSettings):
     debug: bool = False
 
     # GDS variables
-    pdk_root: Path | None = None
-    pdk: str | None = None
-    pdk_hash: str | None = None
+    pdk_root: Path | None = Field(
+        default=None,
+        description="Root directory of the PDK installation",
+    )
+    pdk: str | None = Field(
+        default=None,
+        description="PDK name (e.g. 'ihp-sg13g2')",
+    )
+    pdk_hash: str | None = Field(
+        default=None,
+        description="Specific PDK version hash; "
+        "auto-resolved from librelane when omitted "
+        "if the PDK is supported by ciel",
+    )
     fabric_die_area: tuple[int, int, int, int] = (0, 0, 1000, 1000)
 
     # Windows warning acknowledgement

--- a/tests/cli_test/conftest.py
+++ b/tests/cli_test/conftest.py
@@ -10,24 +10,6 @@ from fabulous.fabulous_cli.helper import create_project
 TILE = "LUT4AB"
 
 
-@pytest.fixture(autouse=True)
-def _mock_ciel_home(tmp_path: Path, mocker: MockerFixture) -> None:
-    """Provide a fake ciel home with ihp-sg13g2 for all CLI tests.
-
-    This ensures tests don't depend on a real ciel installation.
-    Tests that need specific ciel home states (missing, empty) can
-    override by calling mocker.patch again in the test body.
-    """
-    ciel_home = tmp_path / "ciel_home"
-    (ciel_home / "ihp-sg13g2").mkdir(parents=True)
-    mocker.patch(
-        "fabulous.fabulous_cli.helper.get_ciel_home",
-        return_value=str(ciel_home),
-    )
-    # Prevent ciel from attempting real PDK downloads during settings validation
-    mocker.patch("ciel.manage.enable")
-
-
 @pytest.fixture
 def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Create a temporary FABulous project directory."""

--- a/tests/cli_test/conftest.py
+++ b/tests/cli_test/conftest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from dotenv import set_key
-from pytest_mock import MockerFixture
 
 from fabulous.fabulous_cli.helper import create_project
 

--- a/tests/cli_test/test_helper.py
+++ b/tests/cli_test/test_helper.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import pytest
-from pytest_mock import MockerFixture
 
 from fabulous.fabric_definition.define import HDLType
 from fabulous.fabulous_cli.helper import create_project, update_project_version
@@ -22,10 +21,11 @@ def test_create_project(tmp_path: Path) -> None:
     # Check if .env file exists and contains correct content
     env_file = project_dir / ".FABulous" / ".env"
     assert env_file.exists()
-    assert "FAB_PROJ_LANG='verilog'" in env_file.read_text()
-    assert "VERSION=" in env_file.read_text()
-    assert "FAB_PROJ_VERSION=" in env_file.read_text()
-    assert "FAB_PROJ_VERSION_CREATED=" in env_file.read_text()
+    env_content = env_file.read_text()
+    assert "FAB_PROJ_LANG='verilog'" in env_content
+    assert "FAB_PROJ_VERSION=" in env_content
+    assert "FAB_PROJ_VERSION_CREATED=" in env_content
+    assert "FAB_PDK='ihp-sg13g2'" in env_content
 
     # Check if template files were copied
     assert any(project_dir.glob("**/*.v")), (
@@ -54,80 +54,6 @@ def test_create_project_vhdl(tmp_path: Path) -> None:
     assert any(project_dir.glob("**/*.vhdl")), (
         "No VHDL files found in project directory"
     )
-
-
-@pytest.mark.parametrize(
-    ("resolver_behavior", "expect_hash"),
-    [
-        ("abc123def456resolved", True),
-        (None, False),
-        (SystemExit(1), False),
-    ],
-    ids=["resolver_returns_hash", "resolver_returns_none", "resolver_sysexit"],
-)
-def test_create_project_pdk_hash_behavior(
-    tmp_path: Path,
-    mocker: MockerFixture,
-    resolver_behavior: str | None | BaseException,
-    expect_hash: bool,
-) -> None:
-    """Test create_project FAB_PDK_HASH behavior for resolver outcomes."""
-    if isinstance(resolver_behavior, BaseException):
-        mocker.patch(
-            "fabulous.fabulous_cli.helper.get_pdk_hash",
-            side_effect=resolver_behavior,
-        )
-    else:
-        mocker.patch(
-            "fabulous.fabulous_cli.helper.get_pdk_hash",
-            return_value=resolver_behavior,
-        )
-
-    project_dir = tmp_path / "test_project_pdk_hash_behavior"
-    create_project(project_dir)
-
-    env_file = project_dir / ".FABulous" / ".env"
-    assert env_file.exists()
-    env_content = env_file.read_text()
-    if expect_hash:
-        assert "FAB_PDK_HASH='abc123def456resolved'" in env_content
-    else:
-        assert "FAB_PDK_HASH" not in env_content
-
-
-def test_create_project_warns_when_pdk_not_in_ciel(
-    tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test warning when ihp-sg13g2 dir is missing inside ciel home."""
-    # Make ciel home exist but without ihp-sg13g2 subdirectory
-    ciel_home = tmp_path / ".ciel_empty"
-    ciel_home.mkdir()
-    mocker.patch(
-        "fabulous.fabulous_cli.helper.get_ciel_home",
-        return_value=str(ciel_home),
-    )
-    project_dir = tmp_path / "test_project_no_pdk"
-    create_project(project_dir)
-
-    env_file = project_dir / ".FABulous" / ".env"
-    assert "FAB_PDK" not in env_file.read_text()
-    assert any("IHP SG13G2 PDK not found" in r.message for r in caplog.records)
-
-
-def test_create_project_warns_when_ciel_home_missing(
-    tmp_path: Path, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Test warning when ciel home directory does not exist."""
-    mocker.patch(
-        "fabulous.fabulous_cli.helper.get_ciel_home",
-        return_value=str(tmp_path / "nonexistent_ciel"),
-    )
-    project_dir = tmp_path / "test_project_no_ciel"
-    create_project(project_dir)
-
-    env_file = project_dir / ".FABulous" / ".env"
-    assert "FAB_PDK" not in env_file.read_text()
-    assert any("Cannot find ciel home" in r.message for r in caplog.records)
 
 
 def test_update_project_version_success(


### PR DESCRIPTION
With the full auto ciel PDK resolving feature implemented, we no longer need to resolve the PDK root at project creation. 

Ciel always resolves to `~/.ciel`, but on a system where ciel is never used (e.g., a Docker container), this will raise a warning about a missing `~/.ciel` and leave `FAB_PDK` unset, which the auto-resolving logic cannot resolve.  