### PR TITLE
feat: support keep attribute and VHDL open mapping in code generators

### DIFF
--- a/fabulous/fabric_generator/code_generator/code_generator.py
+++ b/fabulous/fabric_generator/code_generator/code_generator.py
@@ -481,6 +481,7 @@ class CodeGenerator(abc.ABC):
         portsPairs: list[tuple[str, str]],
         paramPairs: list[tuple[str, str]] | None = None,
         emulateParamPairs: list[tuple[str, str]] | None = None,
+        add_keep: bool = False,
         indentLevel: int = 0,
     ) -> None:
         """Add an instantiation.
@@ -504,6 +505,9 @@ class CodeGenerator(abc.ABC):
         emulateParamPairs : list[tuple[str, str]] | None, optional
             List of parameter signals of the component in emulation mode only.
             Defaults to None.
+        add_keep : bool, optional
+            Whether to add a FABulous "keep" attribute to the instance.
+            Defaults to False.
         indentLevel : int, optional
             The level of indentation. Defaults to 0.
 

--- a/fabulous/fabric_generator/code_generator/code_generator_VHDL.py
+++ b/fabulous/fabric_generator/code_generator/code_generator_VHDL.py
@@ -51,6 +51,9 @@ class VHDLCodeGenerator(CodeGenerator):
             The indentation level
         """
         #   library template
+        self._add(f"package attr_pack_{name} is")
+        self._add(" attribute keep : string;")
+        self._add("end package;")
         self._add("library IEEE;", indentLevel)
         self._add("use IEEE.STD_LOGIC_1164.ALL;", indentLevel)
         self._add("use IEEE.NUMERIC_STD.ALL;", indentLevel)
@@ -429,6 +432,7 @@ end process;
         portsPairs: list[tuple[str, str]],
         paramPairs: list[tuple[str, str]] | None = None,
         emulateParamPairs: list[tuple[str, str]] | None = None,
+        add_keep: bool = False,  # noqa: ARG002 — accepted for API parity; VHDL has no keep attr
         indentLevel: int = 0,
     ) -> None:
         """Add a component instantiation.
@@ -445,6 +449,8 @@ end process;
             List of (parameter, value) pairs for generic mapping
         emulateParamPairs : list[tuple[str, str]] | None
             Additional parameters (unused)
+        add_keep : bool
+            Accepted for API parity with the Verilog generator (no-op in VHDL)
         indentLevel : int
             The indentation level
         """
@@ -480,7 +486,8 @@ end process;
                 )
             split = signal.split(",")
             if len(split) == 1:
-                connectPair.append(f"{port} => {signal}")
+                rhs = signal or "open"
+                connectPair.append(f"{port} => {rhs}")
             else:
                 for idx, sn in zip(reversed(range(len(split))), split, strict=False):
                     connectPair.append(

--- a/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
+++ b/fabulous/fabric_generator/code_generator/code_generator_Verilog.py
@@ -247,6 +247,7 @@ class VerilogCodeGenerator(CodeGenerator):
         portsPairs: list[tuple[str, str]],
         paramPairs: list[tuple[str, str]] | None = None,
         emulateParamPairs: list[tuple[str, str]] | None = None,
+        add_keep: bool = False,
         indentLevel: int = 0,
     ) -> None:
         """Add a module instantiation.
@@ -257,6 +258,7 @@ class VerilogCodeGenerator(CodeGenerator):
             portsPairs: List of (port, signal) pairs for port mapping
             paramPairs: List of (parameter, value) pairs for parameter mapping
             emulateParamPairs: Parameters for emulation mode only
+            add_keep: Whether to add a "keep" attribute to the instance
             indentLevel: The indentation level
         """
         if emulateParamPairs is None:
@@ -265,7 +267,10 @@ class VerilogCodeGenerator(CodeGenerator):
             paramPairs = []
         if paramPairs:
             port = [f".{i[0]}({i[1]})" for i in paramPairs]
-            self._add(f"{compName}", indentLevel=indentLevel)
+            if add_keep:
+                self._add(f"(* keep *) {compName}", indentLevel=indentLevel)
+            else:
+                self._add(f"{compName}", indentLevel=indentLevel)
             self._add("#(", indentLevel=indentLevel + 1)
             self._add(
                 (f",\n{' ':<{4 * (indentLevel + 1)}}").join(port),
@@ -276,7 +281,10 @@ class VerilogCodeGenerator(CodeGenerator):
             self._add("(", indentLevel=indentLevel + 1)
         elif emulateParamPairs:
             port = [f".{i[0]}({i[1]})" for i in emulateParamPairs]
-            self._add(f"{compName}", indentLevel=indentLevel)
+            if add_keep:
+                self._add(f"(* keep *) {compName}", indentLevel=indentLevel)
+            else:
+                self._add(f"{compName}", indentLevel=indentLevel)
             self._add("`ifdef EMULATION", indentLevel=0)
             self._add("#(", indentLevel=indentLevel + 1)
             self._add(
@@ -288,7 +296,12 @@ class VerilogCodeGenerator(CodeGenerator):
             self._add(f"{compInsName}", indentLevel=indentLevel + 1)
             self._add("(", indentLevel=indentLevel + 1)
         else:
-            self._add(f"{compName} {compInsName} (", indentLevel=indentLevel)
+            if add_keep:
+                self._add(
+                    f"(* keep *) {compName} {compInsName} (", indentLevel=indentLevel
+                )
+            else:
+                self._add(f"{compName} {compInsName} (", indentLevel=indentLevel)
 
         connectPair = []
         for i in portsPairs:


### PR DESCRIPTION
- Add ``add_keep`` parameter to ``addComponentInstantiation`` so Verilog instances can emit the ``(* keep *)`` synthesis attribute.
- Emit a per-module ``attr_pack_<name>`` package in the VHDL generator for parity (VHDL accepts the parameter as a no-op).
- Map empty signals to the VHDL ``open`` keyword in component instantiations so unconnected ports are syntactically valid.