### PR TITLE
fix: allow nix develop from a different directroy

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -221,7 +221,7 @@
             ];
             devshell.startup.fabulous-setup = {
               text = ''
-                export REPO_ROOT=$(git rev-parse --show-toplevel)
+                export REPO_ROOT="${toString ./.}"
                 ORIGINAL_PS1="$PS1"
 
                 . ${virtualenv}/bin/activate
@@ -292,7 +292,7 @@
                 # FAB_YOSYS_PATH: tells FABulous the nix yosys binary is named fab-yosys
                 export FAB_YOSYS_PATH="fab-yosys"
 
-                export REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+                export REPO_ROOT="${toString ./.}"
                 . ${virtualenv}/bin/activate
 
                 # Build PYTHONPATH so librelane + venv + repo root are importable


### PR DESCRIPTION
Currently it is not possible to just run `nix develop /path/to/fabulous/` to get a nix shell with our environment in which ever directory you want, the `REPO_ROOT` is always evaluated using `git rev-parse`. Since `flake.nix` is in the root of the repo anyway, this can be change to just `"${toString ./.}"`.

At least this is what Claude suggested, so please let me know if this might break anything, although it makes sense to me and _it works on my machine_ ...