### PR TITLE
fix: show full version including dev tag on RTD

### DIFF
--- a/docs/source/conf_helper.py
+++ b/docs/source/conf_helper.py
@@ -46,5 +46,8 @@ def get_version() -> str:
 
 
 def get_display_version(version_text: str) -> str:
-    """Strip development and local suffixes from the displayed version tag."""
-    return re.sub(r"\.dev.*$", "", version_text)
+    """Return bare version for tagged releases, or version+dev for dev builds."""
+    base = re.sub(r"(\.dev.*|[+].*)$", "", version_text)
+    if re.search(r"\.dev", version_text):
+        return f"{base}+dev"
+    return base


### PR DESCRIPTION
get_display_version was stripping the .dev suffix, causing the sidebar to show e.g. v2.0.0 instead of v2.0.0.dev+{hash}, leading to the assumption, that this is the doc of a stable version not the current git HEAD. 

