### PR TITLE
chore: drop docformatter from pre-precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,6 @@ repos:
     hooks:
       - id: pydoclint
         args: [ --style=numpy ]
-        exclude: ^(tests/|fabulous/fabulous_cli/fabulous_cli\.py$)
 
   - repo: https://github.com/jeremiah-c-leary/vhdl-style-guide
     rev: 3.35.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,16 +17,6 @@ repos:
       - id: check-toml
       - id: no-commit-to-branch
 
-  - repo: https://github.com/PyCQA/docformatter.git
-    rev: "v1.7.8"
-    hooks:
-      - id: docformatter
-        name: docformatter
-        description: "Formats docstrings to follow PEP 257."
-        args: [ --in-place, --black ]
-        language: python
-        types: [ python ]
-
   - repo: local
     hooks:
       - id: interrogate
@@ -64,7 +54,7 @@ repos:
     hooks:
       - id: pydoclint
         args: [ --style=numpy ]
-        exclude: ^(tests/|FABulous/FABulous_CLI/FABulous_CLI\.py$)
+        exclude: ^(tests/|fabulous/fabulous_cli/fabulous_cli\.py$)
 
   - repo: https://github.com/jeremiah-c-leary/vhdl-style-guide
     rev: 3.35.0

--- a/fabulous/fabric_definition/fabric.py
+++ b/fabulous/fabric_definition/fabric.py
@@ -488,7 +488,7 @@ class Fabric:
                     if fabric_tile and fabric_tile.name == tile.name:
                         positions.append((x, y))
 
-        return positions if positions else None
+        return positions or None
 
     def determine_border_side(self, x: int, y: int) -> Side | None:
         """Determine which border side a tile position is on, if any.

--- a/ruff.toml
+++ b/ruff.toml
@@ -100,18 +100,17 @@ select = [
   "ARG",
   "ANN",
   "D",
-  "DOC",
 ]
 
 
 # Future rules: Currently disabled, since it needs some more work.
 # - E501: Line too long -- Not automatically fixable
 # - N: flake8 Naming
-# - DOC: Doclint
 # - S: flake8 Bandit
 # - TD: flake8 TODOS
 # - FIX: flake8 fixme
 # - PL: pylint
+# - DOC: pydoclint, currently still not fully suported by ruff and only with preview
 
 # Ignoed rules:
 # - PYI063: https://docs.astral.sh/ruff/rules/pep484-style-positional-only-parameter/
@@ -127,9 +126,6 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [lint.per-file-ignores]
 "tests/*" = ["D"]
-
-[lint.pydoclint]
-ignore-one-line-docstrings = true
 
 [lint.pydocstyle]
 convention = "numpy"
@@ -153,7 +149,7 @@ line-ending = "auto"
 #
 # This is currently disabled by default, but it is planned for this
 # to be opt-out in the future.
-docstring-code-format = false
+docstring-code-format = true
 
 # Set the line length limit used when formatting code snippets in
 # docstrings.

--- a/tests/fabric_gen_test/conftest.py
+++ b/tests/fabric_gen_test/conftest.py
@@ -124,7 +124,7 @@ def verify_csv_content(file_path: Path, expected_rows: int | None = None) -> lis
     ----------
     file_path : Path
         The path to the CSV file to verify
-    expected_rows : int, optional
+    expected_rows : int | None, optional
         Expected number of rows in the CSV
 
     Returns

--- a/tests/fabric_gen_test/integration_test/conftest.py
+++ b/tests/fabric_gen_test/integration_test/conftest.py
@@ -163,9 +163,15 @@ class PCF:
         ----------
         signal : str
             User-design signal name as it appears in the PCF.
-        index : int, optional
+        index : int | None, optional
             If ``None`` (default), the whole bus is returned as a
             :class:`LogicArray`. Otherwise a single bit as a :class:`Logic`.
+
+        Returns
+        -------
+        LogicArray | Logic
+            The signal value. If index is None, returns the whole bus as a
+            :class:`LogicArray`. Otherwise a single :class:`Logic`.
         """
         if index is None:
             bits = "".join(
@@ -186,10 +192,10 @@ class PCF:
         ----------
         signal : str
             User-design signal name as it appears in the PCF.
-        value : LogicArray or Logic
+        value : LogicArray | Logic
             New value. Must be a :class:`LogicArray` of matching width when
             ``index`` is ``None``, otherwise a single :class:`Logic`.
-        index : int, optional
+        index : int | None, optional
             If given, only this bit is updated.
         """
         if index is None:
@@ -212,6 +218,11 @@ class PCF:
             ``"IN"``, ``"OUT"`` or ``"EN"``.
         index : int, optional
             Bit index. Default ``0``.
+
+        Returns
+        -------
+        LogicObject
+            The raw cocotb handle.
         """
         return self.signals[signal][index][use]
 
@@ -255,13 +266,11 @@ async def upload_bitstream(
     delay_ns : int, optional
         Duration each strobe is held high (and then low) per row, in
         nanoseconds. Default `10`.
-    num_data_rows : int, optional
+    num_data_rows : int | None, optional
         Number of 32-bit row words per frame in the bitstream payload.
 
     Raises
     ------
-    FileNotFoundError
-        If ``bitstream_path`` does not exist.
     ValueError
         If the file ends before the sync word is found.
     """
@@ -342,6 +351,12 @@ async def setup_fabric(dut: FabricConfigDUT, settle_ns: int = 10) -> PCF:
         cocotb top-level handle.
     settle_ns : int, optional
         Per-phase settling delay in ns. Default ``10``.
+
+    Returns
+    -------
+    PCF
+        A parsed PCF object for driving/sampling signals by user-design
+        signal name.
     """
     pcf = PCF(dut, Path(cocotb.plusargs["FAB_PCF"]))
     await zero_bitstream(dut)

--- a/tests/gds_flow_test/flow_test/conftest.py
+++ b/tests/gds_flow_test/flow_test/conftest.py
@@ -218,7 +218,7 @@ def create_macro(instances: dict[str, Instance]) -> Macro:
 
     Parameters
     ----------
-    instances : dict
+    instances : dict[str, Instance]
         Dictionary mapping instance names to Instance objects.
 
     Returns

--- a/tests/reference_test/helpers.py
+++ b/tests/reference_test/helpers.py
@@ -32,9 +32,17 @@ def compare_files_with_diff(
 ) -> list[str] | None:
     """Compare two files and return unified diff if they differ.
 
+    Parameters
+    ----------
+    current_file : Path
+        Path to the current (output) file.
+    reference_file : Path
+        Path to the reference (expected) file.
+
     Returns
     -------
-        None if files are identical, list of diff lines if different
+    list[str] | None
+        None if files are identical, list of diff lines if different.
     """
     try:
         with current_file.open("r", encoding="utf-8", errors="replace") as f:
@@ -230,19 +238,27 @@ def run_fabulous_commands_with_logging(
 ) -> tuple[FABulous_CLI, dict[str, Any]]:
     """Run standard FABulous commands using existing test patterns.
 
-    Args:
-        project_path: Path to the project directory to run commands in
-        language: Language type for FABulous CLI ("verilog" or "vhdl")
-        caplog: Pytest log capture fixture for collecting log output
-        monkeypatch: Pytest monkeypatch fixture for environment management
-        commands: Optional list of commands to run. If None, runs standard sequence
-        skip_on_fail: Whether to skip remaining commands if one fails
+    Parameters
+    ----------
+    project_path : Path
+        Path to the project directory to run commands in.
+    language : str
+        Language type for FABulous CLI ("verilog" or "vhdl").
+    caplog : pytest.LogCaptureFixture
+        Pytest log capture fixture for collecting log output.
+    monkeypatch : pytest.MonkeyPatch
+        Pytest monkeypatch fixture for environment management.
+    commands : list[str] | None, optional
+        Optional list of commands to run. If None, runs standard sequence.
+    skip_on_fail : bool, optional
+        Whether to skip remaining commands if one fails.
 
     Returns
     -------
-        Tuple of (FABulous_CLI instance, execution_info dict)
-
-    The execution_info dict contains:
+    cli : FABulous_CLI
+        The FABulous CLI instance with executed commands.
+    execution_info : dict[str, Any]
+        Contains:
         - commands_run: List of successfully executed commands
         - commands_failed: List of commands that failed
         - commands_not_executed: List of commands skipped due to failures

--- a/tests/utils_test/test_fabulous_settings.py
+++ b/tests/utils_test/test_fabulous_settings.py
@@ -851,6 +851,12 @@ class TestCheckPdkAutoResolution:
 
         Parameters
         ----------
+        project : Path
+            Project directory path.
+        monkeypatch : pytest.MonkeyPatch
+            Pytest monkeypatch fixture for environment manipulation.
+        mocker : MockerFixture
+            Pytest-mock mocker fixture.
         pdk_name : str
             PDK family name (used for env var and default pdk_root path).
         pdk_root : Path | None
@@ -863,6 +869,11 @@ class TestCheckPdkAutoResolution:
         mock_ciel_enable : bool
             When True (default), mock ``ciel.manage.enable`` so tests don't
             make real network calls.
+
+        Returns
+        -------
+        Path | None
+            The pdk_root path if set_pdk_root_env is True, otherwise None.
         """
         for key in list(os.environ.keys()):
             if key.startswith("FAB_"):


### PR DESCRIPTION
After discussion in #755, we decided to drop docformatter form pre-commit since they were working against each other and ruff covers most of the docformatter features.

While doing this, we also addes pydoclint for the test folder and fixed the few small issues it showed. 