### PR TITLE
chore: mocking ciel enable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,11 @@ def fabulous_test_environment(
         "enable",
         lambda *_args, **_kwargs: None,
     )
+    monkeypatch.setattr(
+        fabulous.fabulous_settings,
+        "get_ciel_home",
+        lambda: str(tmp_path / ".ciel"),
+    )
     (tmp_path / ".ciel" / "ihp-sg13g2").mkdir(parents=True, exist_ok=True)
     setup_logger(0, False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,13 @@ def fabulous_test_environment(
         fabulous.fabulous_settings, "FAB_USER_CONFIG_DIR", fake_user_config_dir
     )
     monkeypatch.setattr(fabulous.fabulous, "FAB_USER_CONFIG_DIR", fake_user_config_dir)
+    # Avoid network-dependent PDK download attempts in tests when settings
+    # validation triggers ciel activation.
+    monkeypatch.setattr(
+        fabulous.fabulous_settings.ciel.manage,
+        "enable",
+        lambda *_args, **_kwargs: None,
+    )
     (tmp_path / ".ciel" / "ihp-sg13g2").mkdir(parents=True, exist_ok=True)
     setup_logger(0, False)
 


### PR DESCRIPTION
This should prevent network dropout that could lead to test failure. 