### PR TITLE
fix: avoid temp file collisions on multi-user machines

### DIFF
--- a/fabulous/fabric_definition/yosys_obj.py
+++ b/fabulous/fabric_definition/yosys_obj.py
@@ -262,33 +262,38 @@ class YosysJson:
         ghdl = get_context().ghdl_path
         json_file = self.srcPath.with_suffix(".json")
 
-        # FIXME: a fake file to ensure things working with 1.3
-        temp: Path = Path(tempfile.gettempdir())
-        temp = temp / "my_package.vhd"
-        temp.touch()
-        temp.write_text("package my_package is\nend package;\n")
         # VHDL files are converted to Verilog by GHDL, so use .v suffix for yosys
         # Verilog/SystemVerilog files use their original suffix
         if self.srcPath.suffix in {".vhd", ".vhdl"}:
-            runCmd = [
-                f"{ghdl!s}",
-                "--synth",
-                "--std=08",
-                "--out=verilog",
-                str(temp),
-                f"{get_context().models_pack!s}",
-                f"{self.srcPath}",
-                "-e",
-                f"{self.srcPath.stem}",
-            ]
+            # FIXME: a fake stub package required by 1.3 -- unique per-invocation
+            # to avoid collisions when multiple users run FABulous on the same machine.
+            with tempfile.NamedTemporaryFile(
+                suffix=".vhd", mode="w", delete=False
+            ) as _tf:
+                _tf.write("package my_package is\nend package;\n")
+                temp = Path(_tf.name)
             try:
-                r = subprocess.run(runCmd, check=True, capture_output=True)
-                self.srcPath.with_suffix(".v").write_text(r.stdout.decode())
-            except subprocess.CalledProcessError as e:
-                raise RuntimeError(
-                    f"Failed to run GHDL on {self.srcPath}: {e.stderr.decode()} "
-                    f"run cmd: {' '.join(runCmd)}"
-                ) from e
+                runCmd = [
+                    f"{ghdl!s}",
+                    "--synth",
+                    "--std=08",
+                    "--out=verilog",
+                    str(temp),
+                    f"{get_context().models_pack!s}",
+                    f"{self.srcPath}",
+                    "-e",
+                    f"{self.srcPath.stem}",
+                ]
+                try:
+                    r = subprocess.run(runCmd, check=True, capture_output=True)
+                    self.srcPath.with_suffix(".v").write_text(r.stdout.decode())
+                except subprocess.CalledProcessError as e:
+                    raise RuntimeError(
+                        f"Failed to run GHDL on {self.srcPath}: {e.stderr.decode()} "
+                        f"run cmd: {' '.join(runCmd)}"
+                    ) from e
+            finally:
+                temp.unlink(missing_ok=True)
             yosys_src = self.srcPath.with_suffix(".v")
         else:
             yosys_src = self.srcPath

--- a/fabulous/fabulous_cli/fabulous_cli.py
+++ b/fabulous/fabulous_cli/fabulous_cli.py
@@ -1539,13 +1539,16 @@ class FABulous_CLI(Cmd):
             script_file.write(f"read_db {db_file}\n")
             file_name = script_file.name
         logger.info(f"Start OpenROAD GUI with odb: {db_file}")
-        sp.run(
-            [
-                str(openroad),
-                "-gui",
-                str(file_name),
-            ]
-        )
+        try:
+            sp.run(
+                [
+                    str(openroad),
+                    "-gui",
+                    str(file_name),
+                ]
+            )
+        finally:
+            Path(file_name).unlink(missing_ok=True)
 
     @with_argparser(gui_parser)
     @with_category(CMD_TOOLS)

--- a/tests/utils_test/test_yosys_obj.py
+++ b/tests/utils_test/test_yosys_obj.py
@@ -4,7 +4,6 @@ This module provides comprehensive tests for the Yosys JSON parser, including pa
 different HDL formats and netlist analysis methods.
 """
 
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -14,7 +13,9 @@ from fabulous.custom_exception import InvalidFileType
 from fabulous.fabric_definition.yosys_obj import YosysJson
 
 
-def setup_mocks(monkeypatch: pytest.MonkeyPatch, json_data: dict) -> None:
+def setup_mocks(
+    monkeypatch: pytest.MonkeyPatch, json_data: dict, tmp_path: Path
+) -> None:
     """Set up mocks."""
     monkeypatch.setattr(
         "subprocess.run",
@@ -37,14 +38,11 @@ def setup_mocks(monkeypatch: pytest.MonkeyPatch, json_data: dict) -> None:
 
     monkeypatch.setattr("builtins.open", mock_open_func)
 
-    # Ensure FABulousSettings validation passes by providing a models pack
-    tmp_mp = Path(tempfile.gettempdir()) / "models_pack.v"
-    try:
-        tmp_mp.write_text("// test models pack\n")
-    except OSError:
-        # In rare cases temp dir may be read-only; fallback to current working dir
-        tmp_mp = Path.cwd() / "models_pack.v"
-        tmp_mp.write_text("// test models pack\n")
+    # Ensure FABulousSettings validation passes by providing a models pack.
+    # Use tmp_path (pytest-isolated per-test dir) to avoid collisions between
+    # concurrent test workers or users sharing the same machine.
+    tmp_mp = tmp_path / "models_pack.v"
+    tmp_mp.write_text("// test models pack\n")
     monkeypatch.setenv("FAB_MODELS_PACK", str(tmp_mp))
 
 
@@ -149,7 +147,7 @@ def test_yosys_json_file_not_exists(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Test YosysJson with unsupported file type."""
-    setup_mocks(monkeypatch, {})
+    setup_mocks(monkeypatch, {}, tmp_path)
     fakePath = tmp_path / "file.txt"
     with pytest.raises(FileNotFoundError, match="does not exist"):
         YosysJson(fakePath)
@@ -159,7 +157,7 @@ def test_yosys_json_unsupported_file_type(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Test YosysJson with unsupported file type."""
-    setup_mocks(monkeypatch, {})
+    setup_mocks(monkeypatch, {}, tmp_path)
     fakePath = tmp_path / "file.txt"
     fakePath.touch()
     with pytest.raises(InvalidFileType, match="Unsupported HDL file type"):
@@ -183,7 +181,7 @@ def test_get_top_module(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None
         "models": {},
     }
 
-    setup_mocks(monkeypatch, json_data)
+    setup_mocks(monkeypatch, json_data, tmp_path)
     fakePath = tmp_path / "test_file.v"
     fakePath.touch()
     fakePath.with_suffix(".json").touch()
@@ -212,7 +210,7 @@ def test_get_top_module_no_top(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) 
         "models": {},
     }
 
-    setup_mocks(monkeypatch, json_data)
+    setup_mocks(monkeypatch, json_data, tmp_path)
     fakePath = tmp_path / "test_file.v"
     fakePath.touch()
     fakePath.with_suffix(".json").touch()
@@ -240,7 +238,7 @@ def test_get_top_module_blackbox_fallback(
         "models": {},
     }
 
-    setup_mocks(monkeypatch, json_data)
+    setup_mocks(monkeypatch, json_data, tmp_path)
     fakePath = tmp_path / "test_file.v"
     fakePath.touch()
     fakePath.with_suffix(".json").touch()
@@ -278,7 +276,7 @@ def test_get_top_module_prefers_top_over_blackbox(
         "models": {},
     }
 
-    setup_mocks(monkeypatch, json_data)
+    setup_mocks(monkeypatch, json_data, tmp_path)
     fakePath = tmp_path / "test_file.v"
     fakePath.touch()
     fakePath.with_suffix(".json").touch()
@@ -329,7 +327,7 @@ def test_getNetPortSrcSinks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
         "models": {},
     }
 
-    setup_mocks(monkeypatch, json_data)
+    setup_mocks(monkeypatch, json_data, tmp_path)
     fakePath = tmp_path / "test_file.v"
     fakePath.touch()
     fakePath.with_suffix(".json").touch()


### PR DESCRIPTION
Three places wrote to fixed, shared paths in the system temp directory, causing permission errors or silent data corruption when multiple users (or parallel test workers) ran FABulous concurrently:

- yosys_obj.py: `my_package.vhd` was always written to the same path (`/tmp/my_package.vhd`). Replaced with a `NamedTemporaryFile` scoped to the VHDL branch with a `finally` cleanup, so each invocation gets a unique path.
- fabulous_cli.py: the OpenROAD TCL script used a unique name (no collision risk) but was never deleted. Added `try/finally` cleanup.
- test_yosys_obj.py: `setup_mocks` wrote `models_pack.v` to the shared temp dir. Switched to pytest's `tmp_path` fixture, which gives each test an isolated directory, safe for parallel workers.
