### PR TITLE
chore: Add default ArchSpec values to bitstream spec

### DIFF
--- a/fabulous/fabric_cad/gen_bitstream_spec.py
+++ b/fabulous/fabric_cad/gen_bitstream_spec.py
@@ -6,6 +6,7 @@ locations and is used during bitstream generation.
 """
 
 import string
+from importlib.metadata import version
 from typing import TYPE_CHECKING
 
 from loguru import logger
@@ -45,6 +46,11 @@ def generateBitstreamSpec(fabric: Fabric) -> dict[str, dict]:
         "ArchSpecs": {
             "MaxFramesPerCol": fabric.maxFramesPerCol,
             "FrameBitsPerRow": fabric.frameBitsPerRow,
+            "FrameSelectWidth": fabric.frameSelectWidth,
+            "DesyncBit": fabric.desync_flag,
+            "SyncHeaderHex": fabric.syncHeaderHex,
+            "IncludeBorderRows": False,  # Currently not supported in FABulous
+            "FABulousVersion": version("FABulous-FPGA"),
         },
     }
 

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -71,6 +71,9 @@ class Fabric:
         file in the generated switch matrix CSV. When `False` (default),
         every connection is written as `1` and order is determined by
         CSV-column position when read back.
+    syncHeaderHex : str
+        Hex string of the 20-byte sync header written at the start of every
+        binary bitstream.
     tileDic : dict[str, Tile]
         A dictionary of tiles used in the fabric. The key is the name of the tile and
         the value is the tile.
@@ -108,6 +111,7 @@ class Fabric:
     superTileEnable: bool = True
     disableUserCLK: bool = False
     preserveListOrder: bool = False
+    syncHeaderHex: str = "00AAFF01000000010000000000000000FAB0FAB1"
 
     tileDic: dict[str, Tile] = field(default_factory=dict)
     superTileDic: dict[str, SuperTile] = field(default_factory=dict)


### PR DESCRIPTION
Since the bit_gen refactor is done, the bitstream spec should carry a few more default values in the ArchSpec part.
https://github.com/FPGA-Research/FABulous-bit-gen/pull/11

