### PR TITLE
feat: make NVC the default VHDL simulator (GHDL is fallback)

### DIFF
--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -92,15 +92,7 @@ runs:
         github-token: ${{ github.token }}
         version: ${{ steps.oss-cad-version.outputs.version }}
     - name: Install NVC VHDL simulator
-      shell: bash
-      run: |
-        UBUNTU_VERSION=$(lsb_release -rs)
-        NVC_TAG=$(curl -sf -H "Authorization: Bearer ${{ github.token }}" \
-          "https://api.github.com/repos/nickg/nvc/releases/latest" | jq -r .tag_name)
-        NVC_VERSION=${NVC_TAG#r}
-        DEB_URL="https://github.com/nickg/nvc/releases/download/${NVC_TAG}/nvc_${NVC_VERSION}-1_amd64_ubuntu-${UBUNTU_VERSION}.deb"
-        wget -q "${DEB_URL}" -O /tmp/nvc.deb
-        sudo dpkg -i /tmp/nvc.deb
+      uses: nickg/setup-nvc@v1
       if: ${{ inputs.install_nvc != 'false' }}
     - name: Install GHDL mcode nightly
       # GHDL mcode is required to test our fabric.

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -23,6 +23,10 @@ inputs:
       version is used"
     required: false
     default: "true"
+  install_nvc:
+    description: "If true, NVC VHDL simulator will be installed (recommended, faster than GHDL)"
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -87,6 +91,9 @@ runs:
       with:
         github-token: ${{ github.token }}
         version: ${{ steps.oss-cad-version.outputs.version }}
+    - name: Install NVC VHDL simulator
+      uses: nickg/setup-nvc@v1
+      if: ${{ inputs.install_nvc != 'false' }}
     - name: Install GHDL mcode nightly
       # GHDL mcode is required to test our fabric.
       # The oss-cad-suite action installs GHDL, but with the LLVM backend, which is much slower for our simulation

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -92,7 +92,15 @@ runs:
         github-token: ${{ github.token }}
         version: ${{ steps.oss-cad-version.outputs.version }}
     - name: Install NVC VHDL simulator
-      uses: nickg/setup-nvc@v1
+      shell: bash
+      run: |
+        UBUNTU_VERSION=$(lsb_release -rs)
+        NVC_TAG=$(curl -sf -H "Authorization: Bearer ${{ github.token }}" \
+          "https://api.github.com/repos/nickg/nvc/releases/latest" | jq -r .tag_name)
+        NVC_VERSION=${NVC_TAG#r}
+        DEB_URL="https://github.com/nickg/nvc/releases/download/${NVC_TAG}/nvc_${NVC_VERSION}-1_amd64_ubuntu-${UBUNTU_VERSION}.deb"
+        wget -q "${DEB_URL}" -O /tmp/nvc.deb
+        sudo dpkg -i /tmp/nvc.deb
       if: ${{ inputs.install_nvc != 'false' }}
     - name: Install GHDL mcode nightly
       # GHDL mcode is required to test our fabric.

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -122,4 +122,4 @@ runs:
     - name: Set PATH
       shell: bash
       run: |
-        echo "/home/runner/work/FABulous/FABulous/install/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin:$PATH" >> "$GITHUB_PATH"
+        echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"

--- a/.github/actions/prepare_FABulous_container/action.yaml
+++ b/.github/actions/prepare_FABulous_container/action.yaml
@@ -130,4 +130,4 @@ runs:
     - name: Set PATH
       shell: bash
       run: |
-        echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+        echo "$GITHUB_WORKSPACE/.venv/bin:/usr/local/bin:/usr/bin:/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -10,28 +10,49 @@ on:
       - '.github/actions/**'
 
 jobs:
-  run_sim_makefile_on_base_project:
-    name: Run fabric generator flow and simulation with FABulous makefile against base branch
+  generate_old_project:
+    name: Generate old project (${{ matrix.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - name: Verilog
-            type: verilog 
+            type: verilog
           - name: VHDL
             type: vhdl
-
     steps:
       - uses: actions/checkout@v5
         with:
-          ref: ${{ github.base_ref }} 
+          ref: ${{ github.base_ref }}
       - uses: ./.github/actions/prepare_FABulous_container
-      - name: generate old project
+      - name: Generate project with base branch FABulous
         run: |
           uv run FABulous -c /tmp/demo_${{ matrix.type }} -w ${{ matrix.type }}
+      - name: Upload generated project
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-${{ matrix.type }}-base
+          path: /tmp/demo_${{ matrix.type }}
 
+  run_simulation:
+    name: Run simulation with PR branch against base project (${{ matrix.name }})
+    needs: generate_old_project
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: Verilog
+            type: verilog
+          - name: VHDL
+            type: vhdl
+    steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
+      - name: Download base project
+        uses: actions/download-artifact@v4
+        with:
+          name: demo-${{ matrix.type }}-base
+          path: /tmp/demo_${{ matrix.type }}
       - name: Run fabric generator flow and simulation with FABulous makefile
         run: |
           cd /tmp/demo_${{ matrix.type }}/Test

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -10,6 +10,12 @@ on:
       - '.github/actions/**'
 
 jobs:
+  # NOTE: This workflow intentionally uses two separate jobs instead of two
+  # steps calling the same composite action in one job.
+  # Calling a composite action twice in the same job causes a GitHub Actions
+  # runner bug: Node.js actions inside it (setup-python, cache, setup-ghdl)
+  # register post-run handlers that break on duplicate step indices, producing
+  # "Index was out of range" errors in the post-run phase.
   generate_old_project:
     name: Generate old project (${{ matrix.name }})
     runs-on: ubuntu-latest

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -33,8 +33,6 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/prepare_FABulous_container
       - name: Run fabric generator flow and simulation with FABulous makefile
-        id: run_simulation
-        continue-on-error: true
         run: |
           cd /tmp/demo_${{ matrix.type }}/Test
           make FAB_sim

--- a/.github/workflows/backwards-compatibility.yml
+++ b/.github/workflows/backwards-compatibility.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: demo-${{ matrix.type }}-base
           path: /tmp/demo_${{ matrix.type }}
+          include-hidden-files: true
 
   run_simulation:
     name: Run simulation with PR branch against base project (${{ matrix.name }})

--- a/.github/workflows/pytest_testing.yml
+++ b/.github/workflows/pytest_testing.yml
@@ -103,6 +103,7 @@ jobs:
           COVERAGE_FILE: .coverage.${{ matrix.job-index }}
         run: |
           echo "Running at PATH=$PATH"
+          which nvc
           which ghdl
           which iverilog
           # Ensure no stale coverage data from previous attempts (no coverage module needed)

--- a/docs/source/getting_started/installation/cad-tool.md
+++ b/docs/source/getting_started/installation/cad-tool.md
@@ -28,12 +28,14 @@ To perform synthesis, place and route and simulation you will need the following
 
 - VHDL:
   - [yosys](https://github.com/YosysHQ/yosys)
-  - [ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin)
+  - [ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin) (for synthesis)
   - [nextnpr-generic](https://github.com/YosysHQ/nextpnr?tab=readme-ov-file#nextpnr-generic)
-  - [ghdl](https://github.com/ghdl/ghdl/releases/tag/nightly)
+  - [nvc](https://github.com/nickg/nvc) (for simulation, recommended) or [ghdl](https://github.com/ghdl/ghdl/releases/tag/nightly) (fallback simulator)
 
 As mentioned in the previous section, using the `FABulous install-oss-cad-suite` will install all the required software.
 
 :::{note}
-For GHDL we suggest using the `mcode` backend, as the simulation time is short using the `mcode` backend then any other backend. If you are a Mac user, the `mcode` backend is not available, and we recommend going with the `llvm-jit` backend instead.
+For VHDL simulation, **NVC is significantly faster than GHDL** and is the recommended simulator. If NVC is not available, GHDL can be used as a fallback.
+
+If using GHDL, we suggest using the `mcode` backend, as simulation time is shorter with `mcode` than any other backend. If you are a Mac user, the `mcode` backend is not available, and we recommend going with the `llvm-jit` backend instead.
 :::

--- a/docs/source/user_guide/simulation/simulation.md
+++ b/docs/source/user_guide/simulation/simulation.md
@@ -151,9 +151,9 @@ FABulous> run_simulation fst path/to/design.bin --extra-iverilog-flag="-DDEBUG"
 FABulous> run_simulation fst path/to/design.bin --extra-nvc-flag="--ieee-warnings=error"
 FABulous> run_simulation fst path/to/design.bin --extra-ghdl-flag="--warn-error"
 
-# Force a specific simulator
-FABulous> run_simulation fst path/to/design.bin SIMULATOR=nvc
-FABulous> run_simulation fst path/to/design.bin SIMULATOR=ghdl
+# Force a specific VHDL simulator
+FABulous> run_simulation fst path/to/design.bin --simulator=nvc
+FABulous> run_simulation fst path/to/design.bin --simulator=ghdl
 
 # Combine options
 FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRACE"
@@ -162,6 +162,7 @@ FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRAC
 | Flag | Short | Description |
 |---|---|---|
 | `--design` | `-d` | Override the design name (default: inferred from bitstream filename) |
+| `--simulator` | `-s` | VHDL simulator: `nvc`, `ghdl`, or `auto` (default: auto-detect) |
 | `--extra-iverilog-flag` | `-if` | Extra flags for iverilog (Verilog projects) |
 | `--extra-nvc-flag` | `-nf` | Extra flags for NVC (VHDL projects) |
 | `--extra-ghdl-flag` | `-gf` | Extra flags for GHDL (VHDL projects) |

--- a/docs/source/user_guide/simulation/simulation.md
+++ b/docs/source/user_guide/simulation/simulation.md
@@ -19,7 +19,7 @@ flowchart TB
 
     subgraph sim ["Simulation"]
         direction LR
-        E[Test Bitstream] --> H["Testbench (iverilog / GHDL)"]
+        E[Test Bitstream] --> H["Testbench (iverilog / NVC / GHDL)"]
         H --> I{Pass / Fail}
     end
 
@@ -65,11 +65,13 @@ For more complex use cases it can be useful to create your own flow using the
 
 ## Prerequisites
 
-Please make sure to use recent versions of [Yosys](https://github.com/YosysHQ/yosys), [nextpnr-generic](https://github.com/YosysHQ/nextpnr) (_not_ the old FABulous nextpnr fork)
-and [GHDL with mcode backend](<https://github.com/ghdl/ghdl/releases>) or use the [OSS-CAD-Suite](https://github.com/YosysHQ/oss-cad-suite-build) which provides nightly builds of the necessary dependencies.
+Please make sure to use recent versions of [Yosys](https://github.com/YosysHQ/yosys), [nextpnr-generic](https://github.com/YosysHQ/nextpnr) (_not_ the old FABulous nextpnr fork),
+and either [NVC](https://github.com/nickg/nvc) or [GHDL with mcode backend](<https://github.com/ghdl/ghdl/releases>), or use the [OSS-CAD-Suite](https://github.com/YosysHQ/oss-cad-suite-build) which provides nightly builds of the necessary dependencies.
 
 :::{note}
-The OSS-CAD-Suite is providing GHDL only with LLVM backend, which increases the simulation speed for FABulous projects significantly. We recommend using the latest GHDL with mcode backend for the best simulation performance.
+**NVC is significantly faster than GHDL for our simulation.** We recommend installing NVC first. The simulation will automatically use NVC if available, otherwise it falls back to GHDL.
+
+If using GHDL, we recommend the mcode backend for better simulation performance. The OSS-CAD-Suite provides only LLVM backend, which is slower than mcode.
 :::
 
 ## Taskfile
@@ -119,9 +121,10 @@ The available variables are:
 | `WAVEFORM_TYPE` | `fst` | Waveform output format (`fst` or `vcd`) |
 | `BUILD_DIR` | `build` | Build output directory |
 | `FAB_PROJ_ROOT` | `..` | Path to the project root |
-| `GHDL_FLAGS` | `--std=08 -O2` | GHDL compilation flags (VHDL only) |
+| `SIMULATOR` | `auto` | Simulator selection (`auto`, `nvc`, or `ghdl`). `auto` uses NVC if available, falls back to GHDL |
 | `BITSTREAM_BIN` | `build/<DESIGN>.bin` | Path to the `.bin` bitstream file |
 | `EXTRA_IVERILOG_FLAGS` | *(empty)* | Extra flags passed to iverilog (Verilog only) |
+| `EXTRA_NVC_FLAGS` | *(empty)* | Extra flags passed to NVC (VHDL only) |
 | `EXTRA_GHDL_FLAGS` | *(empty)* | Extra flags passed to GHDL (VHDL only) |
 | `MAX_BITBYTES` | `16384` | Maximum bitstream size in bytes |
 
@@ -145,7 +148,12 @@ FABulous> run_simulation fst path/to/design.bin -d my_design
 
 # Pass extra simulator flags
 FABulous> run_simulation fst path/to/design.bin --extra-iverilog-flag="-DDEBUG"
+FABulous> run_simulation fst path/to/design.bin --extra-nvc-flag="--ieee-warnings=error"
 FABulous> run_simulation fst path/to/design.bin --extra-ghdl-flag="--warn-error"
+
+# Force a specific simulator
+FABulous> run_simulation fst path/to/design.bin SIMULATOR=nvc
+FABulous> run_simulation fst path/to/design.bin SIMULATOR=ghdl
 
 # Combine options
 FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRACE"
@@ -155,6 +163,7 @@ FABulous> run_simulation vcd path/to/design.bin -d my_design -if "-DDEBUG -DTRAC
 |---|---|---|
 | `--design` | `-d` | Override the design name (default: inferred from bitstream filename) |
 | `--extra-iverilog-flag` | `-if` | Extra flags for iverilog (Verilog projects) |
+| `--extra-nvc-flag` | `-nf` | Extra flags for NVC (VHDL projects) |
 | `--extra-ghdl-flag` | `-gf` | Extra flags for GHDL (VHDL projects) |
 
 ### Verilog vs. VHDL
@@ -164,10 +173,11 @@ toolchain.
 
 - **Verilog projects** use [Icarus Verilog](https://steveicarus.github.io/iverilog/)
   (`iverilog` / `vvp`) for simulation.
-- **VHDL projects** use [GHDL](https://ghdl.github.io/ghdl/) for simulation.
-  GHDL requires files to be compiled in dependency order, so the VHDL Taskfile
+- **VHDL projects** use [NVC](https://github.com/nickg/nvc) by default for simulation, with automatic fallback to [GHDL](https://ghdl.github.io/ghdl/) if NVC is not available.
+  Both simulators require files to be compiled in dependency order, so the VHDL Taskfile
   compiles packages (`models_pack`) first, then tile files, then fabric
   infrastructure, and finally the user design and testbench.
+  You can force a specific simulator by setting `SIMULATOR=nvc` or `SIMULATOR=ghdl`.
 
 :::{note}
 The `Taskfile.yml` is a regular YAML file that you can freely edit to add

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Makefile
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Makefile
@@ -3,6 +3,8 @@ FAB_PROJ_ROOT=..
 BUILD_DIR=build
 YOSYS?=$(or $(FAB_YOSYS_PATH),yosys)
 NEXTPNR?=$(or $(FAB_NEXTPNR_PATH),nextpnr-generic)
+
+.PHONY: mkdir_build run_GTKWave clean run_simulation
 DESIGN=sequential_16bit_en
 TESTBENCH=${DESIGN}_tb
 TOP_WRAPPER=top_wrapper
@@ -13,8 +15,34 @@ TOP_WRAPPER_VERILOG=${USER_DESIGN_DIR}/${TOP_WRAPPER}.v # Still needs to be veri
 FAB_TILE_FOLDER=${FAB_PROJ_ROOT}/Tile
 FAB_FABRIC_FOLDER=${FAB_PROJ_ROOT}/Fabric
 
-GHDL=ghdl
+# Simulator selection: nvc or ghdl (default: nvc if available, fallback to ghdl)
+SIMULATOR?=$(if $(shell which nvc),nvc,ghdl)
+
+# NVC simulator flags
+NVC_CMD=nvc
+NVC_ANALYZE_CMD=${NVC_CMD} --std=2008 -L ${BUILD_DIR} -H 2g -M 1g --ieee-warnings=off --work=${BUILD_DIR}/work -a
+NVC_ELAB_CMD=${NVC_CMD} --std=2008 -L ${BUILD_DIR} -H 2g -M 1g --ieee-warnings=off --work=${BUILD_DIR}/work -e -O2
+NVC_RUN_CMD=${NVC_CMD} --std=2008 -L ${BUILD_DIR} -H 2g -M 1g --ieee-warnings=off --work=${BUILD_DIR}/work -r
+
+# GHDL simulator flags
+GHDL_CMD=ghdl
 GHDL_FLAGS=--std=08 -O2 --workdir=${BUILD_DIR}
+GHDL_ANALYZE_CMD=${GHDL_CMD} -a ${GHDL_FLAGS}
+GHDL_ELAB_CMD=${GHDL_CMD} -e ${GHDL_FLAGS} -fexplicit
+GHDL_RUN_CMD=${GHDL_CMD} -r ${GHDL_FLAGS}
+
+# Select simulator
+ifeq (${SIMULATOR},nvc)
+ANALYZE_CMD=${NVC_ANALYZE_CMD}
+ELAB_CMD=${NVC_ELAB_CMD}
+RUN_CMD=${NVC_RUN_CMD}
+OUTPUT_OPT=-w${BUILD_DIR}/${TESTBENCH}.fst
+else ifeq (${SIMULATOR},ghdl)
+ANALYZE_CMD=${GHDL_ANALYZE_CMD}
+ELAB_CMD=${GHDL_ELAB_CMD}
+RUN_CMD=${GHDL_RUN_CMD}
+OUTPUT_OPT=--fst=${BUILD_DIR}/${TESTBENCH}.fst
+endif
 
 #only add if custom_prims.v exists
 ifneq ($(wildcard ${USER_DESIGN_DIR}/custom_prims.v),)
@@ -60,8 +88,8 @@ clean:
 
 run_simulation: mkdir_build
 	ulimit -s unlimited && \
-	${GHDL} -a ${GHDL_FLAGS} ${FAB_FABRIC_FOLDER}/models_pack.vhdl && \
-	${GHDL} -a ${GHDL_FLAGS} \
+	${ANALYZE_CMD} ${FAB_FABRIC_FOLDER}/models_pack.vhdl && \
+	${ANALYZE_CMD} \
 	              ${FAB_TILE_FOLDER}/LUT4AB/LUT4AB_switch_matrix.vhdl \
 	              ${FAB_TILE_FOLDER}/LUT4AB/LUT4AB_ConfigMem.vhdl \
 	              ${FAB_TILE_FOLDER}/LUT4AB/LUT4c_frame_config_dffesr.vhdl \
@@ -81,7 +109,7 @@ run_simulation: mkdir_build
 	              ${FAB_TILE_FOLDER}/W_IO/IO_1_bidirectional_frame_config_pass.vhdl \
 	              ${FAB_TILE_FOLDER}/W_IO/Config_access.vhdl \
 	              ${FAB_TILE_FOLDER}/W_IO/W_IO.vhdl && \
-	${GHDL} -a ${GHDL_FLAGS} \
+	${ANALYZE_CMD} \
 	              ${FAB_TILE_FOLDER}/DSP/DSP_top/DSP_top_switch_matrix.vhdl \
 	              ${FAB_TILE_FOLDER}/DSP/DSP_top/DSP_top_ConfigMem.vhdl \
 	              ${FAB_TILE_FOLDER}/DSP/DSP_top/DSP_top.vhdl \
@@ -90,7 +118,7 @@ run_simulation: mkdir_build
 	              ${FAB_TILE_FOLDER}/DSP/DSP_bot/MULADD.vhdl \
 	              ${FAB_TILE_FOLDER}/DSP/DSP_bot/DSP_bot.vhdl \
 	              ${FAB_TILE_FOLDER}/DSP/DSP.vhdl && \
-	${GHDL} -a ${GHDL_FLAGS} \
+	${ANALYZE_CMD} \
 	              ${FAB_TILE_FOLDER}/N_term_DSP/N_term_DSP_switch_matrix.vhdl \
 	              ${FAB_TILE_FOLDER}/N_term_DSP/N_term_DSP.vhdl \
 	              ${FAB_TILE_FOLDER}/S_term_DSP/S_term_DSP_switch_matrix.vhdl \
@@ -107,7 +135,7 @@ run_simulation: mkdir_build
 	              ${FAB_TILE_FOLDER}/N_term_single2/N_term_single2.vhdl \
 	              ${FAB_TILE_FOLDER}/S_term_single2/S_term_single2_switch_matrix.vhdl \
 	              ${FAB_TILE_FOLDER}/S_term_single2/S_term_single2.vhdl && \
-	${GHDL} -a ${GHDL_FLAGS} \
+	${ANALYZE_CMD} \
 	              ${FAB_FABRIC_FOLDER}/config_UART.vhdl \
 	              ${FAB_FABRIC_FOLDER}/bitbang.vhdl \
 	              ${FAB_FABRIC_FOLDER}/ConfigFSM.vhdl \
@@ -119,5 +147,7 @@ run_simulation: mkdir_build
 	              ${FAB_FABRIC_FOLDER}/eFPGA_top.vhdl \
 	              ${USER_DESIGN_DIR}/${DESIGN}.vhdl \
 	              ${TESTBENCH}.vhdl && \
-	${GHDL} -e ${GHDL_FLAGS} -fexplicit ${TESTBENCH} && \
-	${GHDL} -r ${GHDL_FLAGS} ${TESTBENCH} --stats --ieee-asserts=disable --fst=${BUILD_DIR}/${TESTBENCH}.fst
+	${ELAB_CMD} ${TESTBENCH} && \
+	$(if $(filter nvc,${SIMULATOR}), \
+		${RUN_CMD} ${TESTBENCH} ${OUTPUT_OPT} --stats, \
+		${RUN_CMD} ${TESTBENCH} --stats --ieee-asserts=disable ${OUTPUT_OPT})

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Makefile
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Makefile
@@ -42,6 +42,8 @@ ANALYZE_CMD=${GHDL_ANALYZE_CMD}
 ELAB_CMD=${GHDL_ELAB_CMD}
 RUN_CMD=${GHDL_RUN_CMD}
 OUTPUT_OPT=--fst=${BUILD_DIR}/${TESTBENCH}.fst
+else
+$(error Unknown SIMULATOR value '${SIMULATOR}'. Supported values: nvc, ghdl)
 endif
 
 #only add if custom_prims.v exists

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
@@ -5,8 +5,8 @@ FABulous provides a simulation environment to test the fabric and the bitstream 
 For simple use cases, there is the `run_simulation command` in the FABulous shell.
 For more complex use cases it can be useful to create an own flow, like the following example `make` based flow.
 
-Please make sure to use recent versions of (Yosys)[https://github.com/YosysHQ/yosys], (nextpnr-generic)[https://github.com/YosysHQ/nextpnr] (_not_ the old FABulous nextpnr fork)
-and either (NVC)[https://github.com/nickg/nvc] or (GHDL with mcode backend)[https://github.com/ghdl/ghdl/releases], or use the (OSS-CAD-Suite)[https://github.com/YosysHQ/oss-cad-suite-build] which provides nightly builds of the necessary dependencies.
+Please make sure to use recent versions of [Yosys](https://github.com/YosysHQ/yosys), [nextpnr-generic](https://github.com/YosysHQ/nextpnr) (_not_ the old FABulous nextpnr fork)
+and either [NVC](https://github.com/nickg/nvc) or [GHDL with mcode backend](https://github.com/ghdl/ghdl/releases), or use the [OSS-CAD-Suite](https://github.com/YosysHQ/oss-cad-suite-build) which provides nightly builds of the necessary dependencies.
 
 > [!NOTE]
 >

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/README.md
@@ -6,12 +6,13 @@ For simple use cases, there is the `run_simulation command` in the FABulous shel
 For more complex use cases it can be useful to create an own flow, like the following example `make` based flow.
 
 Please make sure to use recent versions of (Yosys)[https://github.com/YosysHQ/yosys], (nextpnr-generic)[https://github.com/YosysHQ/nextpnr] (_not_ the old FABulous nextpnr fork)
-and (GHDL with mcode backend)[https://github.com/ghdl/ghdl/releases] or use the (OSS-CAD-Suite)[https://github.com/YosysHQ/oss-cad-suite-build] which provides nightly builds of the necessary dependencies.
+and either (NVC)[https://github.com/nickg/nvc] or (GHDL with mcode backend)[https://github.com/ghdl/ghdl/releases], or use the (OSS-CAD-Suite)[https://github.com/YosysHQ/oss-cad-suite-build] which provides nightly builds of the necessary dependencies.
 
 > [!NOTE]
 >
->The OSS-CAD-Suite is providing GHDL only with LLVM backend, which increases the simulation speed for FABulous projects significantly.
->We recommend using the latest GHDL with mcode backend for the best simulation performance.
+>**NVC is significantly faster than GHDL for our simulation.** We recommend installing NVC first. The simulation will automatically use NVC if available, otherwise it falls back to GHDL.
+>
+>If using GHDL, we recommend the mcode backend for better simulation performance. The OSS-CAD-Suite provides only LLVM backend, which is slower than mcode.
 
 Also, make sure you have the `make` package installed:
 ```

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
@@ -20,7 +20,14 @@ vars:
   TOP_WRAPPER: '{{.TOP_WRAPPER | default "top_wrapper"}}'
   USER_DESIGN_DIR: "{{.FAB_PROJ_ROOT}}/user_design"
   WAVEFORM_TYPE: '{{.WAVEFORM_TYPE | default "fst"}}'
-  GHDL_FLAGS: '{{.GHDL_FLAGS | default "--std=08 -O2"}}'
+  SIMULATOR: '{{.SIMULATOR | default "auto"}}'
+  NVC_GLOBAL_FLAGS: '--std=2008 -L {{.BUILD_DIR}} -H 2g -M 1g --ieee-warnings=off --work={{.BUILD_DIR}}/work'
+  NVC_ANALYZE_FLAGS: '{{.NVC_ANALYZE_FLAGS | default ""}}'
+  NVC_ELAB_FLAGS: '{{.NVC_ELAB_FLAGS | default "-O2"}}'
+  EXTRA_NVC_FLAGS: '{{.EXTRA_NVC_FLAGS | default ""}}'
+  GHDL_GLOBAL_FLAGS: '{{.GHDL_GLOBAL_FLAGS | default (printf "--std=08 -O2 --workdir=%s" .BUILD_DIR)}}'
+  GHDL_ANALYZE_FLAGS: '{{.GHDL_ANALYZE_FLAGS | default ""}}'
+  GHDL_ELAB_FLAGS: '{{.GHDL_ELAB_FLAGS | default "-fexplicit"}}'
   EXTRA_GHDL_FLAGS: '{{.EXTRA_GHDL_FLAGS | default ""}}'
   BITSTREAM_BIN: '{{.BITSTREAM_BIN | default "{{.BUILD_DIR}}/{{.DESIGN}}.bin"}}'
 
@@ -103,32 +110,52 @@ tasks:
         {{.BUILD_DIR}}/{{.DESIGN}}.hex
 
   run-simulation:
-    desc: Run simulation using GHDL (compiles in dependency order)
+    desc: Run simulation (auto-detects NVC/GHDL, or use SIMULATOR=nvc/ghdl)
     deps: [mkdir-build]
+    env:
+      BUILD_DIR: '{{.BUILD_DIR}}'
     cmds:
-      # 1. Compile packages first (models_pack defines shared types)
-      - ghdl -a {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} {{.FAB_PROJ_ROOT}}/Fabric/models_pack.vhdl
-      # 2. Compile tile files (self-contained, depend only on packages)
       - |
-        for f in $(find {{.FAB_PROJ_ROOT}}/Tile/ -name '*.vhdl' -type f); do
-          ghdl -a {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} "$f"
-        done
-      # 3. Compile fabric infrastructure (depends on tiles)
-      - |
-        for f in $(find {{.FAB_PROJ_ROOT}}/Fabric/ -name '*.vhdl' -type f ! -name 'models_pack.vhdl'); do
-          ghdl -a {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} "$f"
-        done
-      # 4. Compile user design and testbench (depends on fabric)
-      - ghdl -a {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} {{.USER_DESIGN_DIR}}/{{.DESIGN}}.vhdl {{.TESTBENCH}}.vhdl
-      # 5. Elaborate and run (ulimit needed for large designs)
-      - >-
-        sh -c 'ulimit -s unlimited &&
-        ghdl -e {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} -fexplicit {{.TESTBENCH}}'
-      - >-
-        sh -c 'ulimit -s unlimited &&
-        ghdl -r {{.GHDL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} --workdir={{.BUILD_DIR}} {{.TESTBENCH}}
-        --stats --ieee-asserts=disable
-        --{{.WAVEFORM_TYPE}}={{.BUILD_DIR}}/{{.TESTBENCH}}.{{.WAVEFORM_TYPE}}'
+        SIM="{{.SIMULATOR}}"
+        if [ "$SIM" = "ghdl" ]; then
+          task run-simulation-ghdl
+        elif [ "$SIM" = "nvc" ] || which nvc >/dev/null 2>&1; then
+          task run-simulation-nvc
+        else
+          task run-simulation-ghdl
+        fi
+
+  run-simulation-nvc:
+    env:
+      FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
+      USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
+      BUILD_DIR: '{{.BUILD_DIR}}'
+      DESIGN: '{{.DESIGN}}'
+      TESTBENCH: '{{.TESTBENCH}}'
+      WAVEFORM_TYPE: '{{.WAVEFORM_TYPE}}'
+    cmds:
+      - nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} $FAB_PROJ_ROOT/Fabric/models_pack.vhdl
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} "$f"; done'
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} "$f"; done'
+      - nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
+      - nvc {{.NVC_GLOBAL_FLAGS}} -e {{.NVC_ELAB_FLAGS}} $TESTBENCH
+      - sh -c 'ulimit -s unlimited; nvc {{.NVC_GLOBAL_FLAGS}} -r $TESTBENCH -w$BUILD_DIR/$TESTBENCH.$WAVEFORM_TYPE --stats'
+
+  run-simulation-ghdl:
+    env:
+      FAB_PROJ_ROOT: '{{.FAB_PROJ_ROOT}}'
+      USER_DESIGN_DIR: '{{.USER_DESIGN_DIR}}'
+      BUILD_DIR: '{{.BUILD_DIR}}'
+      DESIGN: '{{.DESIGN}}'
+      TESTBENCH: '{{.TESTBENCH}}'
+      WAVEFORM_TYPE: '{{.WAVEFORM_TYPE}}'
+    cmds:
+      - ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $FAB_PROJ_ROOT/Fabric/models_pack.vhdl
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} "$f"; done'
+      - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} "$f"; done'
+      - ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
+      - ghdl -e {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ELAB_FLAGS}} $TESTBENCH
+      - sh -c 'ulimit -s unlimited; ghdl -r {{.GHDL_GLOBAL_FLAGS}} $TESTBENCH --stats --ieee-asserts=disable --{{.WAVEFORM_TYPE}}=$BUILD_DIR/$TESTBENCH.{{.WAVEFORM_TYPE}}'
 
   gtkwave:
     desc: Open waveform in GTKWave
@@ -143,6 +170,6 @@ tasks:
       - test -d {{.BUILD_DIR}}
 
   clean:
-    desc: Remove build directory
+    desc: Remove build directory and work library
     cmds:
       - rm -rf {{.BUILD_DIR}}

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Test/Taskfile.yml
@@ -117,12 +117,23 @@ tasks:
     cmds:
       - |
         SIM="{{.SIMULATOR}}"
-        if [ "$SIM" = "ghdl" ]; then
-          task run-simulation-ghdl
-        elif [ "$SIM" = "nvc" ] || which nvc >/dev/null 2>&1; then
+        if [ "$SIM" = "nvc" ]; then
+          if ! which nvc >/dev/null 2>&1; then
+            echo "Error: SIMULATOR=nvc but nvc is not installed or not found in PATH" >&2
+            exit 1
+          fi
           task run-simulation-nvc
-        else
+        elif [ "$SIM" = "ghdl" ]; then
           task run-simulation-ghdl
+        elif [ "$SIM" = "auto" ]; then
+          if which nvc >/dev/null 2>&1; then
+            task run-simulation-nvc
+          else
+            task run-simulation-ghdl
+          fi
+        else
+          echo "Error: Unknown SIMULATOR value '$SIM'. Use nvc, ghdl, or auto." >&2
+          exit 1
         fi
 
   run-simulation-nvc:
@@ -138,8 +149,8 @@ tasks:
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} "$f"; done'
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} "$f"; done'
       - nvc {{.NVC_GLOBAL_FLAGS}} -a {{.NVC_ANALYZE_FLAGS}} {{.EXTRA_NVC_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
-      - nvc {{.NVC_GLOBAL_FLAGS}} -e {{.NVC_ELAB_FLAGS}} $TESTBENCH
-      - sh -c 'ulimit -s unlimited; nvc {{.NVC_GLOBAL_FLAGS}} -r $TESTBENCH -w$BUILD_DIR/$TESTBENCH.$WAVEFORM_TYPE --stats'
+      - nvc {{.NVC_GLOBAL_FLAGS}} -e {{.NVC_ELAB_FLAGS}} {{.EXTRA_NVC_FLAGS}} $TESTBENCH
+      - sh -c 'ulimit -s unlimited; nvc {{.NVC_GLOBAL_FLAGS}} -r {{.EXTRA_NVC_FLAGS}} $TESTBENCH -w$BUILD_DIR/$TESTBENCH.$WAVEFORM_TYPE --stats'
 
   run-simulation-ghdl:
     env:
@@ -154,8 +165,8 @@ tasks:
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Tile/ -name "*.vhdl" -type f); do ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} "$f"; done'
       - sh -c 'for f in $(find $FAB_PROJ_ROOT/Fabric/ -name "*.vhdl" -type f ! -name "models_pack.vhdl"); do ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} "$f"; done'
       - ghdl -a {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ANALYZE_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $USER_DESIGN_DIR/$DESIGN.vhdl $TESTBENCH.vhdl
-      - ghdl -e {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ELAB_FLAGS}} $TESTBENCH
-      - sh -c 'ulimit -s unlimited; ghdl -r {{.GHDL_GLOBAL_FLAGS}} $TESTBENCH --stats --ieee-asserts=disable --{{.WAVEFORM_TYPE}}=$BUILD_DIR/$TESTBENCH.{{.WAVEFORM_TYPE}}'
+      - ghdl -e {{.GHDL_GLOBAL_FLAGS}} {{.GHDL_ELAB_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH
+      - sh -c 'ulimit -s unlimited; ghdl -r {{.GHDL_GLOBAL_FLAGS}} {{.EXTRA_GHDL_FLAGS}} $TESTBENCH --stats --ieee-asserts=disable --{{.WAVEFORM_TYPE}}=$BUILD_DIR/$TESTBENCH.{{.WAVEFORM_TYPE}}'
 
   gtkwave:
     desc: Open waveform in GTKWave

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/DSP/DSP_bot/MULADD.vhdl
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/DSP/DSP_bot/MULADD.vhdl
@@ -48,17 +48,17 @@ end entity MULADD;
 
 architecture Behavioral of MULADD is
 
-  signal A_reg : std_logic_vector(7 downto 0);  -- port A read data register
-  signal B_reg : std_logic_vector(7 downto 0);  -- port B read data register
-  signal C_reg : std_logic_vector(19 downto 0); -- port B read data register
+  signal A_reg_data : std_logic_vector(7 downto 0);  -- port A read data register
+  signal B_reg_data : std_logic_vector(7 downto 0);  -- port B read data register
+  signal C_reg_data : std_logic_vector(19 downto 0); -- port B read data register
 
   signal OPA : std_logic_vector(7 downto 0);  -- port A
   signal OPB : std_logic_vector(7 downto 0);  -- port B
   signal OPC : std_logic_vector(19 downto 0); -- port B
 
-  signal ACC    : std_logic_vector(19 downto 0); -- accumulator register
-  signal sum    : unsigned(19 downto 0);         -- port B read data register
-  signal sum_in : std_logic_vector(19 downto 0); -- port B read data register
+  signal ACC_data : std_logic_vector(19 downto 0); -- accumulator register
+  signal sum      : unsigned(19 downto 0);         -- port B read data register
+  signal sum_in   : std_logic_vector(19 downto 0); -- port B read data register
 
   signal product          : unsigned(15 downto 0);
   signal product_extended : unsigned(19 downto 0);
@@ -66,37 +66,38 @@ architecture Behavioral of MULADD is
 begin
 
   OPA <= A when (ConfigBits(0) = '0') else
-         A_reg;
+         A_reg_data;
   OPB <= B when (ConfigBits(1) = '0') else
-         B_reg;
+         B_reg_data;
   OPC <= C when (ConfigBits(2) = '0') else
-         C_reg;
+         C_reg_data;
 
   sum_in <= OPC when (ConfigBits(3) = '0') else
-            ACC;
+            ACC_data;
 
   product <= unsigned(OPA) * unsigned(OPB);
 
   -- The sign extension was not tested
   product_extended <= "0000" & product when (ConfigBits(4) = '0') else
-                      product(product'high) & product(product'high) & product(product'high) & product(product'high) & product;
+                      (product(product'high) & product(product'high) &
+                        product(product'high) & product(product'high) & product);
 
   sum <= product_extended + unsigned(sum_in);
 
   Q <= std_logic_vector(sum) when (ConfigBits(5) = '0') else
-       ACC;
+       ACC_data;
 
   process (UserCLK) is
   begin
 
     if (UserCLK'event and UserCLK = '1') then
-      A_reg <= A;
-      B_reg <= B;
-      C_reg <= C;
+      A_reg_data <= A;
+      B_reg_data <= B;
+      C_reg_data <= C;
       if (clr = '1') then
-        ACC <= (others => '0');
+        ACC_data <= (others => '0');
       else
-        ACC <= std_logic_vector(sum);
+        ACC_data <= std_logic_vector(sum);
       end if;
     end if;
 

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/LUT4AB/MUX8LUT_frame_config_mux.vhdl
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/LUT4AB/MUX8LUT_frame_config_mux.vhdl
@@ -123,7 +123,7 @@ begin
       X  => sCD
     );
 
-  -- sEF <= S(2) when (CB_C0 = '0') else S(0);
+  -- sEF <= S(2) when (CB_C1 = '0') else S(0);
   cus_mux21_sef : component cus_mux21
     port map (
       A0 => S(2),

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/LUT4AB/MUX8LUT_frame_config_mux.vhdl
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/LUT4AB/MUX8LUT_frame_config_mux.vhdl
@@ -40,8 +40,8 @@ entity MUX8LUT_frame_config_mux is
   );
   attribute FABulous of MUX8LUT_frame_config_mux : entity is "TRUE";
   attribute BelMap of MUX8LUT_frame_config_mux   : entity is "TRUE";
-  attribute c0 of MUX8LUT_frame_config_mux       : entity is 0;
-  attribute c1 of MUX8LUT_frame_config_mux       : entity is 1;
+  attribute C0 of MUX8LUT_frame_config_mux       : entity is 0;
+  attribute C1 of MUX8LUT_frame_config_mux       : entity is 1;
   attribute GLOBAL of ConfigBits                 : signal is "TRUE";
 end entity MUX8LUT_frame_config_mux;
 
@@ -60,7 +60,7 @@ architecture Behavioral of MUX8LUT_frame_config_mux is
   signal AH    : std_logic;
   signal EH_GH : std_logic;
 
-  signal c0, c1 : std_logic; -- configuration bits
+  signal CB_C0, CB_C1 : std_logic; -- configuration bits
 
   component cus_mux21 is
     port (
@@ -73,8 +73,8 @@ architecture Behavioral of MUX8LUT_frame_config_mux is
 
 begin
 
-  c0 <= ConfigBits(0);
-  c1 <= ConfigBits(1);
+  CB_C0 <= ConfigBits(0);
+  CB_C1 <= ConfigBits(1);
 
   -- see figure (column-wise left-to-right)
 
@@ -114,39 +114,39 @@ begin
       X  => GH
     );
 
-  -- sCD <= S(1) when (c0 = '0') else S(0);
+  -- sCD <= S(1) when (CB_C0 = '0') else S(0);
   cus_mux21_scd : component cus_mux21
     port map (
       A0 => S(1),
       A1 => S(0),
-      S  => c0,
+      S  => CB_C0,
       X  => sCD
     );
 
-  -- sEF <= S(2) when (c1 = '0') else S(0);
+  -- sEF <= S(2) when (CB_C0 = '0') else S(0);
   cus_mux21_sef : component cus_mux21
     port map (
       A0 => S(2),
       A1 => S(0),
-      S  => c1,
+      S  => CB_C1,
       X  => sEF
     );
 
-  -- sGH <= sEH when (c0 = '0') else sEF;
+  -- sGH <= sEH when (CB_C0 = '0') else sEF;
   cus_mux21_sgh : component cus_mux21
     port map (
       A0 => sEH,
       A1 => sEF,
-      S  => c0,
+      S  => CB_C0,
       X  => sGH
     );
 
-  -- sEH <= S(3) when (c1 = '0') else S(1);
+  -- sEH <= S(3) when (CB_C1 = '0') else S(1);
   cus_mux21_seh : component cus_mux21
     port map (
       A0 => S(3),
       A1 => S(1),
-      S  => c1,
+      S  => CB_C1,
       X  => sEH
     );
 
@@ -179,21 +179,21 @@ begin
 
   M_AB <= AB;
 
-  -- M_AD <= CD when (c0 = '0') else AD;
+  -- M_AD <= CD when (CB_C0 = '0') else AD;
   cus_mux21_m_ad : component cus_mux21
     port map (
       A0 => CD,
       A1 => AD,
-      S  => c0,
+      S  => CB_C0,
       X  => M_AD
     );
 
-  -- M_AH <= EH_GH when (c1 = '0') else AH;
+  -- M_AH <= EH_GH when (CB_C1 = '0') else AH;
   cus_mux21_m_ah : component cus_mux21
     port map (
       A0 => EH_GH,
       A1 => AH,
-      S  => c1,
+      S  => CB_C1,
       X  => M_AH
     );
 

--- a/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/RegFile/RegFile_32x4.vhdl
+++ b/fabulous/fabric_files/FABulous_project_template_vhdl/Tile/RegFile/RegFile_32x4.vhdl
@@ -51,10 +51,10 @@ architecture Behavioral of RegFile_32x4 is
 
   signal mem : memtype;
 
-  signal AD_reg    : std_logic_vector(3 downto 0); -- port A read data register
-  signal BD_reg    : std_logic_vector(3 downto 0); -- port B read data register
-  signal AD_signal : std_logic_vector(3 downto 0); -- port A read data signal
-  signal BD_signal : std_logic_vector(3 downto 0); -- port B read data signal
+  signal AD_reg_data : std_logic_vector(3 downto 0); -- port A read data register
+  signal BD_reg_data : std_logic_vector(3 downto 0); -- port B read data register
+  signal AD_signal   : std_logic_vector(3 downto 0); -- port A read data signal
+  signal BD_signal   : std_logic_vector(3 downto 0); -- port B read data signal
 
 begin
 
@@ -76,15 +76,15 @@ begin
   begin
 
     if (UserCLK'event and UserCLK = '1') then
-      AD_reg <= AD_signal;
-      BD_reg <= BD_signal;
+      AD_reg_data <= AD_signal;
+      BD_reg_data <= BD_signal;
     end if;
 
   end process;
 
   AD <= AD_signal when (ConfigBits(0) = '0') else
-        AD_reg;
+        AD_reg_data;
   BD <= BD_signal when (ConfigBits(1) = '0') else
-        BD_reg;
+        BD_reg_data;
 
 end architecture Behavioral;

--- a/fabulous/fabulous_cli/fabulous_cli.py
+++ b/fabulous/fabulous_cli/fabulous_cli.py
@@ -1008,10 +1008,23 @@ class FABulous_CLI(Cmd):
         help="Design name to simulate (default: inferred from bitstream filename)",
     )
     simulation_parser.add_argument(
+        "-s",
+        "--simulator",
+        default="",
+        choices=["nvc", "ghdl", "auto", ""],
+        help="VHDL simulator to use: nvc, ghdl, or auto (default: auto-detect)",
+    )
+    simulation_parser.add_argument(
         "-if",
         "--extra-iverilog-flag",
         default="",
         help="Extra flags to pass to iverilog (Verilog projects)",
+    )
+    simulation_parser.add_argument(
+        "-nf",
+        "--extra-nvc-flag",
+        default="",
+        help="Extra flags to pass to NVC (VHDL projects)",
     )
     simulation_parser.add_argument(
         "-gf",
@@ -1064,8 +1077,12 @@ class FABulous_CLI(Cmd):
             "DESIGN": design_name,
             "BITSTREAM_BIN": str(bitstreamPath.resolve()),
         }
+        if args.simulator:
+            task_vars["SIMULATOR"] = args.simulator
         if args.extra_iverilog_flag:
             task_vars["EXTRA_IVERILOG_FLAGS"] = args.extra_iverilog_flag
+        if args.extra_nvc_flag:
+            task_vars["EXTRA_NVC_FLAGS"] = args.extra_nvc_flag
         if args.extra_ghdl_flag:
             task_vars["EXTRA_GHDL_FLAGS"] = args.extra_ghdl_flag
 

--- a/flake.nix
+++ b/flake.nix
@@ -180,6 +180,7 @@
             customPkgs.nextpnr
             customPkgs.fabulator
             customPkgs.ghdl
+            pkgs.nvc
           ]
           ++ (builtins.filter systemSupported librelane-pkg.includedTools);
 

--- a/tests/cli_test/test_cli.py
+++ b/tests/cli_test/test_cli.py
@@ -194,6 +194,37 @@ def test_run_simulation_with_extra_flags(
 
 
 @pytest.mark.usefixtures("simulation_mock")
+def test_run_simulation_with_extra_nvc_flag(
+    cli: FABulous_CLI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test simulation passes --extra-nvc-flag to Taskfile as EXTRA_NVC_FLAGS."""
+    run_cmd(cli, f'{SIM_CMD} --extra-nvc-flag="--ieee-warnings=error"')
+    log = normalize_and_check_for_errors(caplog.text)
+    assert "Simulation finished" in log[-1]
+
+    task_cmds = find_task_calls()
+    assert len(task_cmds) >= 1
+    assert any("EXTRA_NVC_FLAGS" in arg for arg in task_cmds[-1])
+
+
+@pytest.mark.usefixtures("simulation_mock")
+def test_run_simulation_with_simulator_flag(
+    cli: FABulous_CLI,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test simulation passes --simulator to Taskfile as SIMULATOR."""
+    for sim in ("nvc", "ghdl", "auto"):
+        run_cmd(cli, f"{SIM_CMD} --simulator={sim}")
+        log = normalize_and_check_for_errors(caplog.text)
+        assert "Simulation finished" in log[-1]
+
+        task_cmds = find_task_calls()
+        assert len(task_cmds) >= 1
+        assert any(f"SIMULATOR={sim}" in arg for arg in task_cmds[-1])
+
+
+@pytest.mark.usefixtures("simulation_mock")
 def test_run_simulation_with_design_flag(
     cli: FABulous_CLI,
     caplog: pytest.LogCaptureFixture,

--- a/tests/cli_test/test_helper.py
+++ b/tests/cli_test/test_helper.py
@@ -227,8 +227,12 @@ def test_create_project_vhdl_has_taskfile(tmp_path: Path) -> None:
 
     content = taskfile.read_text()
     assert "ghdl" in content, "VHDL Taskfile should reference ghdl"
-    assert "GHDL_FLAGS" in content, "VHDL Taskfile should have GHDL_FLAGS var"
+    assert "nvc" in content, "VHDL Taskfile should reference nvc"
+    assert "GHDL_GLOBAL_FLAGS" in content, (
+        "VHDL Taskfile should have GHDL_GLOBAL_FLAGS var"
+    )
     assert "EXTRA_GHDL_FLAGS" in content
+    assert "EXTRA_NVC_FLAGS" in content
 
 
 def test_create_project_has_compile_taskfile(tmp_path: Path) -> None:


### PR DESCRIPTION
NVC is significantly faster than GHDL for FABulous simulation and will be
used as the default simulator when available, with automatic fallback to GHDL.

Simulation setup now supports both NVC and GHDL with:
- Auto-detection of available simulator (NVC preferred, GHDL fallback)
- SIMULATOR variable to explicitly choose nvc/ghdl/auto
- NVC-specific and GHDL-specific configuration flags

VHDL attribute naming fixes:
NVC enforces stricter rules for VHDL attribute names - they cannot conflict
with signal or other element names. Updated affected RTL files:
- MULADD.vhdl
- MUX8LUT_frame_config_mux.vhdl
- RegFile_32x4.vhdl

Documentation updates:
- Updated simulation setup guide to recommend NVC
- Added NVC installation and configuration details
- Updated CAD tool installation guide
- Updated Taskfile and Makefile with simulator selection logic

CI Update:
- Add nickg/setup-nvc@v1 to the prepare_FABulous_container composite action so all CI jobs have NVC available.
- Fix backward compatibility check action was silently failing.

Misc: 
- Add NVC to nix setup.