### PR TITLE
fix(tests): clear only FAB_* env vars in global test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,8 +69,9 @@ def fabulous_test_environment(
     """Set up global test environment for FABulous tests."""
     fabulous_root = str(Path(__file__).resolve().parent.parent / "FABulous")
 
-    for i in os.environ:
-        monkeypatch.delenv(i[0], raising=False)
+    for key in list(os.environ.keys()):
+        if key.startswith("FAB_"):
+            monkeypatch.delenv(key, raising=False)
 
     fake_user_config_dir = tmp_path / ".fabulous"
 


### PR DESCRIPTION
The original loop used `i[0]` (first char of key) instead of `i`, making the delenv calls no-ops. Also narrows scope to FAB_* only to avoid clearing env vars other fixtures or the test runner rely on.