### PR TITLE
chore: Validate frame address register capacity at fabric creation

### DIFF
--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -118,6 +118,65 @@ class Fabric:
         The wires are used during model generation to work with wire that going cross
         tile.
         """
+        # The FrameAddressRegister (frameBitsPerRow bits wide)
+        # is partitioned into three non-overlapping regions:
+        # upper bits for column select, a single desync bit,
+        # and lower bits for one-hot frame strobe.
+        # See docs/fabric_definition.md for the bit layout.
+        if self.desync_flag >= self.frameBitsPerRow:
+            raise ValueError(
+                f"desync_flag bit position "
+                f"({self.desync_flag}) exceeds "
+                f"FrameAddressRegister width "
+                f"({self.frameBitsPerRow}). "
+                f"Reduce desync_flag or increase "
+                f"frameBitsPerRow."
+            )
+
+        col_select_lo = self.frameBitsPerRow - self.frameSelectWidth
+        if self.maxFramesPerCol > col_select_lo:
+            raise ValueError(
+                f"FrameAddressRegister overflow: "
+                f"frame strobe bits [0:{self.maxFramesPerCol - 1}]"
+                f" overlap with column select bits "
+                f"[{col_select_lo}:"
+                f"{self.frameBitsPerRow - 1}]. "
+                f"Reduce maxFramesPerCol or increase "
+                f"frameBitsPerRow."
+            )
+
+        if self.desync_flag < self.maxFramesPerCol:
+            raise ValueError(
+                f"desync_flag bit position "
+                f"({self.desync_flag}) falls within the "
+                f"frame strobe region "
+                f"[0:{self.maxFramesPerCol - 1}]. "
+                f"Increase desync_flag or reduce "
+                f"maxFramesPerCol."
+            )
+
+        if self.desync_flag >= col_select_lo:
+            raise ValueError(
+                f"desync_flag bit position "
+                f"({self.desync_flag}) falls within the "
+                f"column select region "
+                f"[{col_select_lo}:"
+                f"{self.frameBitsPerRow - 1}]. "
+                f"Adjust desync_flag, frameSelectWidth, "
+                f"or frameBitsPerRow."
+            )
+
+        max_cols = 1 << self.frameSelectWidth
+        if self.numberOfColumns > max_cols:
+            raise ValueError(
+                f"Not enough column address bits: "
+                f"frameSelectWidth ({self.frameSelectWidth})"
+                f" can address {max_cols} columns, "
+                f"but fabric has {self.numberOfColumns} "
+                f"columns. Increase frameSelectWidth or "
+                f"frameBitsPerRow."
+            )
+
         for row in self.tile:
             for tile in row:
                 if tile is None:

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -118,20 +118,38 @@ class Fabric:
         The wires are used during model generation to work with wire that going cross
         tile.
         """
-        if not self.numberOfRows <= 32:
+        if self.numberOfRows > 32:
             raise ValueError(
-                "Due to bistream limitations,"
+                "Due to bitstream limitations, "
                 "numberOfRows must be less than or equal to 32."
             )
 
-        if not self.numberOfColumns <= 32:
+        if self.numberOfColumns > 32:
             raise ValueError(
-                "Due to bistream limitations, "
+                "Due to bitstream limitations, "
                 "numberOfColumns must be less than or equal to 32."
             )
 
+        if self.frameBitsPerRow != 32:
+            raise ValueError(
+                "Due to bitstream limitations, frameBitsPerRow must be 32."
+            )
+
         if self.maxFramesPerCol != 20:
-            raise ValueError("Due to bistream limitations, maxFramesPerCol must be 20.")
+            raise ValueError(
+                "Due to bitstream limitations, maxFramesPerCol must be 20."
+            )
+
+        if self.frameSelectWidth != 5:
+            raise ValueError(
+                "Due to bitstream limitations, frameSelectWidth must be 5."
+            )
+
+        if self.rowSelectWidth != 5:
+            raise ValueError("Due to bitstream limitations, rowSelectWidth must be 5.")
+
+        if self.desync_flag != 20:
+            raise ValueError("Due to bitstream limitations, desync_flag must be 20.")
 
         for tile in self.tileDic.values():
             if len(tile.bels) > 26:

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -118,64 +118,27 @@ class Fabric:
         The wires are used during model generation to work with wire that going cross
         tile.
         """
-        # The FrameAddressRegister (frameBitsPerRow bits wide)
-        # is partitioned into three non-overlapping regions:
-        # upper bits for column select, a single desync bit,
-        # and lower bits for one-hot frame strobe.
-        # See docs/fabric_definition.md for the bit layout.
-        if self.desync_flag >= self.frameBitsPerRow:
+        if not self.numberOfRows <= 32:
             raise ValueError(
-                f"desync_flag bit position "
-                f"({self.desync_flag}) exceeds "
-                f"FrameAddressRegister width "
-                f"({self.frameBitsPerRow}). "
-                f"Reduce desync_flag or increase "
-                f"frameBitsPerRow."
+                "Due to bistream limitations,"
+                "numberOfRows must be less than or equal to 32."
             )
 
-        col_select_lo = self.frameBitsPerRow - self.frameSelectWidth
-        if self.maxFramesPerCol > col_select_lo:
+        if not self.numberOfColumns <= 32:
             raise ValueError(
-                f"FrameAddressRegister overflow: "
-                f"frame strobe bits [0:{self.maxFramesPerCol - 1}]"
-                f" overlap with column select bits "
-                f"[{col_select_lo}:"
-                f"{self.frameBitsPerRow - 1}]. "
-                f"Reduce maxFramesPerCol or increase "
-                f"frameBitsPerRow."
+                "Due to bistream limitations, "
+                "numberOfColumns must be less than or equal to 32."
             )
 
-        if self.desync_flag < self.maxFramesPerCol:
-            raise ValueError(
-                f"desync_flag bit position "
-                f"({self.desync_flag}) falls within the "
-                f"frame strobe region "
-                f"[0:{self.maxFramesPerCol - 1}]. "
-                f"Increase desync_flag or reduce "
-                f"maxFramesPerCol."
-            )
+        if self.maxFramesPerCol != 20:
+            raise ValueError("Due to bistream limitations, maxFramesPerCol must be 20.")
 
-        if self.desync_flag >= col_select_lo:
-            raise ValueError(
-                f"desync_flag bit position "
-                f"({self.desync_flag}) falls within the "
-                f"column select region "
-                f"[{col_select_lo}:"
-                f"{self.frameBitsPerRow - 1}]. "
-                f"Adjust desync_flag, frameSelectWidth, "
-                f"or frameBitsPerRow."
-            )
-
-        max_cols = 1 << self.frameSelectWidth
-        if self.numberOfColumns > max_cols:
-            raise ValueError(
-                f"Not enough column address bits: "
-                f"frameSelectWidth ({self.frameSelectWidth})"
-                f" can address {max_cols} columns, "
-                f"but fabric has {self.numberOfColumns} "
-                f"columns. Increase frameSelectWidth or "
-                f"frameBitsPerRow."
-            )
+        for tile in self.tileDic.values():
+            if len(tile.bels) > 26:
+                raise ValueError(
+                    "Due to naming limitations, "
+                    f"tile {tile.name} cannot have more than 26 BELs."
+                )
 
         for row in self.tile:
             for tile in row:

--- a/tests/fabric_definition/conftest.py
+++ b/tests/fabric_definition/conftest.py
@@ -1,0 +1,32 @@
+"""Conftest file providing fixtures for fabric definition tests."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from fabulous.fabric_definition.fabric import Fabric
+
+
+@pytest.fixture
+def make_fabric() -> Callable[..., Fabric]:
+    """Return a factory that creates a real Fabric with sensible defaults.
+
+    Unlike the mocked fixtures in ``fabric_gen_test/conftest.py``, the objects
+    produced here go through ``__post_init__`` and therefore exercise all
+    validation logic.
+    """
+
+    def _make(**overrides: int) -> Fabric:
+        defaults = {
+            "fabric_dir": Path("/tmp"),
+            "frameBitsPerRow": 32,
+            "maxFramesPerCol": 20,
+            "frameSelectWidth": 5,
+            "desync_flag": 20,
+            "numberOfColumns": 15,
+        }
+        defaults.update(overrides)
+        return Fabric(**defaults)
+
+    return _make

--- a/tests/fabric_definition/test_fabric.py
+++ b/tests/fabric_definition/test_fabric.py
@@ -1,43 +1,26 @@
-"""Tests for FrameAddressRegister bit-field validation in Fabric.__post_init__."""
+"""Tests for hardcoded validation checks in Fabric.__post_init__."""
 
 from collections.abc import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
 from fabulous.fabric_definition.fabric import Fabric
+from fabulous.fabric_definition.tile import Tile
 
 
-class TestFrameAddressRegisterValidation:
-    """Validate that non-overlapping bit regions are enforced."""
+class TestFabricValidation:
+    """Validate hardcoded bitstream and naming constraints."""
 
     @pytest.mark.parametrize(
         "overrides",
         [
+            pytest.param({}, id="defaults"),
+            pytest.param({"numberOfRows": 32}, id="rows_at_boundary"),
+            pytest.param({"numberOfColumns": 32}, id="columns_at_boundary"),
             pytest.param(
-                {},
-                id="defaults",
-            ),
-            pytest.param(
-                {"maxFramesPerCol": 26, "desync_flag": 26},
-                id="frame_strobe_at_boundary",
-            ),
-            pytest.param(
-                {"desync_flag": 20, "maxFramesPerCol": 20},
-                id="desync_at_frame_strobe_boundary",
-            ),
-            pytest.param(
-                {"numberOfColumns": 16, "frameSelectWidth": 4},
-                id="column_bits_exact_fit",
-            ),
-            pytest.param(
-                {
-                    "frameBitsPerRow": 10,
-                    "maxFramesPerCol": 4,
-                    "desync_flag": 4,
-                    "frameSelectWidth": 3,
-                    "numberOfColumns": 8,
-                },
-                id="tight_valid_layout",
+                {"numberOfRows": 32, "numberOfColumns": 32},
+                id="both_at_boundary",
             ),
         ],
     )
@@ -54,44 +37,54 @@ class TestFrameAddressRegisterValidation:
         ("overrides", "error_match"),
         [
             pytest.param(
-                {"maxFramesPerCol": 28},
-                "FrameAddressRegister overflow",
-                id="frame_strobe_overlaps_column_select",
+                {"numberOfRows": 33},
+                "numberOfRows must be less than or equal to 32",
+                id="rows_exceed_32",
             ),
             pytest.param(
-                {"desync_flag": 10, "maxFramesPerCol": 20},
-                "frame strobe region",
-                id="desync_in_frame_strobe",
+                {"numberOfRows": 64},
+                "numberOfRows must be less than or equal to 32",
+                id="rows_far_exceed_32",
             ),
             pytest.param(
-                {"desync_flag": 28},
-                "column select region",
-                id="desync_in_column_select",
+                {"numberOfColumns": 33},
+                "numberOfColumns must be less than or equal to 32",
+                id="columns_exceed_32",
             ),
             pytest.param(
-                {"desync_flag": 27},
-                "column select region",
-                id="desync_at_column_select_boundary",
+                {"numberOfColumns": 64},
+                "numberOfColumns must be less than or equal to 32",
+                id="columns_far_exceed_32",
             ),
             pytest.param(
-                {"desync_flag": 32, "frameBitsPerRow": 32},
-                "exceeds FrameAddressRegister width",
-                id="desync_exceeds_register_width",
+                {"frameBitsPerRow": 16},
+                "frameBitsPerRow must be 32",
+                id="frame_bits_per_row_wrong",
             ),
             pytest.param(
-                {"frameSelectWidth": 3},
-                "Not enough column address bits",
-                id="insufficient_column_bits",
+                {"maxFramesPerCol": 19},
+                "maxFramesPerCol must be 20",
+                id="max_frames_below_20",
             ),
             pytest.param(
-                {"numberOfColumns": 17, "frameSelectWidth": 4},
-                "Not enough column address bits",
-                id="column_bits_one_over",
+                {"maxFramesPerCol": 21},
+                "maxFramesPerCol must be 20",
+                id="max_frames_above_20",
             ),
             pytest.param(
-                {"frameBitsPerRow": 4, "maxFramesPerCol": 20, "frameSelectWidth": 5},
-                "exceeds FrameAddressRegister width",
-                id="all_regions_overlap",
+                {"frameSelectWidth": 4},
+                "frameSelectWidth must be 5",
+                id="frame_select_width_wrong",
+            ),
+            pytest.param(
+                {"rowSelectWidth": 3},
+                "rowSelectWidth must be 5",
+                id="row_select_width_wrong",
+            ),
+            pytest.param(
+                {"desync_flag": 10},
+                "desync_flag must be 20",
+                id="desync_flag_wrong",
             ),
         ],
     )
@@ -103,3 +96,27 @@ class TestFrameAddressRegisterValidation:
     ) -> None:
         with pytest.raises(ValueError, match=error_match):
             make_fabric(**overrides)
+
+    @pytest.mark.parametrize(
+        ("num_bels", "should_raise"),
+        [
+            pytest.param(26, False, id="bels_at_boundary"),
+            pytest.param(27, True, id="bels_exceed_26"),
+            pytest.param(30, True, id="bels_far_exceed_26"),
+        ],
+    )
+    def test_tile_bel_count(
+        self,
+        make_fabric: Callable[..., Fabric],
+        num_bels: int,
+        should_raise: bool,
+    ) -> None:
+        tile = MagicMock(spec=Tile)
+        tile.name = "test_tile"
+        tile.bels = [MagicMock() for _ in range(num_bels)]
+        if should_raise:
+            with pytest.raises(ValueError, match="cannot have more than 26 BELs"):
+                make_fabric(tileDic={"test_tile": tile})
+        else:
+            fabric = make_fabric(tileDic={"test_tile": tile})
+            assert len(fabric.tileDic["test_tile"].bels) == num_bels

--- a/tests/fabric_definition/test_fabric.py
+++ b/tests/fabric_definition/test_fabric.py
@@ -1,0 +1,105 @@
+"""Tests for FrameAddressRegister bit-field validation in Fabric.__post_init__."""
+
+from collections.abc import Callable
+
+import pytest
+
+from fabulous.fabric_definition.fabric import Fabric
+
+
+class TestFrameAddressRegisterValidation:
+    """Validate that non-overlapping bit regions are enforced."""
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            pytest.param(
+                {},
+                id="defaults",
+            ),
+            pytest.param(
+                {"maxFramesPerCol": 26, "desync_flag": 26},
+                id="frame_strobe_at_boundary",
+            ),
+            pytest.param(
+                {"desync_flag": 20, "maxFramesPerCol": 20},
+                id="desync_at_frame_strobe_boundary",
+            ),
+            pytest.param(
+                {"numberOfColumns": 16, "frameSelectWidth": 4},
+                id="column_bits_exact_fit",
+            ),
+            pytest.param(
+                {
+                    "frameBitsPerRow": 10,
+                    "maxFramesPerCol": 4,
+                    "desync_flag": 4,
+                    "frameSelectWidth": 3,
+                    "numberOfColumns": 8,
+                },
+                id="tight_valid_layout",
+            ),
+        ],
+    )
+    def test_valid_configurations(
+        self,
+        make_fabric: Callable[..., Fabric],
+        overrides: dict,
+    ) -> None:
+        fabric = make_fabric(**overrides)
+        for key, value in overrides.items():
+            assert getattr(fabric, key) == value
+
+    @pytest.mark.parametrize(
+        ("overrides", "error_match"),
+        [
+            pytest.param(
+                {"maxFramesPerCol": 28},
+                "FrameAddressRegister overflow",
+                id="frame_strobe_overlaps_column_select",
+            ),
+            pytest.param(
+                {"desync_flag": 10, "maxFramesPerCol": 20},
+                "frame strobe region",
+                id="desync_in_frame_strobe",
+            ),
+            pytest.param(
+                {"desync_flag": 28},
+                "column select region",
+                id="desync_in_column_select",
+            ),
+            pytest.param(
+                {"desync_flag": 27},
+                "column select region",
+                id="desync_at_column_select_boundary",
+            ),
+            pytest.param(
+                {"desync_flag": 32, "frameBitsPerRow": 32},
+                "exceeds FrameAddressRegister width",
+                id="desync_exceeds_register_width",
+            ),
+            pytest.param(
+                {"frameSelectWidth": 3},
+                "Not enough column address bits",
+                id="insufficient_column_bits",
+            ),
+            pytest.param(
+                {"numberOfColumns": 17, "frameSelectWidth": 4},
+                "Not enough column address bits",
+                id="column_bits_one_over",
+            ),
+            pytest.param(
+                {"frameBitsPerRow": 4, "maxFramesPerCol": 20, "frameSelectWidth": 5},
+                "exceeds FrameAddressRegister width",
+                id="all_regions_overlap",
+            ),
+        ],
+    )
+    def test_invalid_configurations(
+        self,
+        make_fabric: Callable[..., Fabric],
+        overrides: dict,
+        error_match: str,
+    ) -> None:
+        with pytest.raises(ValueError, match=error_match):
+            make_fabric(**overrides)


### PR DESCRIPTION
Add checks in Fabric.__post_init__() to catch frame address overflow early

Closes #490