### PR TITLE
fix(geometry): support T-shape and thin fabrics

### DIFF
--- a/fabulous/geometry_generator/fabric_geometry.py
+++ b/fabulous/geometry_generator/fabric_geometry.py
@@ -81,18 +81,24 @@ class FabricGeometry:
                 tileName = tile.name
                 tileGeom = self.tileGeomMap[tileName]
 
-                if tileGeom == queried:
+                if tileGeom is queried:
                     searchedTile = None
+                    # Pick the in-fabric neighbour on the relevant axis:
+                    # for NORTHSOUTH borders that means the tile above or
+                    # below (whichever is non-NULL); for EASTWEST it's the
+                    # tile to the left or right. T-shaped fabrics can have
+                    # one side be NULL even when i / j is not at the grid
+                    # bounds, so we fall back to the opposite direction.
                     if queried.border == Border.NORTHSOUTH:
-                        if i == 0:
+                        if i + 1 < self.fabric.numberOfRows:
                             searchedTile = self.fabric.tile[i + 1][j]
-                        else:
+                        if searchedTile is None and i - 1 >= 0:
                             searchedTile = self.fabric.tile[i - 1][j]
 
                     elif queried.border == Border.EASTWEST:
-                        if j == 0:
+                        if j + 1 < self.fabric.numberOfColumns:
                             searchedTile = self.fabric.tile[i][j + 1]
-                        else:
+                        if searchedTile is None and j - 1 >= 0:
                             searchedTile = self.fabric.tile[i][j - 1]
 
                     if searchedTile is not None:
@@ -120,8 +126,22 @@ class FabricGeometry:
                         self.tileGeomMap[tile.name] = TileGeometry()
 
                     tileGeom = self.tileGeomMap[tile.name]
-                    northSouth = i == 0 or i + 1 == self.fabric.numberOfRows
-                    eastWest = j == 0 or j + 1 == self.fabric.numberOfColumns
+                    # A tile sits on a north/south border if it is on the
+                    # top/bottom row OR the cell above/below is NULL — the
+                    # latter case lets termination tiles on the inner edge
+                    # of T-shaped fabrics be classified correctly.
+                    northSouth = (
+                        i == 0
+                        or i + 1 == self.fabric.numberOfRows
+                        or self.fabric.tile[i - 1][j] is None
+                        or self.fabric.tile[i + 1][j] is None
+                    )
+                    eastWest = (
+                        j == 0
+                        or j + 1 == self.fabric.numberOfColumns
+                        or self.fabric.tile[i][j - 1] is None
+                        or self.fabric.tile[i][j + 1] is None
+                    )
 
                     if northSouth and eastWest:
                         tileGeom.border = Border.CORNER

--- a/fabulous/geometry_generator/tile_geometry.py
+++ b/fabulous/geometry_generator/tile_geometry.py
@@ -261,7 +261,14 @@ class TileGeometry:
         self.eastMiddleY = self.smGeometry.relY + self.smGeometry.height + padding
         self.westMiddleY = self.smGeometry.relY + self.smGeometry.height + padding
 
-        if self.border == Border.NORTHSOUTH:
+        alignNorthSouth = (
+            self.border == Border.NORTHSOUTH and self.neighbourConstraints is not None
+        )
+        alignEastWest = (
+            self.border == Border.EASTWEST and self.neighbourConstraints is not None
+        )
+
+        if alignNorthSouth:
             wireNorthPositions = sorted(
                 self.neighbourConstraints.southPositions, reverse=True
             )
@@ -270,16 +277,22 @@ class TileGeometry:
             )
             northIter = iter(wireNorthPositions)
             southIter = iter(wireSouthPositions)
-            self.northMiddleX = next(northIter, None)
-            self.southMiddleX = next(southIter, None)
+            self.northMiddleX = next(northIter, self.northMiddleX)
+            self.southMiddleX = next(southIter, self.southMiddleX)
+        else:
+            northIter = iter(())
+            southIter = iter(())
 
-        if self.border == Border.EASTWEST:
+        if alignEastWest:
             wireEastPositions = sorted(self.neighbourConstraints.westPositions)
             wireWestPositions = sorted(self.neighbourConstraints.eastPositions)
             eastIter = iter(wireEastPositions)
             westIter = iter(wireWestPositions)
-            self.eastMiddleY = next(eastIter, None)
-            self.westMiddleY = next(westIter, None)
+            self.eastMiddleY = next(eastIter, self.eastMiddleY)
+            self.westMiddleY = next(westIter, self.westMiddleY)
+        else:
+            eastIter = iter(())
+            westIter = iter(())
 
         for portGeom in self.smGeometry.portGeoms:
             if abs(portGeom.offset) != 1:
@@ -300,8 +313,8 @@ class TileGeometry:
                 wireGeom.addPathLoc(Location(endX, endY))
                 self.wireConstraints.northPositions.append(self.northMiddleX)
 
-                if self.border == Border.NORTHSOUTH:
-                    self.northMiddleX = next(northIter, 0)
+                if alignNorthSouth:
+                    self.northMiddleX = next(northIter, self.northMiddleX - 1)
                 else:
                     self.northMiddleX -= 1
 
@@ -318,8 +331,8 @@ class TileGeometry:
                 wireGeom.addPathLoc(Location(endX, endY))
                 self.wireConstraints.southPositions.append(self.southMiddleX)
 
-                if self.border == Border.NORTHSOUTH:
-                    self.southMiddleX = next(southIter, 0)
+                if alignNorthSouth:
+                    self.southMiddleX = next(southIter, self.southMiddleX - 1)
                 else:
                     self.southMiddleX -= 1
 
@@ -336,8 +349,8 @@ class TileGeometry:
                 wireGeom.addPathLoc(Location(endX, endY))
                 self.wireConstraints.eastPositions.append(self.eastMiddleY)
 
-                if self.border == Border.EASTWEST:
-                    self.eastMiddleY = next(eastIter, 0)
+                if alignEastWest:
+                    self.eastMiddleY = next(eastIter, self.eastMiddleY + 1)
                 else:
                     self.eastMiddleY += 1
 
@@ -354,8 +367,8 @@ class TileGeometry:
                 wireGeom.addPathLoc(Location(endX, endY))
                 self.wireConstraints.westPositions.append(self.westMiddleY)
 
-                if self.border == Border.EASTWEST:
-                    self.westMiddleY = next(westIter, 0)
+                if alignEastWest:
+                    self.westMiddleY = next(westIter, self.westMiddleY + 1)
                 else:
                     self.westMiddleY += 1
 


### PR DESCRIPTION
Closes #600

Two related issues in `fabulous/geometry_generator/`:

- **T-shape concavity tiles** were classified as non-border because border
  detection only checked grid-edge position, not whether a NULL cell sat next
  to the tile. Their wires then routed off into empty cells.
- **Thin (1×N / N×1) fabrics** crashed: every interior tile is a border-axis
  tile but has no same-axis neighbour, so `neighbourConstraints` was `None`
  and the alignment block dereferenced it.

Changes:

- `fabric_geometry.py` — widen `northSouth` / `eastWest` to also flag NULL
  adjacency; bounds-check the neighbour-pick so we try the opposite side if
  the first candidate is NULL; switch `tileGeom == queried` to identity
  (`is`) since `TileGeometry` is a dataclass and two distinct instances with
  default fields compare equal.
- `tile_geometry.py` — gate the alignment block with
  `neighbourConstraints is not None`; when the constraint queue is exhausted
  mid-loop, fall through to the same local-stride pattern as the non-border
  branch instead of clamping to 0.