### PR TITLE
fix: set diodes on both ports as the default

### DIFF
--- a/fabulous/fabric_files/FABulous_project_template_common/Tile/DSP/gds_config.yaml
+++ b/fabulous/fabric_files/FABulous_project_template_common/Tile/DSP/gds_config.yaml
@@ -1,3 +1,5 @@
+DIODE_ON_PORTS: "out"
+
 DIE_AREA: [0, 0, 250, 490]
 
 pdk::gf180mcuD:

--- a/fabulous/fabric_files/FABulous_project_template_common/Tile/LUT4AB/gds_config.yaml
+++ b/fabulous/fabric_files/FABulous_project_template_common/Tile/LUT4AB/gds_config.yaml
@@ -1,3 +1,5 @@
+DIODE_ON_PORTS: "out"
+
 DIE_AREA: [0, 0, 246, 245]
 
 pdk::gf180mcuD:

--- a/fabulous/fabric_files/FABulous_project_template_common/Tile/RegFile/gds_config.yaml
+++ b/fabulous/fabric_files/FABulous_project_template_common/Tile/RegFile/gds_config.yaml
@@ -1,3 +1,5 @@
+DIODE_ON_PORTS: "out"
+
 DIE_AREA: [0, 0, 260, 245]
 
 pdk::gf180mcuD:

--- a/fabulous/fabric_files/FABulous_project_template_common/Tile/include/gds_config.yaml
+++ b/fabulous/fabric_files/FABulous_project_template_common/Tile/include/gds_config.yaml
@@ -26,7 +26,7 @@ TOP_MARGIN_MULT: 1
 LEFT_MARGIN_MULT: 6
 RIGHT_MARGIN_MULT: 6
 
-DIODE_ON_PORTS: "out"
+DIODE_ON_PORTS: "both"
 
 pdk::sky130A:
   #Floor planning


### PR DESCRIPTION
This is needed to avoid antenna violations after stitching, since border tiles have external connections.
For internal/high density tiles, the diodes should only be put on output ports to save area.

close #786 
close #787