### PR TITLE
chore: decouple fabric from component generator interfaces

### DIFF
--- a/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
+++ b/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
@@ -188,61 +188,102 @@ def _serialize_supertile_ports(
 
 
 def generate_IO_pin_order_config(
-    fabric: Fabric,
     tile_or_super_tile: Tile | SuperTile,
     outfile: Path,
+    *,
+    fabric: Fabric | None = None,
     prefix: str = "",
+    external_port_side: Side = Side.SOUTH,
 ) -> None:
-    """Generate IO pin order configuration for a tile or supertile.
+    """Generate IO pin order configuration YAML for a tile or super tile.
+
+    When ``fabric`` is provided, external-port sides are resolved from each
+    (sub)tile's placement within the fabric; otherwise ``external_port_side``
+    is used as the fallback for every concrete (sub)tile.
 
     Parameters
     ----------
-    fabric : Fabric
-        The fabric containing the tile or supertile
     tile_or_super_tile : Tile | SuperTile
-        The tile or super tile to generate configuration for
+        The tile or super tile to generate configuration for.
     outfile : Path
-        Output YAML file path
+        Output YAML file path.
+    fabric : Fabric | None
+        Optional fabric used to derive border-aware external-port sides.
     prefix : str
-        Prefix to add to port names
+        Prefix to add to port names.
+    external_port_side : Side
+        Fallback side used for BEL external ports when no fabric placement
+        context applies.
     """
-    positions = fabric.find_tile_positions(tile_or_super_tile)
-
     if isinstance(tile_or_super_tile, SuperTile):
-        external_port_sides: dict[tuple[int, int], Side] = {}
-        if positions:
-            # For multi-entry config, find top-left position (min x, min y)
-            if len(positions) == 1:
-                base_x, base_y = positions[0]
-            else:
-                base_x = min(pos[0] for pos in positions)
-                base_y = min(pos[1] for pos in positions)
-
-            for st_y, row in enumerate(tile_or_super_tile.tileMap):
-                for st_x, st_tile in enumerate(row):
-                    if st_tile is None:
-                        continue
-                    fabric_x = base_x + st_x
-                    fabric_y = base_y + st_y
-                    border_side = fabric.determine_border_side(fabric_x, fabric_y)
-                    if border_side:
-                        external_port_sides[(st_x, st_y)] = border_side
-
-        config_payload = _serialize_supertile_ports(
-            tile_or_super_tile, prefix, external_port_sides
+        sides = _resolve_supertile_external_port_sides(
+            tile_or_super_tile, fabric, external_port_side
         )
+        payload = _serialize_supertile_ports(tile_or_super_tile, prefix, sides)
     else:
-        external_port_side = Side.SOUTH
-        if positions:
-            x, y = positions[0]
-            if border_side := fabric.determine_border_side(x, y):
-                external_port_side = border_side
-
-        config_payload = {
-            "X0Y0": _serialize_tile_ports(
-                tile_or_super_tile, prefix, external_port_side
-            )
+        side = _resolve_tile_external_port_side(
+            tile_or_super_tile, fabric, external_port_side
+        )
+        payload = {
+            "X0Y0": _serialize_tile_ports(tile_or_super_tile, prefix, side),
         }
 
     with outfile.open("w") as file_descriptor:
-        yaml.dump(config_payload, file_descriptor)
+        yaml.dump(payload, file_descriptor)
+
+
+def _resolve_tile_external_port_side(
+    tile: Tile,
+    fabric: Fabric | None,
+    default_side: Side,
+) -> Side:
+    """Resolve a tile's external side from fabric placement when possible."""
+    if fabric is None:
+        return default_side
+    positions = fabric.find_tile_positions(tile)
+    if not positions:
+        return default_side
+    x, y = positions[0]
+    return fabric.determine_border_side(x, y) or default_side
+
+
+def _resolve_supertile_external_port_sides(
+    super_tile: SuperTile,
+    fabric: Fabric | None,
+    default_side: Side,
+) -> dict[tuple[int, int], Side]:
+    """Resolve SuperTile external sides from fabric placement when possible.
+
+    Without a fabric, every concrete subtile maps to ``default_side``. With a
+    fabric, only subtiles that land on a fabric border get an entry; interior
+    subtiles are omitted so the serializer's perimeter-side heuristic applies.
+    """
+    if fabric is None:
+        return {
+            (x, y): default_side
+            for y, row in enumerate(super_tile.tileMap)
+            for x, subtile in enumerate(row)
+            if subtile is not None
+        }
+
+    sides: dict[tuple[int, int], Side] = {}
+    positions = fabric.find_tile_positions(super_tile)
+    if not positions:
+        return sides
+
+    if len(positions) == 1:
+        base_x, base_y = positions[0]
+    else:
+        base_x = min(pos[0] for pos in positions)
+        base_y = min(pos[1] for pos in positions)
+
+    for st_y, row in enumerate(super_tile.tileMap):
+        for st_x, st_tile in enumerate(row):
+            if st_tile is None:
+                continue
+            if border_side := fabric.determine_border_side(
+                base_x + st_x, base_y + st_y
+            ):
+                sides[(st_x, st_y)] = border_side
+
+    return sides

--- a/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
+++ b/fabulous/fabric_generator/gds_generator/gen_io_pin_config_yaml.py
@@ -197,8 +197,8 @@ def generate_IO_pin_order_config(
 ) -> None:
     """Generate IO pin order configuration YAML for a tile or super tile.
 
-    When ``fabric`` is provided, external-port sides are resolved from each
-    (sub)tile's placement within the fabric; otherwise ``external_port_side``
+    When `fabric` is provided, external-port sides are resolved from each
+    (sub)tile's placement within the fabric; otherwise `external_port_side`
     is used as the fallback for every concrete (sub)tile.
 
     Parameters
@@ -216,74 +216,45 @@ def generate_IO_pin_order_config(
         context applies.
     """
     if isinstance(tile_or_super_tile, SuperTile):
-        sides = _resolve_supertile_external_port_sides(
-            tile_or_super_tile, fabric, external_port_side
-        )
+        sides: dict[tuple[int, int], Side] = {}
+        if (fabric is not None) and (
+            positions := fabric.find_tile_positions(tile_or_super_tile)
+        ):
+            if len(positions) == 1:
+                base_x, base_y = positions[0]
+            else:
+                base_x = min(pos[0] for pos in positions)
+                base_y = min(pos[1] for pos in positions)
+
+            for st_y, row in enumerate(tile_or_super_tile.tileMap):
+                for st_x, st_tile in enumerate(row):
+                    if st_tile is None:
+                        continue
+                    if border_side := fabric.determine_border_side(
+                        base_x + st_x, base_y + st_y
+                    ):
+                        sides[(st_x, st_y)] = border_side
+        else:
+            sides = {
+                (x, y): external_port_side
+                for y, row in enumerate(tile_or_super_tile.tileMap)
+                for x, subtile in enumerate(row)
+                if subtile is not None
+            }
+
         payload = _serialize_supertile_ports(tile_or_super_tile, prefix, sides)
     else:
-        side = _resolve_tile_external_port_side(
-            tile_or_super_tile, fabric, external_port_side
-        )
+        if fabric is not None and (
+            positions := fabric.find_tile_positions(tile_or_super_tile)
+        ):
+            x, y = positions[0]
+            side = fabric.determine_border_side(x, y) or external_port_side
+        else:
+            side = external_port_side
+
         payload = {
             "X0Y0": _serialize_tile_ports(tile_or_super_tile, prefix, side),
         }
 
     with outfile.open("w") as file_descriptor:
         yaml.dump(payload, file_descriptor)
-
-
-def _resolve_tile_external_port_side(
-    tile: Tile,
-    fabric: Fabric | None,
-    default_side: Side,
-) -> Side:
-    """Resolve a tile's external side from fabric placement when possible."""
-    if fabric is None:
-        return default_side
-    positions = fabric.find_tile_positions(tile)
-    if not positions:
-        return default_side
-    x, y = positions[0]
-    return fabric.determine_border_side(x, y) or default_side
-
-
-def _resolve_supertile_external_port_sides(
-    super_tile: SuperTile,
-    fabric: Fabric | None,
-    default_side: Side,
-) -> dict[tuple[int, int], Side]:
-    """Resolve SuperTile external sides from fabric placement when possible.
-
-    Without a fabric, every concrete subtile maps to ``default_side``. With a
-    fabric, only subtiles that land on a fabric border get an entry; interior
-    subtiles are omitted so the serializer's perimeter-side heuristic applies.
-    """
-    if fabric is None:
-        return {
-            (x, y): default_side
-            for y, row in enumerate(super_tile.tileMap)
-            for x, subtile in enumerate(row)
-            if subtile is not None
-        }
-
-    sides: dict[tuple[int, int], Side] = {}
-    positions = fabric.find_tile_positions(super_tile)
-    if not positions:
-        return sides
-
-    if len(positions) == 1:
-        base_x, base_y = positions[0]
-    else:
-        base_x = min(pos[0] for pos in positions)
-        base_y = min(pos[1] for pos in positions)
-
-    for st_y, row in enumerate(super_tile.tileMap):
-        for st_x, st_tile in enumerate(row):
-            if st_tile is None:
-                continue
-            if border_side := fabric.determine_border_side(
-                base_x + st_x, base_y + st_y
-            ):
-                sides[(st_x, st_y)] = border_side
-
-    return sides

--- a/fabulous/fabric_generator/gen_fabric/gen_configmem.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_configmem.py
@@ -14,7 +14,6 @@ from bitarray import bitarray
 from loguru import logger
 
 from fabulous.fabric_definition.define import IO
-from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
 from fabulous.fabric_generator.code_generator.code_generator_Verilog import (
@@ -26,33 +25,40 @@ if TYPE_CHECKING:
     from fabulous.fabric_definition.configmem import ConfigMem
 
 
-def generateConfigMemInit(fabric: Fabric, file: Path, tileConfigBitsCount: int) -> None:
+def generateConfigMemInit(
+    file: Path,
+    tileConfigBitsCount: int,
+    frame_bits_per_row: int = 32,
+    max_frame_per_col: int = 20,
+) -> None:
     """Generate the config memory initialization file.
 
     The amount of configuration bits is determined
-    by the `frameBitsPerRow` attribute of the fabric. The function will pack the
-    configuration bit from the highest to the lowest bit in the config memory. I. e. if
-    there are 100 configuration bits, with 32 frame bits per row, the function will pack
-    from bit 99 starting from bit 31 of frame 0 to bit 28 of frame 3.
+    by ``frame_bits_per_row``. The function will pack the configuration bit from
+    the highest to the lowest bit in the config memory. I. e. if there are 100
+    configuration bits, with 32 frame bits per row, the function will pack from
+    bit 99 starting from bit 31 of frame 0 to bit 28 of frame 3.
 
     Parameters
     ----------
-    fabric : Fabric
-        The fabric object containing fabric configuration
     file : Path
         The output file of the config memory initialization file.
     tileConfigBitsCount : int
         The number of tile config bits of the tile.
+    frame_bits_per_row : int
+        The number of configuration bits per frame row.
+    max_frame_per_col : int
+        The number of frames stored per tile column.
 
     Raises
     ------
     ValueError
         If the tile config bits exceed the fabric capacity.
     """
-    if tileConfigBitsCount > fabric.frameBitsPerRow * fabric.maxFramesPerCol:
+    if tileConfigBitsCount > frame_bits_per_row * max_frame_per_col:
         raise ValueError(
             f"Tile config bits ({tileConfigBitsCount}) exceed fabric capacity "
-            f"({fabric.frameBitsPerRow * fabric.maxFramesPerCol} bits). "
+            f"({frame_bits_per_row * max_frame_per_col} bits). "
             f"Please adjust the tile configuration."
         )
 
@@ -67,20 +73,20 @@ def generateConfigMemInit(fabric: Fabric, file: Path, tileConfigBitsCount: int) 
     with file.open("w", newline="") as f:
         writer = csv.writer(f)
         writer.writerow(fieldName)
-        bits = bitarray(fabric.frameBitsPerRow * fabric.maxFramesPerCol)
+        bits = bitarray(frame_bits_per_row * max_frame_per_col)
         bits[:tileConfigBitsCount] = 1
 
         # adjust for zero-based indexing in subsequent calculations
         tileConfigBitsCount -= 1
 
         count = 0
-        for k in range(fabric.maxFramesPerCol):
+        for k in range(max_frame_per_col):
             entry = {}
             # frame0, frame1, ...
             entry["frame_name"] = f"frame{k}"
             # and the index (0, 1, 2, ...), in case we need
             entry["frame_index"] = str(k)
-            bitSlice = bits[count : count + fabric.frameBitsPerRow]
+            bitSlice = bits[count : count + frame_bits_per_row]
             entry["bits_used_in_frame"] = bitSlice.count(1)
             entry["used_bits_mask"] = bitSlice.to01(group=4, sep="_")
             if bitSlice.count(1) == 0:
@@ -88,16 +94,20 @@ def generateConfigMemInit(fabric: Fabric, file: Path, tileConfigBitsCount: int) 
             else:
                 entry["ConfigBits_ranges"] = (
                     f"{tileConfigBitsCount}:"
-                    f"{max(tileConfigBitsCount - fabric.frameBitsPerRow + 1, 0)}"
+                    f"{max(tileConfigBitsCount - frame_bits_per_row + 1, 0)}"
                 )
-            count += fabric.frameBitsPerRow
-            tileConfigBitsCount -= fabric.frameBitsPerRow
+            count += frame_bits_per_row
+            tileConfigBitsCount -= frame_bits_per_row
 
             writer.writerow([entry[field] for field in fieldName])
 
 
 def generateConfigMem(
-    writer: CodeGenerator, fabric: Fabric, tile: Tile, configMemCsv: Path
+    writer: CodeGenerator,
+    tile: Tile,
+    configMemCsv: Path,
+    frame_bits_per_row: int = 32,
+    max_frame_per_col: int = 20,
 ) -> None:
     """Generate the RTL code for configuration memory.
 
@@ -114,12 +124,14 @@ def generateConfigMem(
     ----------
     writer : CodeGenerator
         The code generator instance for RTL output
-    fabric : Fabric
-        The fabric object containing fabric configuration
     tile : Tile
         A tile object.
     configMemCsv : Path
         The directory of the config memory CSV file.
+    frame_bits_per_row : int
+        The number of configuration bits per frame row.
+    max_frame_per_col : int
+        The number of frames stored per tile column.
 
     Raises
     ------
@@ -130,11 +142,11 @@ def generateConfigMem(
     """
     # test if we have a bitstream mapping file
     # if not, we will take the default, which was passed on from  GenerateConfigMemInit
-    if tile.globalConfigBits > fabric.frameBitsPerRow * fabric.maxFramesPerCol:
+    if tile.globalConfigBits > frame_bits_per_row * max_frame_per_col:
         raise ValueError(
             f"Tile {tile.name} has {tile.globalConfigBits} global config bits, "
             " which exceeds fabric capacity "
-            f"({fabric.frameBitsPerRow * fabric.maxFramesPerCol} bits). "
+            f"({frame_bits_per_row * max_frame_per_col} bits). "
             "Please adjust the tile configuration."
         )
 
@@ -153,19 +165,24 @@ def generateConfigMem(
         logger.info(f"Parsing {tile.name}_configMem.csv")
         configMemList = parseConfigMem(
             configMemCsv,
-            fabric.maxFramesPerCol,
-            fabric.frameBitsPerRow,
+            max_frame_per_col,
+            frame_bits_per_row,
             tile.globalConfigBits,
         )
     elif tile.globalConfigBits > 0:
         logger.info(f"{tile.name}_configMem.csv does not exist")
         logger.info(f"Generating a default configMem for {tile.name}")
-        generateConfigMemInit(fabric, configMemCsv, tile.globalConfigBits)
+        generateConfigMemInit(
+            configMemCsv,
+            tile.globalConfigBits,
+            frame_bits_per_row=frame_bits_per_row,
+            max_frame_per_col=max_frame_per_col,
+        )
         logger.info(f"Parsing {tile.name}_configMem.csv")
         configMemList = parseConfigMem(
             configMemCsv,
-            fabric.maxFramesPerCol,
-            fabric.frameBitsPerRow,
+            max_frame_per_col,
+            frame_bits_per_row,
             tile.globalConfigBits,
         )
     else:
@@ -193,7 +210,7 @@ def generateConfigMem(
     writer.addHeader(f"{tile.name}_ConfigMem")
     writer.addParameterStart(indentLevel=1)
     if isinstance(writer, VerilogCodeGenerator):  # emulation only in Verilog
-        maxBits = fabric.frameBitsPerRow * fabric.maxFramesPerCol
+        maxBits = frame_bits_per_row * max_frame_per_col
         writer.addPreprocIfDef("EMULATION")
         writer.addParameter(
             "Emulate_Bitstream",
@@ -202,13 +219,13 @@ def generateConfigMem(
             indentLevel=2,
         )
         writer.addPreprocEndif()
-    if fabric.maxFramesPerCol != 0:
+    if max_frame_per_col != 0:
         writer.addParameter(
-            "MaxFramesPerCol", "integer", fabric.maxFramesPerCol, indentLevel=2
+            "MaxFramesPerCol", "integer", max_frame_per_col, indentLevel=2
         )
-    if fabric.frameBitsPerRow != 0:
+    if frame_bits_per_row != 0:
         writer.addParameter(
-            "FrameBitsPerRow", "integer", fabric.frameBitsPerRow, indentLevel=2
+            "FrameBitsPerRow", "integer", frame_bits_per_row, indentLevel=2
         )
     writer.addParameter("NoConfigBits", "integer", tile.globalConfigBits, indentLevel=2)
     writer.addParameterEnd(indentLevel=1)
@@ -228,12 +245,12 @@ def generateConfigMem(
         writer.addPreprocIfDef("EMULATION")
         for i in configMemList:
             counter = 0
-            for k in range(fabric.frameBitsPerRow):
+            for k in range(frame_bits_per_row):
                 # Safely check if bit is set, treat missing bits as '0'
                 bit_value = i.usedBitMask[k] if k < len(i.usedBitMask) else "0"
                 if bit_value == "1":
-                    index = i.frameIndex * fabric.frameBitsPerRow + (
-                        fabric.frameBitsPerRow - 1 - k
+                    index = i.frameIndex * frame_bits_per_row + (
+                        frame_bits_per_row - 1 - k
                     )
                     writer.addAssignScalar(
                         f"ConfigBits[{i.configBitRanges[counter]}]",
@@ -247,17 +264,15 @@ def generateConfigMem(
     writer.addComment("instantiate frame latches", end="")
     for i in configMemList:
         counter = 0
-        for k in range(fabric.frameBitsPerRow):
+        for k in range(frame_bits_per_row):
             # Safely check if bit is set, treat missing bits as '0'
             bit_value = i.usedBitMask[k] if k < len(i.usedBitMask) else "0"
             if bit_value == "1":
                 writer.addInstantiation(
                     compName="config_latch",
-                    compInsName=(
-                        f"Inst_{i.frameName}_bit{fabric.frameBitsPerRow - 1 - k}"
-                    ),
+                    compInsName=(f"Inst_{i.frameName}_bit{frame_bits_per_row - 1 - k}"),
                     portsPairs=[
-                        ("D", f"FrameData[{fabric.frameBitsPerRow - 1 - k}]"),
+                        ("D", f"FrameData[{frame_bits_per_row - 1 - k}]"),
                         ("E", f"FrameStrobe[{i.frameIndex}]"),
                         ("Q", f"ConfigBits[{i.configBitRanges[counter]}]"),
                         ("QN", f"ConfigBits_N[{i.configBitRanges[counter]}]"),

--- a/fabulous/fabric_generator/gen_fabric/gen_configmem.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_configmem.py
@@ -34,7 +34,7 @@ def generateConfigMemInit(
     """Generate the config memory initialization file.
 
     The amount of configuration bits is determined
-    by ``frame_bits_per_row``. The function will pack the configuration bit from
+    by `frame_bits_per_row`. The function will pack the configuration bit from
     the highest to the lowest bit in the config memory. I. e. if there are 100
     configuration bits, with 32 frame bits per row, the function will pack from
     bit 99 starting from bit 31 of frame 0 to bit 28 of frame 3.

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -24,7 +24,6 @@ from fabulous.fabric_definition.define import (
     Direction,
     MultiplexerStyle,
 )
-from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
 from fabulous.fabric_generator.code_generator.code_generator_VHDL import (
@@ -39,10 +38,12 @@ from fabulous.fabric_generator.parser.parse_switchmatrix import parseMatrix
 
 def genTileSwitchMatrix(
     writer: CodeGenerator,
-    fabric: Fabric,
     tile: Tile,
     switch_matrix_debug_signal: bool,
     csv_output_dir: Path | None = None,
+    config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
+    multiplexer_style: MultiplexerStyle = MultiplexerStyle.CUSTOM,
+    generate_delay_in_switch_matrix: int = 80,
 ) -> None:
     """Generate the RTL code for the tile switch matrix.
 
@@ -57,8 +58,6 @@ def genTileSwitchMatrix(
     ----------
     writer : CodeGenerator
         The code generator instance for RTL output
-    fabric : Fabric
-        The fabric object containing global configuration
     tile : Tile
         The tile object containing BELs and port information
     switch_matrix_debug_signal : bool
@@ -68,6 +67,12 @@ def genTileSwitchMatrix(
         `.list` format. If None, the CSV is written to the same directory as the
         source `.list` file. This parameter is ignored when the input is already
         a `.csv` file.
+    config_bit_mode : ConfigBitMode
+        The configuration-bit mode for the tile (frame-based or flip-flop chain).
+    multiplexer_style : MultiplexerStyle
+        The multiplexer style used to implement switch-matrix muxes.
+    generate_delay_in_switch_matrix : int
+        Per-mux delay (ps) emitted on assign statements in the switch matrix.
 
     Raises
     ------
@@ -167,13 +172,13 @@ def genTileSwitchMatrix(
 
     writer.addComment("global", onNewLine=True)
     if noConfigBits > 0:
-        if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
             writer.addPortScalar("MODE", IO.INPUT, indentLevel=2)
             writer.addComment("global signal 1: configuration, 0: operation")
             writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
             writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
             writer.addPortScalar("CLK", IO.INPUT, indentLevel=2)
-        if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+        if config_bit_mode == ConfigBitMode.FRAME_BASED:
             writer.addPortVector(
                 "ConfigBits", IO.INPUT, "NoConfigBits-1", indentLevel=2
             )
@@ -238,9 +243,9 @@ def genTileSwitchMatrix(
     # for example in terminating switch matrices at the fabric borders,
     # we may just change direction without any switching
     if noConfigBits > 0:
-        if fabric.configBitMode == "ff_chain":
+        if config_bit_mode == "ff_chain":
             writer.addConnectionVector("ConfigBits", noConfigBits)
-        if fabric.configBitMode == "FlipFlopChain":
+        if config_bit_mode == "FlipFlopChain":
             # we pad to an even number of bits: (int(math.ceil(ConfigBitCounter/2.0))*2)
             writer.addConnectionVector(
                 "ConfigBits", int(math.ceil(noConfigBits / 2.0)) * 2
@@ -256,11 +261,11 @@ def genTileSwitchMatrix(
     # again, we add this only if needed
     # TODO Should ff_chain be the same as FlipFlopChain?
     if noConfigBits > 0:
-        if fabric.configBitMode == "ff_chain":
+        if config_bit_mode == "ff_chain":
             writer.addShiftRegister(noConfigBits)
-        elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
             writer.addFlipFlopChain(noConfigBits)
-        elif fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+        elif config_bit_mode == ConfigBitMode.FRAME_BASED:
             pass
 
     # the switch matrix implementation
@@ -295,7 +300,7 @@ def genTileSwitchMatrix(
                 writer.addAssignScalar(
                     portName,
                     connections[portName][0],
-                    delay=fabric.generateDelayInSwitchMatrix,
+                    delay=generate_delay_in_switch_matrix,
                 )
             writer.addNewLine()
         elif muxSize >= 2:
@@ -315,7 +320,7 @@ def genTileSwitchMatrix(
             for end in range(start + 1, paddedMuxSize):
                 portsPairs.append((f"A{end}", "GND0"))
 
-            if fabric.multiplexerStyle == MultiplexerStyle.CUSTOM:
+            if multiplexer_style == MultiplexerStyle.CUSTOM:
                 if paddedMuxSize == 2:
                     portsPairs.append(("S", f"ConfigBits[{configBitstreamPosition}+0]"))
                 else:
@@ -332,7 +337,7 @@ def genTileSwitchMatrix(
 
             portsPairs.append(("X", f"{portName}"))
 
-            if fabric.multiplexerStyle == MultiplexerStyle.CUSTOM:
+            if multiplexer_style == MultiplexerStyle.CUSTOM:
                 # we add the input signal in reversed order
                 # Changed it such that the left-most entry is located at the end of the
                 # concatenated vector for the multiplexing
@@ -341,7 +346,7 @@ def genTileSwitchMatrix(
                 writer.addAssignScalar(
                     f"{portName}_input",
                     connections[portName][::-1],
-                    delay=fabric.generateDelayInSwitchMatrix,
+                    delay=generate_delay_in_switch_matrix,
                 )
                 writer.addInstantiation(
                     compName=muxComponentName,

--- a/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_switchmatrix.py
@@ -43,7 +43,7 @@ def genTileSwitchMatrix(
     csv_output_dir: Path | None = None,
     config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
     multiplexer_style: MultiplexerStyle = MultiplexerStyle.CUSTOM,
-    generate_delay_in_switch_matrix: int = 80,
+    default_pip_delay: int = 80,
 ) -> None:
     """Generate the RTL code for the tile switch matrix.
 
@@ -71,7 +71,7 @@ def genTileSwitchMatrix(
         The configuration-bit mode for the tile (frame-based or flip-flop chain).
     multiplexer_style : MultiplexerStyle
         The multiplexer style used to implement switch-matrix muxes.
-    generate_delay_in_switch_matrix : int
+    default_pip_delay : int
         Per-mux delay (ps) emitted on assign statements in the switch matrix.
 
     Raises
@@ -300,7 +300,7 @@ def genTileSwitchMatrix(
                 writer.addAssignScalar(
                     portName,
                     connections[portName][0],
-                    delay=generate_delay_in_switch_matrix,
+                    delay=default_pip_delay,
                 )
             writer.addNewLine()
         elif muxSize >= 2:
@@ -346,7 +346,7 @@ def genTileSwitchMatrix(
                 writer.addAssignScalar(
                     f"{portName}_input",
                     connections[portName][::-1],
-                    delay=generate_delay_in_switch_matrix,
+                    delay=default_pip_delay,
                 )
                 writer.addInstantiation(
                     compName=muxComponentName,

--- a/fabulous/fabric_generator/gen_fabric/gen_tile.py
+++ b/fabulous/fabric_generator/gen_fabric/gen_tile.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from pathlib import Path
 
 from fabulous.fabric_definition.define import IO, ConfigBitMode, Direction
-from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.code_generator.code_generator import CodeGenerator
@@ -29,7 +28,14 @@ from fabulous.fabric_generator.code_generator.code_generator_VHDL import (
 )
 
 
-def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
+def generateTile(
+    writer: CodeGenerator,
+    tile: Tile,
+    frame_bits_per_row: int = 32,
+    max_frame_per_col: int = 20,
+    disable_user_clk: bool = False,
+    config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
+) -> None:
     """Generate the RTL code for a tile given the tile object.
 
     This function creates the complete RTL implementation for a tile, including:
@@ -66,10 +72,16 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
     ----------
     writer : CodeGenerator
         The code generator instance for RTL output
-    fabric : Fabric
-        The fabric object containing global configuration
     tile : Tile
         The tile object containing BELs and port information
+    frame_bits_per_row : int
+        Number of configuration bits per row for frame-based configuration
+    max_frame_per_col : int
+        Maximum number of frames per column for frame-based configuration
+    disable_user_clk : bool
+        If True, the UserCLK port will not be generated or connected
+    config_bit_mode : ConfigBitMode
+        The configuration bit mode to use (frame-based or FlipFlop chain)
 
     Raises
     ------
@@ -82,7 +94,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
     writer.addHeader(f"{tile.name}")
     writer.addParameterStart(indentLevel=1)
     if isinstance(writer, VerilogCodeGenerator):  # emulation only in Verilog
-        maxBits = fabric.frameBitsPerRow * fabric.maxFramesPerCol
+        maxBits = frame_bits_per_row * max_frame_per_col
         writer.addPreprocIfDef("EMULATION")
         writer.addParameter(
             "Emulate_Bitstream",
@@ -91,12 +103,8 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
             indentLevel=2,
         )
         writer.addPreprocEndif()
-    writer.addParameter(
-        "MaxFramesPerCol", "integer", fabric.maxFramesPerCol, indentLevel=2
-    )
-    writer.addParameter(
-        "FrameBitsPerRow", "integer", fabric.frameBitsPerRow, indentLevel=2
-    )
+    writer.addParameter("MaxFramesPerCol", "integer", max_frame_per_col, indentLevel=2)
+    writer.addParameter("FrameBitsPerRow", "integer", frame_bits_per_row, indentLevel=2)
     if tile.globalConfigBits > 0:
         writer.addParameter(
             "NoConfigBits", "integer", tile.globalConfigBits, indentLevel=2
@@ -142,11 +150,11 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
 
     writer.addComment("Tile IO ports from BELs", onNewLine=True, indentLevel=1)
 
-    if not fabric.disableUserCLK:
+    if not disable_user_clk:
         writer.addPortScalar("UserCLK", IO.INPUT, indentLevel=2)
         writer.addPortScalar("UserCLKo", IO.OUTPUT, indentLevel=2)
 
-    if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED:
         writer.addPortVector("FrameData", IO.INPUT, "FrameBitsPerRow-1", indentLevel=2)
         writer.addComment("CONFIG_PORT", onNewLine=False, end="")
         writer.addPortVector(
@@ -160,7 +168,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
             "FrameStrobe_O", IO.OUTPUT, "MaxFramesPerCol-1", indentLevel=2
         )
 
-    elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+    elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
         writer.addPortScalar("MODE", IO.INPUT, indentLevel=2)
         writer.addPortScalar("CONFin", IO.INPUT, indentLevel=2)
         writer.addPortScalar("CONFout", IO.OUTPUT, indentLevel=2)
@@ -283,13 +291,13 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
     # buffer FrameData signals
     writer.addAssignScalar("FrameData_O_i", "FrameData_i")
     writer.addNewLine()
-    for i in range(fabric.frameBitsPerRow):
+    for i in range(frame_bits_per_row):
         writer.addInstantiation(
             "my_buf",
             f"data_inbuf_{i}",
             portsPairs=[("A", f"FrameData[{i}]"), ("X", f"FrameData_i[{i}]")],
         )
-    for i in range(fabric.frameBitsPerRow):
+    for i in range(frame_bits_per_row):
         writer.addInstantiation(
             "my_buf",
             f"data_outbuf_{i}",
@@ -302,14 +310,14 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
     # strobe is always added even when config bits are 0
     writer.addAssignScalar("FrameStrobe_O_i", "FrameStrobe_i")
     writer.addNewLine()
-    for i in range(fabric.maxFramesPerCol):
+    for i in range(max_frame_per_col):
         writer.addInstantiation(
             "my_buf",
             f"strobe_inbuf_{i}",
             portsPairs=[("A", f"FrameStrobe[{i}]"), ("X", f"FrameStrobe_i[{i}]")],
         )
 
-    for i in range(fabric.maxFramesPerCol):
+    for i in range(max_frame_per_col):
         writer.addInstantiation(
             "my_buf",
             f"strobe_outbuf_{i}",
@@ -355,7 +363,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
 
             added.add((port.sourceName, port.destinationName))
 
-    if not fabric.disableUserCLK:
+    if not disable_user_clk:
         writer.addInstantiation(
             "clk_buf",
             "inst_clk_buf",
@@ -364,14 +372,14 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
 
     writer.addNewLine()
     # top configuration data daisy chaining
-    if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+    if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
         writer.addComment("top configuration data daisy chaining", onNewLine=True)
         writer.addAssignScalar("conf_data(conf_data'low)", "CONFin")
         writer.addComment("conf_data'low=0 and CONFin is from tile entity")
         writer.addAssignScalar("conf_data(conf_data'high)", "CONFout")
         writer.addComment("CONFout is from tile entity")
 
-    if fabric.configBitMode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
         writer.addComment("configuration storage latches", onNewLine=True)
         writer.addInstantiation(
             compName=f"{tile.name}_ConfigMem",
@@ -417,7 +425,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
         # Shared ports
         for port in bel.sharedPort:
             if port[0] == "UserCLK":
-                if not fabric.disableUserCLK:
+                if not disable_user_clk:
                     userclk_pair = (port[0], port[0])
             else:
                 portsPairs.append((port[0], port[0]))
@@ -438,7 +446,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
         if userclk_pair is not None:
             portsPairs.append(userclk_pair)
 
-        if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+        if config_bit_mode == ConfigBitMode.FRAME_BASED:
             if bel.configBit > 0:
                 portsPairs.append(
                     (
@@ -447,7 +455,7 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
                         f"{belConfigBitsCounter}]",
                     )
                 )
-        elif fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+        elif config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
             portsPairs.append(("MODE", "Mode"))
             portsPairs.append(("CONFin", f"conf_data({belCounter})"))
             portsPairs.append(("CONFout", f"conf_data({belCounter + 1})"))
@@ -519,13 +527,13 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
 
     portsPairs += list(zip(port, signal, strict=False))
 
-    if fabric.configBitMode == ConfigBitMode.FLIPFLOP_CHAIN:
+    if config_bit_mode == ConfigBitMode.FLIPFLOP_CHAIN:
         portsPairs.append(("MODE", "Mode"))
         portsPairs.append(("CONFin", f"conf_data({belCounter})"))
         portsPairs.append(("CONFout", f"conf_data({belCounter + 1})"))
         portsPairs.append(("CLK", "CLK"))
 
-    if fabric.configBitMode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED and tile.globalConfigBits > 0:
         portsPairs.append(
             (
                 "ConfigBits",
@@ -550,7 +558,12 @@ def generateTile(writer: CodeGenerator, fabric: Fabric, tile: Tile) -> None:
 
 
 def generateSuperTile(
-    writer: CodeGenerator, fabric: Fabric, superTile: SuperTile
+    writer: CodeGenerator,
+    superTile: SuperTile,
+    frame_bits_per_row: int = 32,
+    max_frame_per_col: int = 20,
+    disable_user_clk: bool = False,
+    config_bit_mode: ConfigBitMode = ConfigBitMode.FRAME_BASED,
 ) -> None:
     """Generate a super tile wrapper for given super tile.
 
@@ -566,16 +579,22 @@ def generateSuperTile(
     ----------
     writer : CodeGenerator
         The code generator instance for RTL output
-    fabric : Fabric
-        The fabric object containing global configuration
     superTile : SuperTile
         Super tile object containing tile map and configuration
+    frame_bits_per_row : int
+        Number of configuration bits per row for frame-based configuration
+    max_frame_per_col : int
+        Maximum number of frames per column for frame-based configuration
+    disable_user_clk : bool
+        If True, the UserCLK port will not be generated or connected
+    config_bit_mode : ConfigBitMode
+        The configuration bit mode to use (frame-based or FlipFlop chain)
     """
     writer.addHeader(f"{superTile.name}")
     writer.addParameterStart(indentLevel=1)
     if isinstance(writer, VerilogCodeGenerator):
         writer.addPreprocIfDef("EMULATION")
-        maxBits = fabric.frameBitsPerRow * fabric.maxFramesPerCol
+        maxBits = frame_bits_per_row * max_frame_per_col
         for y, row in enumerate(superTile.tileMap):
             for x, tile in enumerate(row):
                 if not tile:
@@ -587,12 +606,8 @@ def generateSuperTile(
                     indentLevel=2,
                 )
         writer.addPreprocEndif()
-    writer.addParameter(
-        "MaxFramesPerCol", "integer", fabric.maxFramesPerCol, indentLevel=2
-    )
-    writer.addParameter(
-        "FrameBitsPerRow", "integer", fabric.frameBitsPerRow, indentLevel=2
-    )
+    writer.addParameter("MaxFramesPerCol", "integer", max_frame_per_col, indentLevel=2)
+    writer.addParameter("FrameBitsPerRow", "integer", frame_bits_per_row, indentLevel=2)
 
     writer.addParameterEnd(indentLevel=1)
     writer.addPortStart(indentLevel=1)
@@ -634,7 +649,7 @@ def generateSuperTile(
                 writer.addPortScalar(p[0], p[1], indentLevel=2)
 
     # add config port
-    if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+    if config_bit_mode == ConfigBitMode.FRAME_BASED:
         for y, row in enumerate(superTile.tileMap):
             for x, _tile in enumerate(row):
                 if y - 1 < 0 or superTile.tileMap[y - 1][x] is None:
@@ -675,7 +690,7 @@ def generateSuperTile(
                         indentLevel=2,
                     )
                     writer.addComment("CONFIG_PORT", onNewLine=False)
-    if not fabric.disableUserCLK:
+    if not disable_user_clk:
         for y, row in enumerate(superTile.tileMap):
             for x, _tile in enumerate(row):
                 if y - 1 < 0 or superTile.tileMap[y - 1][x] is None:
@@ -730,7 +745,7 @@ def generateSuperTile(
                     "MaxFramesPerCol-1",
                     indentLevel=1,
                 )
-                if not fabric.disableUserCLK:
+                if not disable_user_clk:
                     writer.addConnectionScalar(f"Tile_X{x}Y{y}_UserCLKo", indentLevel=1)
             if (
                 0 <= x - 1 < len(superTile.tileMap[y])
@@ -826,13 +841,13 @@ def generateSuperTile(
                 for p in b.externalOutput:
                     portsPairs.append((p, p))
 
-                if not fabric.disableUserCLK:
+                if not disable_user_clk:
                     for p in b.sharedPort:
                         if "UserCLK" not in p[0]:
                             portsPairs.append(("UserCLK", p[0]))
 
             # add clock to tile
-            if not fabric.disableUserCLK:
+            if not disable_user_clk:
                 if (
                     0 <= y + 1 < len(superTile.tileMap)
                     and superTile.tileMap[y + 1][x] is not None
@@ -841,7 +856,7 @@ def generateSuperTile(
                 else:
                     portsPairs.append(("UserCLK", f"Tile_X{x}Y{y}_UserCLK"))
                 portsPairs.append(("UserCLKo", f"Tile_X{x}Y{y}_UserCLKo"))
-            if fabric.configBitMode == ConfigBitMode.FRAME_BASED:
+            if config_bit_mode == ConfigBitMode.FRAME_BASED:
                 # add connection for frameData, frameStrobe
                 if (
                     0 <= x - 1 < len(superTile.tileMap[0])

--- a/fabulous/fabulous_api.py
+++ b/fabulous/fabulous_api.py
@@ -26,6 +26,7 @@ from fabulous.fabric_cad.timing_model.models import (
 
 # Importing Modules from FABulous Framework.
 from fabulous.fabric_definition.bel import Bel
+from fabulous.fabric_definition.define import ConfigBitMode, Side
 from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.supertile import SuperTile
 from fabulous.fabric_definition.tile import Tile
@@ -187,7 +188,13 @@ class FABulous_API:
             If tile is not found in fabric.
         """
         if tile := self.fabric.getTileByName(tileName):
-            generateConfigMem(self.writer, self.fabric, tile, configMem)
+            generateConfigMem(
+                self.writer,
+                tile,
+                configMem,
+                frame_bits_per_row=self.fabric.frameBitsPerRow,
+                max_frame_per_col=self.fabric.maxFramesPerCol,
+            )
         else:
             raise ValueError(f"Tile {tileName} not found")
 
@@ -220,15 +227,24 @@ class FABulous_API:
             )
             genTileSwitchMatrix(
                 self.writer,
-                self.fabric,
                 tile,
                 switch_matrix_debug_signal,
                 csv_output_dir=csv_output_dir,
+                config_bit_mode=self.fabric.configBitMode,
+                multiplexer_style=self.fabric.multiplexerStyle,
+                generate_delay_in_switch_matrix=self.fabric.generateDelayInSwitchMatrix,
             )
         else:
             raise ValueError(f"Tile {tileName} not found")
 
-    def genTile(self, tileName: str) -> None:
+    def genTile(
+        self,
+        tileName: str,
+        frame_bit_per_row: int | None = None,
+        max_frame_per_col: int | None = None,
+        disable_user_clk: bool | None = None,
+        config_bit_mode: ConfigBitMode | None = None,
+    ) -> None:
         """Generate a tile based on its name.
 
         Using 'generateTile' defined in 'fabric_gen.py'.
@@ -237,6 +253,18 @@ class FABulous_API:
         ----------
         tileName : str
             Name of the tile generated.
+        frame_bit_per_row : int | None
+            Override for the fabric's ``frameBitsPerRow``. If ``None``, the value
+            from ``self.fabric`` is used.
+        max_frame_per_col : int | None
+            Override for the fabric's ``maxFramesPerCol``. If ``None``, the value
+            from ``self.fabric`` is used.
+        disable_user_clk : bool | None
+            Override for the fabric's ``disableUserCLK``. If ``None``, the value
+            from ``self.fabric`` is used.
+        config_bit_mode : ConfigBitMode | None
+            Override for the fabric's ``configBitMode``. If ``None``, the value
+            from ``self.fabric`` is used.
 
         Raises
         ------
@@ -244,11 +272,25 @@ class FABulous_API:
             If tile is not found in fabric.
         """
         if tile := self.fabric.getTileByName(tileName):
-            generateTile(self.writer, self.fabric, tile)
+            generateTile(
+                self.writer,
+                tile,
+                frame_bit_per_row or self.fabric.frameBitsPerRow,
+                max_frame_per_col or self.fabric.maxFramesPerCol,
+                disable_user_clk or self.fabric.disableUserCLK,
+                config_bit_mode or self.fabric.configBitMode,
+            )
         else:
             raise ValueError(f"Tile {tileName} not found")
 
-    def genSuperTile(self, tileName: str) -> None:
+    def genSuperTile(
+        self,
+        tileName: str,
+        frame_bit_per_row: int | None = None,
+        max_frame_per_col: int | None = None,
+        disable_user_clk: bool | None = None,
+        config_bit_mode: ConfigBitMode | None = None,
+    ) -> None:
         """Generate a super tile based on its name.
 
         Using 'generateSuperTile' defined in 'fabric_gen.py'.
@@ -257,6 +299,18 @@ class FABulous_API:
         ----------
         tileName : str
             Name of the super tile generated.
+        frame_bit_per_row : int | None
+            Override for the fabric's ``frameBitsPerRow``. If ``None``, the value
+            from ``self.fabric`` is used.
+        max_frame_per_col : int | None
+            Override for the fabric's ``maxFramesPerCol``. If ``None``, the value
+            from ``self.fabric`` is used.
+        disable_user_clk : bool | None
+            Override for the fabric's ``disableUserCLK``. If ``None``, the value
+            from ``self.fabric`` is used.
+        config_bit_mode : ConfigBitMode | None
+            Override for the fabric's ``configBitMode``. If ``None``, the value
+            from ``self.fabric`` is used.
 
         Raises
         ------
@@ -264,7 +318,14 @@ class FABulous_API:
             If super tile is not found in fabric.
         """
         if tile := self.fabric.getSuperTileByName(tileName):
-            generateSuperTile(self.writer, self.fabric, tile)
+            generateSuperTile(
+                self.writer,
+                tile,
+                frame_bit_per_row or self.fabric.frameBitsPerRow,
+                max_frame_per_col or self.fabric.maxFramesPerCol,
+                disable_user_clk or self.fabric.disableUserCLK,
+                config_bit_mode or self.fabric.configBitMode,
+            )
         else:
             raise ValueError(f"SuperTile {tileName} not found")
 
@@ -490,7 +551,14 @@ class FABulous_API:
                 logger.info(f"Generating IO BELs for tile {tile.name}")
                 self.genIOBelForTile(tile.name)
 
-    def gen_io_pin_order_config(self, tile: Tile | SuperTile, outfile: Path) -> None:
+    def gen_io_pin_order_config(
+        self,
+        tile: Tile | SuperTile,
+        outfile: Path,
+        prefix: str = "",
+        *,
+        external_port_side: Side = Side.SOUTH,
+    ) -> None:
         """Generate IO pin order configuration YAML for a tile or super tile.
 
         Parameters
@@ -499,8 +567,19 @@ class FABulous_API:
             The fabric element for which to generate the configuration.
         outfile : Path
             Output YAML path.
+        prefix : str
+            Prefix to add to port names.
+        external_port_side : Side
+            Side used for BEL external ports when no fabric placement context
+            is available.
         """
-        generate_IO_pin_order_config(self.fabric, tile, outfile)
+        generate_IO_pin_order_config(
+            tile,
+            outfile,
+            fabric=self.fabric,
+            prefix=prefix,
+            external_port_side=external_port_side,
+        )
 
     def genTileMacro(
         self,

--- a/fabulous/fabulous_api.py
+++ b/fabulous/fabulous_api.py
@@ -232,7 +232,7 @@ class FABulous_API:
                 csv_output_dir=csv_output_dir,
                 config_bit_mode=self.fabric.configBitMode,
                 multiplexer_style=self.fabric.multiplexerStyle,
-                generate_delay_in_switch_matrix=self.fabric.generateDelayInSwitchMatrix,
+                default_pip_delay=self.fabric.generateDelayInSwitchMatrix,
             )
         else:
             raise ValueError(f"Tile {tileName} not found")

--- a/tests/fabric_gen_test/configmem_test/test_configmem_rtl.py
+++ b/tests/fabric_gen_test/configmem_test/test_configmem_rtl.py
@@ -159,7 +159,13 @@ def test_configmem_rtl_with_generated_configmem_simulation(
     csv_path = tmp_path / f"{tile_config.name}_configMem.csv"
 
     # Generate the ConfigMem RTL
-    generateConfigMem(writer, fabric_config, tile_config, csv_path)
+    generateConfigMem(
+        writer,
+        tile_config,
+        csv_path,
+        frame_bits_per_row=fabric_config.frameBitsPerRow,
+        max_frame_per_col=fabric_config.maxFramesPerCol,
+    )
 
     # Check if RTL file was created - skip if no config bits were generated
     if tile_config.globalConfigBits != 0:
@@ -252,7 +258,13 @@ def test_configmem_rtl_with_custom_configmem_simulation(
     mock_parse.return_value = configmem_list_data
 
     # Generate the ConfigMem RTL
-    generateConfigMem(writer, default_fabric, default_tile, csv_path)
+    generateConfigMem(
+        writer,
+        default_tile,
+        csv_path,
+        frame_bits_per_row=default_fabric.frameBitsPerRow,
+        max_frame_per_col=default_fabric.maxFramesPerCol,
+    )
 
     bit_mapping = {}  # Key: "frame,framedata_bit", Value: config_bit_index
 

--- a/tests/fabric_gen_test/configmem_test/test_gen_configmem.py
+++ b/tests/fabric_gen_test/configmem_test/test_gen_configmem.py
@@ -39,7 +39,12 @@ def _expect_capacity_error(
 ) -> None:
     """Test that capacity error is raised with meaningful message."""
     with pytest.raises((ValueError, RuntimeError, AssertionError)) as exc_info:
-        generateConfigMemInit(fabric_config, output_file, tile_config_bits)
+        generateConfigMemInit(
+            output_file,
+            tile_config_bits,
+            frame_bits_per_row=fabric_config.frameBitsPerRow,
+            max_frame_per_col=fabric_config.maxFramesPerCol,
+        )
     # Verify that the error message is meaningful
     error_msg = str(exc_info.value).lower()
     assert "exceed fabric capacity" in error_msg
@@ -66,7 +71,12 @@ class TestGenerateConfigMemInit:
         if tile_config_bits == 0:
             return
 
-        generateConfigMemInit(fabric_config, output_file, tile_config_bits)
+        generateConfigMemInit(
+            output_file,
+            tile_config_bits,
+            frame_bits_per_row=fabric_config.frameBitsPerRow,
+            max_frame_per_col=fabric_config.maxFramesPerCol,
+        )
         rows = verify_csv_content(
             output_file, expected_rows=fabric_config.maxFramesPerCol
         )
@@ -92,12 +102,20 @@ class TestGenerateConfigMemInit:
         if not has_capacity:
             with pytest.raises((ValueError, RuntimeError, AssertionError)):
                 generateConfigMemInit(
-                    fabric_config, tmp_path / "should_fail.csv", tile_config_bits
+                    tmp_path / "should_fail.csv",
+                    tile_config_bits,
+                    frame_bits_per_row=fabric_config.frameBitsPerRow,
+                    max_frame_per_col=fabric_config.maxFramesPerCol,
                 )
             return
 
         output_file = tmp_path / f"bitmask_{fabric_config.name}_{tile_config.name}.csv"
-        generateConfigMemInit(fabric_config, output_file, tile_config_bits)
+        generateConfigMemInit(
+            output_file,
+            tile_config_bits,
+            frame_bits_per_row=fabric_config.frameBitsPerRow,
+            max_frame_per_col=fabric_config.maxFramesPerCol,
+        )
 
         rows = verify_csv_content(
             output_file, expected_rows=fabric_config.maxFramesPerCol
@@ -134,14 +152,22 @@ class TestGenerateConfigMemInit:
         if not has_capacity:
             with pytest.raises((ValueError, RuntimeError, AssertionError)):
                 generateConfigMemInit(
-                    fabric_config, tmp_path / "should_fail.csv", tile_config_bits
+                    tmp_path / "should_fail.csv",
+                    tile_config_bits,
+                    frame_bits_per_row=fabric_config.frameBitsPerRow,
+                    max_frame_per_col=fabric_config.maxFramesPerCol,
                 )
             return
 
         output_file = (
             tmp_path / f"allocation_{fabric_config.name}_{tile_config.name}.csv"
         )
-        generateConfigMemInit(fabric_config, output_file, tile_config_bits)
+        generateConfigMemInit(
+            output_file,
+            tile_config_bits,
+            frame_bits_per_row=fabric_config.frameBitsPerRow,
+            max_frame_per_col=fabric_config.maxFramesPerCol,
+        )
 
         rows = verify_csv_content(
             output_file, expected_rows=fabric_config.maxFramesPerCol
@@ -181,10 +207,20 @@ class TestGenerateConfigMemInit:
         # Expect error when fabric can't accommodate the config bits
         if not has_capacity:
             with pytest.raises((ValueError, RuntimeError, AssertionError)):
-                generateConfigMemInit(default_fabric, output_file, tile_config_bits)
+                generateConfigMemInit(
+                    output_file,
+                    tile_config_bits,
+                    frame_bits_per_row=default_fabric.frameBitsPerRow,
+                    max_frame_per_col=default_fabric.maxFramesPerCol,
+                )
             return
 
-        generateConfigMemInit(default_fabric, output_file, tile_config_bits)
+        generateConfigMemInit(
+            output_file,
+            tile_config_bits,
+            frame_bits_per_row=default_fabric.frameBitsPerRow,
+            max_frame_per_col=default_fabric.maxFramesPerCol,
+        )
 
         rows = verify_csv_content(output_file)
 
@@ -223,10 +259,22 @@ class TestGeneratedConfigMemRTL:
         )
         if not has_capacity and tile_config.globalConfigBits > 0:
             with pytest.raises(ValueError, match="adjust the tile configuration."):
-                generateConfigMem(writer, fabric_config, tile_config, config_csv)
+                generateConfigMem(
+                    writer,
+                    tile_config,
+                    config_csv,
+                    frame_bits_per_row=fabric_config.frameBitsPerRow,
+                    max_frame_per_col=fabric_config.maxFramesPerCol,
+                )
             return
 
-        generateConfigMem(writer, fabric_config, tile_config, config_csv)
+        generateConfigMem(
+            writer,
+            tile_config,
+            config_csv,
+            frame_bits_per_row=fabric_config.frameBitsPerRow,
+            max_frame_per_col=fabric_config.maxFramesPerCol,
+        )
 
         # Verify output file was created and contains expected content
         output_file = writer.outFileName
@@ -273,7 +321,13 @@ class TestGeneratedConfigMemRTL:
         mock_parse.return_value = config_memlist_data
 
         # Generate the ConfigMem RTL
-        generateConfigMem(writer, default_fabric, default_tile, csv_path)
+        generateConfigMem(
+            writer,
+            default_tile,
+            csv_path,
+            frame_bits_per_row=default_fabric.frameBitsPerRow,
+            max_frame_per_col=default_fabric.maxFramesPerCol,
+        )
 
         # Read the generated RTL
         rtl_content = writer.outFileName.read_text()

--- a/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
+++ b/tests/fabric_gen_test/switchmatrix_test/test_gen_switchmatrix.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import pytest
 from pytest_mock import MockerFixture
 
-from fabulous.fabric_definition.fabric import Fabric
 from fabulous.fabric_definition.tile import Tile
 from fabulous.fabric_generator.gen_fabric.gen_switchmatrix import genTileSwitchMatrix
 from tests.fabric_gen_test.conftest import (
@@ -28,7 +27,6 @@ class TestListFileCsvOutputDirectory:
 
     def test_csv_written_to_custom_directory(
         self,
-        default_fabric: Fabric,
         default_tile: Tile,
         tmp_path: Path,
         mocker: MockerFixture,
@@ -53,7 +51,6 @@ class TestListFileCsvOutputDirectory:
         with pytest.raises(AttributeError):
             genTileSwitchMatrix(
                 None,
-                default_fabric,
                 default_tile,
                 False,
                 csv_output_dir=custom_output_dir,
@@ -66,7 +63,6 @@ class TestListFileCsvOutputDirectory:
 
     def test_default_writes_to_same_directory(
         self,
-        default_fabric: Fabric,
         default_tile: Tile,
         tmp_path: Path,
         mocker: MockerFixture,
@@ -85,7 +81,7 @@ class TestListFileCsvOutputDirectory:
         )
 
         with pytest.raises(AttributeError):
-            genTileSwitchMatrix(None, default_fabric, default_tile, False)
+            genTileSwitchMatrix(None, default_tile, False)
 
         expected_csv = tmp_path / "test_matrix.csv"
         assert expected_csv.exists()
@@ -93,7 +89,6 @@ class TestListFileCsvOutputDirectory:
 
     def test_creates_nested_output_directory(
         self,
-        default_fabric: Fabric,
         default_tile: Tile,
         tmp_path: Path,
         mocker: MockerFixture,
@@ -117,7 +112,6 @@ class TestListFileCsvOutputDirectory:
         with pytest.raises(AttributeError):
             genTileSwitchMatrix(
                 None,
-                default_fabric,
                 default_tile,
                 False,
                 csv_output_dir=custom_output_dir,
@@ -150,7 +144,6 @@ class TestListFileCsvOutputDirectory:
         with pytest.raises(AttributeError):
             genTileSwitchMatrix(
                 None,
-                mocker.MagicMock(),
                 default_tile,
                 False,
                 csv_output_dir=custom_output_dir,

--- a/tests/gds_flow_test/flow_test/test_gen_io_pin_config_yaml.py
+++ b/tests/gds_flow_test/flow_test/test_gen_io_pin_config_yaml.py
@@ -391,12 +391,12 @@ class TestGenerateIOPinOrderConfig:
         return tile
 
     def test_generate_io_pin_order_config_writes_yaml(
-        self, mock_fabric: Fabric, mock_tile: Tile, tmp_path: Path
+        self, mock_tile: Tile, tmp_path: Path
     ) -> None:
         """Test that config is written to YAML file."""
         outfile = tmp_path / "test_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_tile, outfile)
+        generate_IO_pin_order_config(mock_tile, outfile)
 
         assert outfile.exists()
 
@@ -407,12 +407,12 @@ class TestGenerateIOPinOrderConfig:
         assert "X0Y0" in config
 
     def test_generate_io_pin_order_config_tile_structure(
-        self, mock_fabric: Fabric, mock_tile: Tile, tmp_path: Path
+        self, mock_tile: Tile, tmp_path: Path
     ) -> None:
         """Test structure of generated config for a tile."""
         outfile = tmp_path / "test_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_tile, outfile)
+        generate_IO_pin_order_config(mock_tile, outfile)
 
         with outfile.open() as f:
             config = yaml.safe_load(f)
@@ -424,12 +424,12 @@ class TestGenerateIOPinOrderConfig:
         assert "WEST" in config["X0Y0"]
 
     def test_generate_io_pin_order_config_with_prefix(
-        self, mock_fabric: Fabric, mock_tile: Tile, tmp_path: Path
+        self, mock_tile: Tile, tmp_path: Path
     ) -> None:
         """Test generation with prefix."""
         outfile = tmp_path / "test_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_tile, outfile, prefix="Pre_")
+        generate_IO_pin_order_config(mock_tile, outfile, prefix="Pre_")
 
         with outfile.open() as f:
             config = yaml.safe_load(f)
@@ -439,7 +439,7 @@ class TestGenerateIOPinOrderConfig:
         assert config is not None
 
     def test_generate_io_pin_order_config_supertile(
-        self, mock_fabric: Fabric, mocker: MockerFixture, tmp_path: Path
+        self, mocker: MockerFixture, tmp_path: Path
     ) -> None:
         """Test generation for a SuperTile."""
         # Create mock supertile
@@ -458,40 +458,16 @@ class TestGenerateIOPinOrderConfig:
         mock_supertile.tileMap = [[mock_tile]]
         mock_supertile.getPortsAroundTile.return_value = {}
 
-        # Fabric returns position
-        mock_fabric.find_tile_positions.return_value = [(0, 0)]
-        mock_fabric.determine_border_side.return_value = Side.SOUTH
-
         outfile = tmp_path / "test_supertile_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_supertile, outfile)
+        generate_IO_pin_order_config(mock_supertile, outfile)
 
         assert outfile.exists()
 
-    def test_generate_io_pin_order_config_no_positions(
-        self, mock_fabric: Fabric, mock_tile: Tile, tmp_path: Path
+    def test_generate_io_pin_order_config_defaults_external_side_to_south(
+        self, mock_tile: Tile, mocker: MockerFixture, tmp_path: Path
     ) -> None:
-        """Test generation when fabric returns no positions."""
-        mock_fabric.find_tile_positions.return_value = []
-
-        outfile = tmp_path / "test_config.yaml"
-
-        generate_IO_pin_order_config(mock_fabric, mock_tile, outfile)
-
-        # Should still work with default side
-        assert outfile.exists()
-
-    def test_generate_io_pin_order_config_border_side_handling(
-        self,
-        mock_fabric: Fabric,
-        mock_tile: Tile,
-        mocker: MockerFixture,
-        tmp_path: Path,
-    ) -> None:
-        """Test that border side is used for external ports."""
-        mock_fabric.determine_border_side.return_value = Side.EAST
-
-        # Add BEL with external ports
+        """Test generation uses SOUTH for external ports by default."""
         bel = mocker.MagicMock()
         bel.externalInput = ["ext_in"]
         bel.externalOutput = []
@@ -499,7 +475,62 @@ class TestGenerateIOPinOrderConfig:
 
         outfile = tmp_path / "test_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_tile, outfile)
+        generate_IO_pin_order_config(mock_tile, outfile)
+
+        with outfile.open() as f:
+            config = yaml.safe_load(f)
+
+        south_configs = config["X0Y0"]["SOUTH"]
+        pin_lists = [c["pins"] for c in south_configs]
+        all_pins = [pin for pins in pin_lists for pin in pins]
+
+        assert "ext_in" in all_pins
+
+    def test_generate_io_pin_order_config_without_fabric_uses_external_side(
+        self, mock_tile: Tile, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test generation without fabric placement context."""
+        bel = mocker.MagicMock()
+        bel.externalInput = ["ext_in"]
+        bel.externalOutput = []
+        mock_tile.bels = [bel]
+
+        outfile = tmp_path / "test_config.yaml"
+
+        generate_IO_pin_order_config(
+            mock_tile,
+            outfile,
+            external_port_side=Side.EAST,
+        )
+
+        with outfile.open() as f:
+            config = yaml.safe_load(f)
+
+        east_configs = config["X0Y0"]["EAST"]
+        pin_lists = [c["pins"] for c in east_configs]
+        all_pins = [pin for pins in pin_lists for pin in pins]
+
+        assert "ext_in" in all_pins
+
+    def test_generate_io_pin_order_config_external_side_handling(
+        self,
+        mock_tile: Tile,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ) -> None:
+        """Test that explicit external side is used for external ports."""
+        bel = mocker.MagicMock()
+        bel.externalInput = ["ext_in"]
+        bel.externalOutput = []
+        mock_tile.bels = [bel]
+
+        outfile = tmp_path / "test_config.yaml"
+
+        generate_IO_pin_order_config(
+            mock_tile,
+            outfile,
+            external_port_side=Side.EAST,
+        )
 
         with outfile.open() as f:
             config = yaml.safe_load(f)
@@ -511,10 +542,10 @@ class TestGenerateIOPinOrderConfig:
 
         assert "ext_in" in all_pins
 
-    def test_generate_io_pin_order_config_supertile_multiple_positions(
-        self, mock_fabric: Fabric, mocker: MockerFixture, tmp_path: Path
+    def test_generate_io_pin_order_config_supertile_uses_fabric_border_side(
+        self, mocker: MockerFixture, tmp_path: Path
     ) -> None:
-        """Test supertile with multiple positions uses top-left."""
+        """SuperTile subtile sides come from fabric placement when given."""
         mock_supertile = mocker.MagicMock(spec=SuperTile)
 
         mock_tile = mocker.MagicMock(spec=Tile)
@@ -524,20 +555,72 @@ class TestGenerateIOPinOrderConfig:
             Side.SOUTH: PinOrderConfig(),
             Side.WEST: PinOrderConfig(),
         }
-        mock_tile.bels = []
+        bel = mocker.MagicMock()
+        bel.externalInput = ["ext_in"]
+        bel.externalOutput = []
+        mock_tile.bels = [bel]
 
         mock_supertile.tileMap = [[mock_tile]]
-        mock_supertile.getPortsAroundTile.return_value = {}
+        mock_supertile.getPortsAroundTile.return_value = {"0,0": [[]]}
 
-        # Multiple positions
-        mock_fabric.find_tile_positions.return_value = [(2, 3), (0, 1), (1, 2)]
-        mock_fabric.determine_border_side.return_value = None
+        mock_fabric = mocker.MagicMock(spec=Fabric)
+        mock_fabric.find_tile_positions.return_value = [(2, 0)]
+        mock_fabric.determine_border_side.return_value = Side.EAST
 
         outfile = tmp_path / "test_config.yaml"
 
-        generate_IO_pin_order_config(mock_fabric, mock_supertile, outfile)
+        generate_IO_pin_order_config(
+            mock_supertile,
+            outfile,
+            fabric=mock_fabric,
+        )
 
-        assert outfile.exists()
+        with outfile.open() as f:
+            config = yaml.safe_load(f)
+
+        east_configs = config["X0Y0"]["EAST"]
+        pin_lists = [c["pins"] for c in east_configs]
+        all_pins = [pin for pins in pin_lists for pin in pins]
+
+        assert "ext_in" in all_pins
+
+    def test_generate_io_pin_order_config_supertile_without_fabric(
+        self, mocker: MockerFixture, tmp_path: Path
+    ) -> None:
+        """Test SuperTile generation without fabric placement context."""
+        mock_supertile = mocker.MagicMock(spec=SuperTile)
+
+        mock_tile = mocker.MagicMock(spec=Tile)
+        mock_tile.pinOrderConfig = {
+            Side.NORTH: PinOrderConfig(),
+            Side.EAST: PinOrderConfig(),
+            Side.SOUTH: PinOrderConfig(),
+            Side.WEST: PinOrderConfig(),
+        }
+        bel = mocker.MagicMock()
+        bel.externalInput = ["ext_in"]
+        bel.externalOutput = []
+        mock_tile.bels = [bel]
+
+        mock_supertile.tileMap = [[mock_tile]]
+        mock_supertile.getPortsAroundTile.return_value = {"0,0": [[]]}
+
+        outfile = tmp_path / "test_config.yaml"
+
+        generate_IO_pin_order_config(
+            mock_supertile,
+            outfile,
+            external_port_side=Side.EAST,
+        )
+
+        with outfile.open() as f:
+            config = yaml.safe_load(f)
+
+        east_configs = config["X0Y0"]["EAST"]
+        pin_lists = [c["pins"] for c in east_configs]
+        all_pins = [pin for pins in pin_lists for pin in pins]
+
+        assert "ext_in" in all_pins
 
 
 class TestPinOrderConfigIntegration:


### PR DESCRIPTION
Update the public signatures of the per-component generators (`gen_tile`, `gen_configmem`, `gen_switchmatrix`, `gen_io_pin_config_yaml`) to make their inputs explicit, drop unused parameters, and align return shapes. Tests for each generator are updated to the new interfaces.